### PR TITLE
Add maintainer feedback for PR 42

### DIFF
--- a/submissions/Clay-HHK/agent-habitat-belt/FEEDBACK.md
+++ b/submissions/Clay-HHK/agent-habitat-belt/FEEDBACK.md
@@ -1,0 +1,23 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#42](https://github.com/open-city-ai/haidian/pull/42)
+- Reviewed head: `974e0db5cb2448943f93808c4897a01d76ff82a0`
+- Reviewed package SHA-256: `b7ab4f39e15886445c7f90b768f07c3d71dcfd59c66a269c42759fabe9cce5d5`
+- Disposition: accepted for repository intake
+- Review Agent score: 79/100
+
+CI、四项本地 gate、真实 Agent review 与人工视觉抽查通过；得分达到 60 分最低线，mandatory-rejection 为 pass，未发现原则性或法律法规阻断。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 在正式评审材料首页持续明确：临时几何及其派生面积、线位不得作为官方红线、审批或工程依据。
+2. 官方几何发布后，按统一 EPSG:4548 口径整体重算 GeoJSON、指标、图纸、HTML、分期和正文数值，并提交差异报告。
+3. 增加区域协同矩阵，覆盖北纬社区、未来科学城、怀柔科学城、经开区和京津冀的能力互补、接口及数据/知识产权边界。
+4. 统一“七要素/八要素”口径，为四个产业测试验证场景和近期项目补充最小可行试点、RACI、人工接管、退出条件及 KPI 框架。
+5. 修复 A3 第 2 页自检表换行拥挤，补充实际 Logo 原型和不依赖未清权底图的参照关系图，并校验 A0/A3 实际打印尺度。
+6. 在现场部署或正式采用前完成数据保护、安全、伦理、字体许可、Logo 作者声明和商标近似检索。
+
+以上意见不阻断本次 intake；稿件更新后须重新核验 package SHA 与展示批准状态。


### PR DESCRIPTION
Adds the non-blocking maintainer feedback record for accepted intake PR #42, including the locked reviewed head, package SHA-256, Review Agent score, and follow-up priorities.\n\nValidation: PASS with maintainer bypass; only expected provisional-boundary/sensitive-data review warnings remain.