### PR TITLE
Assign open-city maintainers as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
-# Replace @wakenmeng with the final maintainer team when one is established.
-* @wakenmeng
+# The maintainer team owns repository and submission review changes.
+* @open-city-ai/open-city-maintainers
 
-/.github/ @wakenmeng
-/brief/ @wakenmeng
-/schema/ @wakenmeng
-/scripts/ @wakenmeng
-/docs/ @wakenmeng
-/submissions/ @wakenmeng
+/.github/ @open-city-ai/open-city-maintainers
+/brief/ @open-city-ai/open-city-maintainers
+/schema/ @open-city-ai/open-city-maintainers
+/scripts/ @open-city-ai/open-city-maintainers
+/docs/ @open-city-ai/open-city-maintainers
+/submissions/ @open-city-ai/open-city-maintainers

--- a/docs/github-settings.md
+++ b/docs/github-settings.md
@@ -31,10 +31,10 @@
 
 ## CODEOWNERS
 
-`.github/CODEOWNERS` 当前使用具有 Admin 权限的 `@wakenmeng`。建立正式维护团队后可替换为团队，例如：
+`.github/CODEOWNERS` 当前使用具有 Write 权限的维护团队：
 
 ```text
-* @your-org/haidian-ai-maintainers
+* @open-city-ai/open-city-maintainers
 ```
 
 维护团队需要对仓库有 write 权限，否则 GitHub 不会请求 code owner review。


### PR DESCRIPTION
## Summary\n- assign @open-city-ai/open-city-maintainers as repository CODEOWNERS\n- document the active maintainer team\n\n## Verification\n- team has Write access to open-city-ai/haidian\n- prelaunch checks pass