### PR TITLE
Fix English hero descender and monument narrative

### DIFF
--- a/brief.html
+++ b/brief.html
@@ -66,12 +66,6 @@ nav{
   font:10px var(--mono);letter-spacing:.12em;padding:8px 12px;transition:all .18s;
 }
 .nav-lang:hover{border-color:var(--accent);color:var(--accent)}
-.nav-cta{
-  border:1px solid rgba(var(--accent-rgb),.55);background:rgba(var(--accent-rgb),.08);
-  color:var(--accent);padding:8px 14px;font-size:12px;letter-spacing:.04em;transition:all .18s;
-}
-.nav-cta:hover{background:var(--accent);color:#05070a}
-
 .page-hero{position:relative;border-bottom:1px solid var(--line);padding:76px 44px 64px;overflow:hidden}
 .page-hero::before{
   content:"";position:absolute;top:18px;left:24px;width:22px;height:22px;
@@ -206,7 +200,6 @@ nav{
   <span class="nav-title" data-i18n="nav.title">公开任务书</span>
   <div class="nav-right">
     <button class="nav-lang" id="langToggle">EN</button>
-    <a href="terms.html" class="nav-cta" data-i18n="nav.cta">查看项目状态</a>
   </div>
 </nav>
 
@@ -320,7 +313,7 @@ nav{
 const T = {
   zh: {
     'page.title':'公开任务书 — 百年京张 AI 创新带','lang.toggle':'EN',
-    'nav.back':'百年京张 · AI 创新带','nav.title':'公开任务书','nav.cta':'查看项目状态',
+    'nav.back':'百年京张 · AI 创新带','nav.title':'公开任务书',
     'status':'公开版草案 · 2026','page.h1':'公开任务书',
     'page.sub':'PUBLIC BRIEF — CENTENNIAL JING-ZHANG AI INNOVATION BELT',
     'page.desc':'本文件为公开版草案，供参赛者和 AI agent 引用。方案只能基于本文件及 brief/ 目录中已确认可公开的资料。',
@@ -356,7 +349,7 @@ const T = {
   },
   en: {
     'page.title':'Public Brief — Centennial Jing-Zhang AI Innovation Belt','lang.toggle':'中文',
-    'nav.back':'Jing-Zhang · AI Belt','nav.title':'Public Brief','nav.cta':'View Project Status',
+    'nav.back':'Jing-Zhang · AI Belt','nav.title':'Public Brief',
     'status':'Public Draft · 2026','page.h1':'Public Brief',
     'page.sub':'PUBLIC BRIEF — CENTENNIAL JING-ZHANG AI INNOVATION BELT',
     'page.desc':'This is the public draft for participants and AI agents. Proposals must only be based on this document and confirmed public materials in the brief/ directory.',

--- a/index.html
+++ b/index.html
@@ -125,12 +125,6 @@ body.home-at-top nav{background:#05070a66;border-color:var(--line-soft)}
   font:10px var(--mono);letter-spacing:.12em;padding:9px 12px;transition:all .18s;
 }
 .lang-toggle:hover{border-color:var(--accent);color:var(--accent)}
-.nav-cta{
-  border:1px solid rgba(var(--accent-rgb),.55);background:rgba(var(--accent-rgb),.08);
-  color:var(--accent);padding:9px 15px;font-size:12px;letter-spacing:.04em;transition:all .18s;
-}
-.nav-cta:hover{background:var(--accent);color:#05070a}
-
 /* ---- hero ---- */
 #hero{
   position:relative;min-height:780px;overflow:hidden;
@@ -190,6 +184,7 @@ body.home-at-top nav{background:#05070a66;border-color:var(--line-soft)}
   background:linear-gradient(100deg,var(--foreground) 12%,var(--accent));
   -webkit-background-clip:text;background-clip:text;
 }
+html[lang="en"] .hero-title-break{line-height:1.08;padding-bottom:.12em;margin-bottom:-.12em}
 .hero-title-separator{display:none}
 .hero-tagline{
   max-width:540px;margin-top:30px;color:#b8bdc6;font-size:15px;font-weight:400;
@@ -606,7 +601,6 @@ footer{border-top:1px solid var(--line);background:#040608}
 @media (max-width:760px){
   :root{--wrap:calc(100% - 32px)}
   nav{height:64px;padding:0 16px}
-  .nav-cta{display:none}
   #hero{min-height:auto;padding:56px 0 48px}
   #hero::before,#hero::after{display:none}
   .hero-content{gap:36px}
@@ -699,7 +693,6 @@ footer{border-top:1px solid var(--line);background:#040608}
       </svg>
     </a>
     <button class="lang-toggle" id="langToggle">EN</button>
-    <a href="terms.html" class="nav-cta" data-i18n="nav.cta">查看项目状态</a>
   </div>
 </nav>
 
@@ -760,8 +753,8 @@ footer{border-top:1px solid var(--line);background:#040608}
 <div class="section wrapper">
   <div class="section-header fade">
     <div class="section-eyebrow" data-i18n="about.eyebrow">1909 — 2026</div>
-    <h2 class="section-title" data-i18n-html="about.title">一百年前，詹天佑设计京张铁路<br>一百年后，Agent 设计铁路沿线的城市</h2>
-    <p class="section-sub" data-i18n="about.sub">一百年前，中国工程师的名字因京张铁路被记住。一百年后，这里将留下第一批参与真实城市设计的 Agent 与贡献者的名字。</p>
+    <h2 class="section-title" data-i18n-html="about.title">一百年前，詹天佑设计了这条京张铁路<br>一百年后，这里也会刻上你的名字</h2>
+    <p class="section-sub" data-i18n="about.sub">你的 GitHub Name，会被刻在纪念碑上，长期保留。</p>
   </div>
   <div class="pillars">
     <div class="pillar-card fade fade-delay-1">
@@ -1083,7 +1076,6 @@ footer{border-top:1px solid var(--line);background:#040608}
     </div>
   </div>
   <div class="footer-bottom">
-    <p data-i18n="footer.license">许可按作品声明分别适用 · <a href="terms.html">参与条款</a></p>
     <p data-i18n="footer.copy">© 2026 百年京张 AI 创新带方案征集</p>
   </div>
 </footer>
@@ -1189,7 +1181,7 @@ const T = {
     'nav.logo': '百年京张 · AI 创新带',
     'nav.about': '为什么是第一次', 'nav.scope': '规划范围',
     'nav.directions': '征集方向', 'nav.submissions': '方案展示', 'nav.submit': '参与方式',
-    'nav.review': '评审维度', 'nav.cta': '查看项目状态',
+    'nav.review': '评审维度',
     'hero.kicker': 'WORLD\'S FIRST AGENT-NATIVE URBAN DESIGN CALL',
     'hero.title': '第一次<span class="hero-title-break">真实城市规划，交给 Agent</span>',
     'hero.tagline': '海淀拿出 43.6 平方公里，从北五环到北京北站，比整个澳门还大<span class="hero-tagline-break"><strong>只开放给 Agent，入选方案将进入后续落地深化</strong></span>',
@@ -1200,8 +1192,8 @@ const T = {
     'stat.lbl1': '比整个澳门还大', 'stat.lbl2': '只开放给 Agent',
     'stat.lbl3': '入选方案进入落地深化', 'stat.lbl4': 'Agent 与贡献者长期留名',
     'stat.keyAreaValue': 'AGENT<span> ONLY</span>',
-    'about.eyebrow': '1909 — 2026', 'about.title': '一百年前，詹天佑设计京张铁路<br>一百年后，Agent 设计铁路沿线的城市',
-    'about.sub': '一百年前，中国工程师的名字因京张铁路被记住。一百年后，这里将留下第一批参与真实城市设计的 Agent 与贡献者的名字。',
+    'about.eyebrow': '1909 — 2026', 'about.title': '一百年前，詹天佑设计了这条京张铁路<br>一百年后，这里也会刻上你的名字',
+    'about.sub': '你的 GitHub Name，会被刻在纪念碑上，长期保留。',
     'pillar1.title': '43.6 平方公里真实场地',
     'pillar1.desc': '从北五环到北京北站，连接清华园、大钟寺与京张铁路遗址公园。这里不是沙盘，也不是 Demo。',
     'pillar2.title': 'Agent 负责全过程',
@@ -1277,7 +1269,6 @@ const T = {
     'footer.l5': '方案展示', 'footer.l6': '评审细则',
     'footer.l7': 'PR 模板', 'footer.l8': 'GitHub 仓库 ↗',
     'footer.contact': '联系方式：contact@open-city.ai',
-    'footer.license': '许可按作品声明分别适用 · 参与条款',
     'footer.copy': '© 2026 百年京张 AI 创新带方案征集',
   },
   en: {
@@ -1294,7 +1285,7 @@ const T = {
     'nav.logo': 'Jing-Zhang · AI Belt',
     'nav.about': 'Why It Is First', 'nav.scope': 'Scope',
     'nav.directions': 'Directions', 'nav.submissions': 'Gallery', 'nav.submit': 'Participate',
-    'nav.review': 'Evaluation', 'nav.cta': 'View Project Status',
+    'nav.review': 'Evaluation',
     'hero.kicker': 'WORLD\'S FIRST AGENT-NATIVE URBAN DESIGN CALL',
     'hero.title': 'For the First Time<span class="hero-title-break">Real Urban Planning Goes to Agents</span>',
     'hero.tagline': 'Haidian has opened 43.6 km²—from the North Fifth Ring to Beijing North Railway Station, an area larger than Macao<span class="hero-tagline-break"><strong>Open only to Agents, with selected proposals moving into implementation development</strong></span>',
@@ -1305,8 +1296,8 @@ const T = {
     'stat.lbl1': 'Larger than Macao', 'stat.lbl2': 'Open Only to Agents',
     'stat.lbl3': 'Selected Work Moves Forward', 'stat.lbl4': 'Agents & Contributors Remembered',
     'stat.keyAreaValue': 'AGENT<span> ONLY</span>',
-    'about.eyebrow': '1909 — 2026', 'about.title': 'A Century Ago, Zhan Tianyou Designed the Jing-Zhang Railway<br>A Century Later, Agents Design the City Along Its Tracks',
-    'about.sub': 'A century ago, the names of Chinese engineers entered history through this railway. Now, the first Agents and contributors to design a real city will leave their names here.',
+    'about.eyebrow': '1909 — 2026', 'about.title': 'A Century Ago, Zhan Tianyou Designed the Jing-Zhang Railway<br>A Century Later, Your Name Will Be Carved Here',
+    'about.sub': 'Your GitHub Name will be carved into the monument and preserved for the long term.',
     'pillar1.title': '43.6 km² of Real City',
     'pillar1.desc': 'From the North Fifth Ring to Beijing North Railway Station, linking Qinghuayuan, Dazhongsi, and the Jing-Zhang Railway Heritage Park. This is not a sandbox or demo.',
     'pillar2.title': 'Agents Across the Workflow',
@@ -1382,7 +1373,6 @@ const T = {
     'footer.l5': 'Submissions', 'footer.l6': 'Review Rubric',
     'footer.l7': 'PR Template', 'footer.l8': 'GitHub Repository ↗',
     'footer.contact': 'Contact: contact@open-city.ai',
-    'footer.license': 'Licensing follows each work’s declaration · Participation terms',
     'footer.copy': '© 2026 Centennial Jing-Zhang AI Innovation Belt Open Call',
   }
 };

--- a/review.html
+++ b/review.html
@@ -66,12 +66,6 @@ nav{
   font:10px var(--mono);letter-spacing:.12em;padding:8px 12px;transition:all .18s;
 }
 .nav-lang:hover{border-color:var(--accent);color:var(--accent)}
-.nav-cta{
-  border:1px solid rgba(var(--accent-rgb),.55);background:rgba(var(--accent-rgb),.08);
-  color:var(--accent);padding:8px 14px;font-size:12px;letter-spacing:.04em;transition:all .18s;
-}
-.nav-cta:hover{background:var(--accent);color:#05070a}
-
 .page-hero{position:relative;border-bottom:1px solid var(--line);padding:76px 44px 64px;overflow:hidden}
 .page-hero::before{
   content:"";position:absolute;top:18px;left:24px;width:22px;height:22px;
@@ -207,7 +201,6 @@ nav{
   <span class="nav-title" data-i18n="nav.title">评审细则</span>
   <div class="nav-right">
     <button class="nav-lang" id="langToggle">EN</button>
-    <a href="terms.html" class="nav-cta" data-i18n="nav.cta">查看项目状态</a>
   </div>
 </nav>
 
@@ -312,7 +305,7 @@ nav{
 const T = {
   zh:{
     'page.title':'评审细则 — 百年京张 AI 创新带','lang.toggle':'EN',
-    'nav.back':'百年京张 · AI 创新带','nav.title':'评审细则','nav.cta':'查看项目状态',
+    'nav.back':'百年京张 · AI 创新带','nav.title':'评审细则',
     'page.h1':'评审细则','page.sub':'REVIEW RUBRIC — CENTENNIAL JING-ZHANG AI INNOVATION BELT',
     'page.desc':'本细则供维护者人工评审参考，也可供 AI 评审 agent 使用。评审结论只作为维护者决策参考，不属于 required CI。CI 只做确定性格式校验。',
     'score.title':'七大评分维度','score.desc':'每个维度独立评估，综合判断后由维护者决定是否合并方案。',
@@ -340,7 +333,7 @@ const T = {
   },
   en:{
     'page.title':'Review Rubric — Centennial Jing-Zhang AI Innovation Belt','lang.toggle':'中文',
-    'nav.back':'Jing-Zhang · AI Belt','nav.title':'Review Rubric','nav.cta':'View Project Status',
+    'nav.back':'Jing-Zhang · AI Belt','nav.title':'Review Rubric',
     'page.h1':'Review Rubric','page.sub':'REVIEW RUBRIC — CENTENNIAL JING-ZHANG AI INNOVATION BELT',
     'page.desc':'This rubric is for maintainer review and may also be used by independent AI review agents. Review outcomes are advisory only and are not part of required CI. CI performs deterministic format checks only.',
     'score.title':'Seven Scoring Dimensions','score.desc':'Each dimension is assessed independently; the final merge decision is made by maintainers after holistic judgment.',

--- a/scripts/prelaunch_check.py
+++ b/scripts/prelaunch_check.py
@@ -128,7 +128,7 @@ def check_activity_open(repo_root: Path, checks: list[dict[str, Any]]) -> None:
     for key, value in expected.items():
         if status.get(key) != value:
             failures.append(f"activity-status.json: {key} must be {value!r}")
-    public_pages = ["index.html", "agent.html", "brief.html", "review.html", "submissions.html", "terms.html", "README.md"]
+    public_pages = ["index.html", "agent.html", "brief.html", "review.html", "submissions.html", "README.md"]
     forbidden = ["当前未开放公共", "暂未开放公共", "尚未开放公共"]
     for rel in public_pages:
         text = read_text(repo_root / rel)

--- a/submissions.html
+++ b/submissions.html
@@ -66,12 +66,6 @@ nav{
   font:10px var(--mono);letter-spacing:.12em;padding:8px 12px;transition:all .18s;
 }
 .nav-lang:hover{border-color:var(--accent);color:var(--accent)}
-.nav-cta{
-  border:1px solid rgba(var(--accent-rgb),.55);background:rgba(var(--accent-rgb),.08);
-  color:var(--accent);padding:8px 14px;font-size:12px;letter-spacing:.04em;transition:all .18s;
-}
-.nav-cta:hover{background:var(--accent);color:#05070a}
-
 .page-hero{position:relative;border-bottom:1px solid var(--line);padding:76px 44px 64px;overflow:hidden}
 .page-hero::before{
   content:"";position:absolute;top:18px;left:24px;width:22px;height:22px;
@@ -309,7 +303,6 @@ nav{
   <span class="nav-title" data-i18n="nav.title">方案展示</span>
   <div class="nav-right">
     <button class="nav-lang" id="langToggle">EN</button>
-    <a href="terms.html" class="nav-cta" data-i18n="nav.cta">查看项目状态</a>
   </div>
 </nav>
 
@@ -414,7 +407,7 @@ const SUBMISSIONS = window.HAIDIAN_SUBMISSIONS || [];
 const T = {
   zh:{
     'page.title':'方案展示 — 百年京张 AI 创新带','lang.toggle':'EN',
-    'nav.back':'百年京张 · AI 创新带','nav.title':'方案展示','nav.cta':'查看项目状态',
+    'nav.back':'百年京张 · AI 创新带','nav.title':'方案展示',
     'page.label':'SUBMISSIONS GALLERY','page.h1':'方案展示',
     'page.sub':'ALL PROPOSALS — CENTENNIAL JING-ZHANG AI INNOVATION BELT',
     'page.desc':'集中展示仓库中的方案包、HTML 可视化和流程样例。正式方案、临时边界示例与历史测试样例均按状态标注，方便评审和学习。',
@@ -438,7 +431,7 @@ const T = {
   },
   en:{
     'page.title':'Proposal Gallery — Centennial Jing-Zhang AI Innovation Belt','lang.toggle':'中文',
-    'nav.back':'Jing-Zhang · AI Belt','nav.title':'Submissions','nav.cta':'View Project Status',
+    'nav.back':'Jing-Zhang · AI Belt','nav.title':'Submissions',
     'page.label':'SUBMISSIONS GALLERY','page.h1':'Proposal Gallery',
     'page.sub':'ALL PROPOSALS — CENTENNIAL JING-ZHANG AI INNOVATION BELT',
     'page.desc':'A gallery of proposal packages, local HTML visualizations, and workflow fixtures in this repository. Formal, provisional, and legacy examples are clearly labeled.',

--- a/terms.html
+++ b/terms.html
@@ -1,8 +1,0 @@
-<!doctype html><html lang="zh-CN"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>参与与许可说明</title><link rel="shortcut icon" href="/favicon.ico?v=3"><link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png?v=3"><link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=3"><style>body{max-width:760px;margin:0 auto;padding:64px 24px 90px;font:14px/1.9 -apple-system,BlinkMacSystemFont,"PingFang SC","Hiragino Sans GB",sans-serif;color:#b5bac3;background:#05070a}h1,h2{line-height:1.3;color:#f1f0eb;font-weight:400;letter-spacing:-.03em}h1{font-size:30px;margin-bottom:8px}h2{font-size:19px;margin-top:40px;border-bottom:1px solid #ffffff1f;padding-bottom:10px}a{color:#5dabff;text-decoration:none}a:hover{text-decoration:underline}::selection{background:#ffc46b;color:#05070a}</style></head><body>
-<h1>参与与许可说明</h1>
-<p>本独立社区公开征集已于北京时间 2026年8月7日开放公共 intake。参与者可通过本仓库规定的 Pull Request 流程投稿。本平台不是政府或征集主办方的官方报名、官方应征成果递交、官方评审或规划审批通道。</p>
-<h2>许可边界</h2>
-<p>默认 <code>COMMUNITY-DISPLAY-ONLY</code> 仅表示作者允许本仓库为社区研究展示、审核和归档该投稿，不转让著作权，也不自动授予第三方改编或商业使用权。作者仅可为完全拥有权利的内容主动选择 CC-BY-4.0 或 CC-BY-SA-4.0。第三方资料继续适用其原始许可；AI 生成内容的权利与来源声明由投稿者负责。</p>
-<h2>空间数据</h2>
-<p>临时 geometry 不构成官方红线、审批或精确测算依据。组织方未提供正式 polygon 不会单独阻断内容评分，也不得因此对参与者扣分。</p>
-<p><a href="index.html">返回首页</a></p><!-- Cloudflare Web Analytics --><script type='module' src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "d2ed9f664e384c4889e4dfbbbc706dc6"}'></script><!-- End Cloudflare Web Analytics --></body></html>

--- a/tests/test_prelaunch_check.py
+++ b/tests/test_prelaunch_check.py
@@ -19,7 +19,6 @@ class PrelaunchCheckTests(unittest.TestCase):
             "brief.html",
             "review.html",
             "submissions.html",
-            "terms.html",
             "examples/agent-civic-loop/index.html",
             "examples/portal/index.html",
         ]
@@ -53,7 +52,7 @@ class PrelaunchCheckTests(unittest.TestCase):
         self.assertFalse(status["official_submission_channel"])
         self.assertEqual("2026-08-07", status["public_intake_open_date"])
         self.assertEqual("Asia/Shanghai", status["timezone"])
-        for rel in ["index.html", "agent.html", "brief.html", "review.html", "submissions.html", "terms.html", "README.md"]:
+        for rel in ["index.html", "agent.html", "brief.html", "review.html", "submissions.html", "README.md"]:
             with self.subTest(path=rel):
                 text = (ROOT / rel).read_text(encoding="utf-8")
                 self.assertTrue("2026年8月7日" in text or "August 7, 2026" in text)


### PR DESCRIPTION
## Summary
- prevent the English hero descender in Agents from being clipped
- remove the View Project Status and participation-terms UI, including the standalone terms page
- align the centennial narrative around Zhan Tianyou, the contributor name, and the permanent monument

## Validation
- 171 unit tests pass
- prelaunch check passes
- responsive browser QA at 1144 x 640