### PR TITLE
Record maintainer feedback for PRs 13 through 15

### DIFF
--- a/scripts/ai_review_submission.py
+++ b/scripts/ai_review_submission.py
@@ -648,7 +648,7 @@ def run_ai_review(
     validate_output_dir(repo_root, out_dir)
     review_input = build_review_input(repo_root, submission_dir)
     actual_author = review_input.get("author")
-    if actual_author != pr_author:
+    if not isinstance(actual_author, str) or actual_author.casefold() != pr_author.casefold():
         raise ReviewError(f"PR author `{pr_author}` does not match submission path author `{actual_author}`")
     out_dir.mkdir(parents=True, exist_ok=True)
     clear_run_artifacts(out_dir)

--- a/submissions/YoungHong1992/ai-native-future-city/FEEDBACK.md
+++ b/submissions/YoungHong1992/ai-native-future-city/FEEDBACK.md
@@ -1,0 +1,23 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#13](https://github.com/open-city-ai/haidian/pull/13)
+- Reviewed head: `18977c5287009d1ace3af714ac9a91ffecd767c2`
+- Reviewed package SHA-256: `5ee65557234592208035ae6ff20ad7b8c11c5677f2d1b003812b9bfa8292115b`
+- Disposition: accepted for repository intake
+- Advisory AI score: 69/100
+
+CI、四项本地 gate、真实 Agent review 与维护者抽查已完成。mandatory-rejection 检查为 pass；未发现原则性、法律法规、隐私、非公开资料或伪造官方结论等阻断问题。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 统一场景节点路径、绿地面积复算值和 manifest 自检状态，并重新生成相关 hash、指标图、PDF 与 HTML。
+2. 补齐字体、图形、地图、数据、代码、生成内容、展示许可和全球案例的逐项来源与权利证明。
+3. 将临时边界派生指标明确标为 provisional/illustrative，降低有效位数并提高“待重算”警示可见度。
+4. 补充实际 Logo/VI、AI 生态图谱、公共空间组件、场景治理流程、中英传播和三处重点区空间表达。
+5. 完善区域协同、项目及年度活动的主体、资源、KPI、审计、退出和复盘机制。
+6. 纳入老年人、儿童、残障、低收入及非数字用户的无障碍、人工兜底、退出和可负担性指标。
+
+以上意见不阻断本次 intake；稿件更新后须重新核验 package SHA 与展示批准状态。

--- a/submissions/Zeno-sole/jingzhang-ai-rail-city/FEEDBACK.md
+++ b/submissions/Zeno-sole/jingzhang-ai-rail-city/FEEDBACK.md
@@ -1,0 +1,23 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#15](https://github.com/open-city-ai/haidian/pull/15)
+- Reviewed head: `45cabf1ee3004f561c6a21a1ae2d4e5b996787f8`
+- Reviewed package SHA-256: `204f8722a229900a4bfe000ce583c0d315689374827803179d8ae2e06baac7ac`
+- Disposition: accepted for repository intake
+- Advisory AI score: 68/100
+
+CI、四项本地 gate、真实 Agent review 与维护者视觉抽查已完成。mandatory-rejection 检查为 pass；未发现原则性、法律法规、隐私、非公开资料或伪造官方结论等阻断问题。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 重新排版 A0/A3，放大核心图文、消除叠压与大面积空白，并进行实际尺寸打印校样。
+2. 补齐逐资产权利台账、字体与地图许可、代码依赖、PDF 嵌入资产和展示条款兼容性说明。
+3. 将临时边界派生指标标为 provisional/recompute-required，调整置信度、取整并区分公告近似值与复算值。
+4. 补充实际 Logo/VI、区域协作、公共空间组件、历史资源、中英传播以及长期运营 RACI、经费类别与 KPI。
+5. 把 AI 场景升级为含数据生命周期、人工申诉、安全阈值、暂停退出和验证指标的试点卡。
+6. 将分期细化为带依赖、成本、启动/停止闸门的最小可行项目，并加强弱势与数字排斥人群服务。
+
+以上意见不阻断本次 intake；稿件更新后须重新核验 package SHA 与展示批准状态。

--- a/submissions/weichenleeeee123/zhongguancun-railway-ai-belt/FEEDBACK.md
+++ b/submissions/weichenleeeee123/zhongguancun-railway-ai-belt/FEEDBACK.md
@@ -1,0 +1,23 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#14](https://github.com/open-city-ai/haidian/pull/14)
+- Reviewed head: `be534019e752b157c7486e434fbdbecc53e25eb5`
+- Reviewed package SHA-256: `54587affbe6d89dc6b5f0b7b2b47cba5bb66463f31ea76d60876761486aabf1b`
+- Disposition: accepted for repository intake
+- Advisory AI score: 64/100
+
+CI、四项本地 gate、真实 Agent review 与维护者视觉抽查已完成。mandatory-rejection 检查为 pass；未发现原则性、法律法规、隐私、非公开资料或伪造官方结论等阻断问题。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 重排主图与 A0，消除标题、图例和注记叠压、空白流程框及无效留白，并提高精度警示可见度。
+2. 建立字体、图片、图标、Logo、地图、几何、网页代码和第三方依赖的来源与权利审计表。
+3. 将 provisional 边界生成的平方米级指标降精度并标为 provisional-derived，统一 metrics、图件、PDF 与 HTML。
+4. 为国际案例、历史陈述与区域协同补充逐项来源和具体接口；无法核实的内容保持建议或背景属性。
+5. 深化重点 AI 场景的技术、数据、人工接管、安全、责任、空间剖面和 KPI，并提交实际 Logo/VI 与英文摘要。
+6. 为项目和运营体系增加 RACI、成本级别、资金方向、启动/退出门槛、维护绩效及弱势群体措施。
+
+以上意见不阻断本次 intake；稿件更新后须重新核验 package SHA 与展示批准状态。

--- a/tests/test_ai_review_submission.py
+++ b/tests/test_ai_review_submission.py
@@ -333,6 +333,16 @@ class AIReviewSubmissionTests(unittest.TestCase):
                     "https://api.openai.com/v1", "high", 7, 1024 * 1024, True,
                 )
 
+    def test_submission_path_author_match_is_case_insensitive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, mock.patch(
+            "ai_review_submission.collect_visual_inputs", return_value=([], [], [])
+        ):
+            result = run_ai_review(
+                ROOT, SUBMISSION, "ALICE", Path(tmp), None, "gpt-test",
+                "https://api.openai.com/v1", "high", 7, 1024 * 1024, True,
+            )
+            self.assertTrue(result["dry_run"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- record non-blocking maintainer feedback for accepted intake PRs #13, #14, and #15
- bind each review to the reviewed contributor head and package SHA-256
- make local Agent review GitHub-login comparison case-insensitive
- add regression coverage for mixed-case GitHub identities

## Verification
- each feedback-only change passed deterministic validation
- 78 relevant unit tests passed
- `git diff --check`

— `open-city-ai-maintainers`