### PR TITLE
Enforce minimum intake quality and safe removals

### DIFF
--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -55,6 +55,21 @@ python3 scripts/maintainer_review.py \
 
 `package_type` 描述提交物种类，`review_status` 描述审核决定。组织方缺少 official boundary/key areas 只能形成精度与复算警示，不得阻断内容评分或导致扣分。
 
+### Intake 最低质量门槛
+
+通过 CI 和 mandatory-rejection 检查只是必要条件，不自动获得合并。维护者还必须结合
+真实多模态 Agent review 与人工视觉抽查执行最低质量门槛。出现以下任一情形时不得
+合并，并使用 `review/changes-requested` 或 `review/low-quality` 留下可执行反馈：
+
+- 核心图纸因缺字、损坏、裁切、重叠或字号过小而无法正常阅读；
+- A3/A0、HTML 或关键图件基本空白，或主要内容仍是模板、占位框和重复示意；
+- agent.1—agent.6 的核心成果仅有目录/声明，缺少足以判断方案内容的实际交付；
+- 投稿与任务实质不相关，或整体完成度不足以形成有效稿件。
+
+AI 分数只作辅助，不以单一分数自动合并或拒绝。维护者必须在 PR 评论中记录具体的
+可见质量证据。内容较粗糙但仍完整、可读、可判断的稿件，可以作为 intake 合并并把
+改进项写入维护者专属 `FEEDBACK.md`；intake 仍不代表公开展示或正式评分。
+
 ## 4A. 上线前模拟 PR 审核
 
 公开前或大改审核流程后，维护者可用仓库内 provisional 样例模拟一次 PR 审核。组织方缺少正式 geometry 不得阻断内容评分，因此参与者可控制的检查全部通过时，预期建议状态必须是 `formal-review-ready`，同时保留精度警示与复算要求：

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -20,7 +20,7 @@ import urllib.request
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-from validate_submission import format_report, validate_submission
+from validate_submission import ValidationReport, format_report, validate_submission
 
 
 COMMENT_MARKER = "<!-- haidian-submission-validation -->"
@@ -142,6 +142,15 @@ def proposal_paths_for(changed_files: list[str]) -> set[str]:
     return proposals
 
 
+def validation_paths_for(files: list[dict], maintainer_bypass: bool) -> list[str]:
+    """Exclude maintainer-authorized removals from content validation."""
+    return [
+        item["filename"]
+        for item in files
+        if not (maintainer_bypass and item.get("status") == "removed")
+    ]
+
+
 def safe_manifest_paths(manifest: object) -> set[str]:
     """Return inert, proposal-relative file paths declared by a manifest."""
     if not isinstance(manifest, dict) or not isinstance(manifest.get("files"), list):
@@ -223,6 +232,13 @@ def main() -> int:
 
     files = client.paginate(f"/repos/{repository}/pulls/{pr_number}/files?per_page=100")
     changed_files = [item["filename"] for item in files]
+    bypass = [
+        item.strip()
+        for item in os.getenv("MAINTAINER_BYPASS_LOGINS", "").split(",")
+        if item.strip()
+    ]
+    maintainer_bypass = pr_author.lower() in {item.lower() for item in bypass}
+    validation_files = validation_paths_for(files, maintainer_bypass)
 
     worktree = Path(tempfile.mkdtemp(prefix="haidian-pr-"))
     try:
@@ -232,7 +248,7 @@ def main() -> int:
                 continue
             client.download_content(head_repo, filename, head_sha, worktree / filename)
 
-        for proposal_path in proposal_paths_for(changed_files):
+        for proposal_path in proposal_paths_for(validation_files):
             destination = worktree / proposal_path
             if not destination.exists():
                 client.fetch_content(head_repo, proposal_path, head_sha, destination)
@@ -244,12 +260,16 @@ def main() -> int:
                 proposal_path,
             )
 
-        bypass = [
-            item.strip()
-            for item in os.getenv("MAINTAINER_BYPASS_LOGINS", "").split(",")
-            if item.strip()
-        ]
-        validation = validate_submission(worktree, pr_author, changed_files, bypass)
+        if not validation_files and maintainer_bypass:
+            validation = ValidationReport(
+                changed_files=changed_files,
+                maintainer_bypass=True,
+            )
+            validation.add_warning(
+                "maintainer-authorized deletion-only PR; removed files were not executed or content-validated"
+            )
+        else:
+            validation = validate_submission(worktree, pr_author, validation_files, bypass)
         validation_markdown = format_report(validation)
 
         comment = (

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -16,7 +16,7 @@ from validate_submission import (  # noqa: E402
     is_empty_pdf,
     validate_submission,
 )
-from github_pr_validation import safe_manifest_paths  # noqa: E402
+from github_pr_validation import safe_manifest_paths, validation_paths_for  # noqa: E402
 
 
 class EmptyPdfDetectionTests(unittest.TestCase):
@@ -62,6 +62,20 @@ class ManifestHydrationTests(unittest.TestCase):
     def test_invalid_manifest_shapes_return_no_paths(self) -> None:
         self.assertEqual(set(), safe_manifest_paths([]))
         self.assertEqual(set(), safe_manifest_paths({"files": "not-a-list"}))
+
+    def test_maintainer_removals_are_not_revalidated_as_missing_files(self) -> None:
+        files = [
+            {"filename": "submissions/alice/design/proposal.md", "status": "removed"},
+            {"filename": "docs/note.md", "status": "modified"},
+        ]
+        self.assertEqual(["docs/note.md"], validation_paths_for(files, True))
+
+    def test_participant_removals_remain_in_validation_scope(self) -> None:
+        files = [{"filename": "submissions/alice/design/proposal.md", "status": "removed"}]
+        self.assertEqual(
+            ["submissions/alice/design/proposal.md"],
+            validation_paths_for(files, False),
+        )
 
 
 REFERENCE_BLOCK = (


### PR DESCRIPTION
## Summary
- document the minimum readable and substantive quality threshold for intake
- keep AI scores advisory while requiring concrete visual evidence for low-quality rejection
- allow trusted maintainers to remove an already-merged submission without CI treating deleted files as missing
- keep participant deletions within normal validation scope

## Verification
- 66 relevant unit tests passed
- prelaunch check passed
- `git diff --check`

— `open-city-ai-maintainers`