### PR TITLE
Add maintainer-owned submission feedback

### DIFF
--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -39,6 +39,11 @@ python3 scripts/maintainer_review.py \
 
 不要把这些文件写入参赛者投稿目录，也不要提交到仓库或展示页。
 
+需要把非阻断性的质量改进建议随稿长期保存时，维护者可在投稿根目录添加
+`FEEDBACK.md`。该文件只记录维护者结论，不属于参赛者方案包，不代表公开展示、
+精选、正式专业评分或现实实施批准。CI 禁止参赛者创建或修改该文件；维护者应在
+合并投稿后通过独立 PR 添加或更新，并注明对应 PR 与 commit SHA。
+
 ## 4. 复制 PR 评论
 
 把命令输出复制到 PR comment。maintainer review 的可见结果只在 PR comment 中展示，不进入 `submissions-data.js`、方案卡片或公开展示页。按建议状态处理：

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1360,7 +1360,7 @@ def validate_proposal_file(
             report.add_error(f"{proposal_path}: missing front matter field `{key}`")
 
     author = metadata.get("author_github", "")
-    if author and author.lower() != pr_author.lower():
+    if author and author.lower() != pr_author.lower() and not report.maintainer_bypass:
         report.add_error(
             f"{proposal_path}: author_github `{author}` must match PR author `{pr_author}`"
         )
@@ -1778,6 +1778,11 @@ def validate_submission(
             proposal_files.add(path)
         elif len(parts) == 4 and parts[3] == "changelog.md":
             changelog_files.add(path)
+        elif len(parts) == 4 and parts[3] == "FEEDBACK.md":
+            if not report.maintainer_bypass:
+                report.add_error(
+                    f"{path}: only maintainers may add or edit FEEDBACK.md"
+                )
         elif len(parts) == 4 and parts[3] == "risk.json":
             risk_files.add(path)
         elif len(parts) == 4 and parts[3] == "spatial.json":
@@ -1816,7 +1821,7 @@ def validate_submission(
                 report.add_error(f"{path}: visual assets must use one of {allowed}")
         else:
             report.add_error(
-                f"{path}: each proposal directory may contain proposal.md, changelog.md, risk.json, spatial.json, simulation.json, AI package files, assets/*, geometry/*, drawings/*, report/*, and visual/index.html plus visual/assets/* only"
+                f"{path}: each proposal directory may contain proposal.md, changelog.md, maintainer-only FEEDBACK.md, risk.json, spatial.json, simulation.json, AI package files, assets/*, geometry/*, drawings/*, report/*, and visual/index.html plus visual/assets/* only"
             )
 
         if not full_path.exists():

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -723,6 +723,36 @@ class SubmissionWorkflowTests(unittest.TestCase):
                 "\n".join(report.errors),
             )
 
+    def test_participant_cannot_add_maintainer_feedback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            feedback = f"{base}/FEEDBACK.md"
+            self.write(root, feedback, "# Maintainer feedback\n")
+            report = validate_submission(root, "alice", [*changed, feedback])
+            self.assertFalse(report.ok)
+            self.assertIn(
+                "only maintainers may add or edit FEEDBACK.md",
+                "\n".join(report.errors),
+            )
+
+    def test_maintainer_can_add_feedback_to_valid_submission(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            self.write_minimal_ai_package(root, base)
+            feedback = f"{base}/FEEDBACK.md"
+            self.write(root, feedback, "# Maintainer feedback\n")
+            report = validate_submission(
+                root,
+                "maintainer",
+                [feedback],
+                ["maintainer"],
+            )
+            self.assertTrue(report.ok, "\n".join(report.errors))
+            self.assertTrue(report.maintainer_bypass)
+
     def test_review_artifacts_cannot_be_committed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- allow only configured maintainers to add or edit submission-root `FEEDBACK.md`
- let maintainer bypass validate an existing participant-owned package without impersonating its author
- document the audit boundary and add regression tests

## Verification
- `python3 -m unittest tests.test_submission_workflow` (56 passed)
- `git diff --check`

— `open-city-ai-maintainers`