### PR TITLE
Fix maintainer validation for submissions docs

### DIFF
--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -137,6 +137,9 @@ PARTICIPANT_PROTECTED_GLOBAL_FILES = {
     "submissions-data.js",
     "gallery-publication.json",
 }
+MAINTAINER_CONTROLLED_SUBMISSIONS_ROOT_FILES = {
+    "submissions/README.md",
+}
 PROTECTED_REVIEW_ARTIFACT_PREFIXES = (
     ".maintainer-review/",
     "docs/reviews/",
@@ -1724,6 +1727,13 @@ def validate_submission(
             report.add_error(
                 f"{path}: maintainer review artifacts must stay local and only be shared through PR comments"
             )
+            continue
+
+        if path in MAINTAINER_CONTROLLED_SUBMISSIONS_ROOT_FILES:
+            if not report.maintainer_bypass:
+                report.add_error(
+                    f"{path}: only maintainers may edit submissions root documentation"
+                )
             continue
 
         if not report.maintainer_bypass:

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -698,6 +698,31 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertTrue(report.ok, "\n".join(report.errors))
             self.assertTrue(report.maintainer_bypass)
 
+    def test_maintainer_bypass_allows_submissions_root_readme(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write(root, "submissions/README.md", "# Submission documentation\n")
+            report = validate_submission(
+                root,
+                "maintainer",
+                ["submissions/README.md"],
+                ["maintainer"],
+            )
+            self.assertTrue(report.ok, "\n".join(report.errors))
+            self.assertTrue(report.maintainer_bypass)
+            self.assertEqual([], report.proposal_files)
+
+    def test_participant_cannot_modify_submissions_root_readme(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write(root, "submissions/README.md", "# Submission documentation\n")
+            report = validate_submission(root, "alice", ["submissions/README.md"])
+            self.assertFalse(report.ok)
+            self.assertIn(
+                "only maintainers may edit submissions root documentation",
+                "\n".join(report.errors),
+            )
+
     def test_review_artifacts_cannot_be_committed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- treat `submissions/README.md` as explicit maintainer-controlled root documentation
- skip proposal-package path parsing only for this exact allowlisted file when maintainer bypass is active
- keep ordinary participants blocked from editing it
- preserve malformed-path, cross-account, protected-artifact, and proposal-package validation

## Validation
- exact previous 15-file maintainer change set: PASS
- participant editing `submissions/README.md`: FAIL as expected
- submission workflow tests: 54 passed
- full suite: 173 passed
- prelaunch check: PASS