### PR TITLE
Add maintainer feedback for PR 45

### DIFF
--- a/submissions/dudulu-ai/jingzhang-ai-commons-rail/FEEDBACK.md
+++ b/submissions/dudulu-ai/jingzhang-ai-commons-rail/FEEDBACK.md
@@ -1,0 +1,23 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#45](https://github.com/open-city-ai/haidian/pull/45)
+- Reviewed head: `0f3f5dd8fa8ddc80aaf034e6c9f72e89a4a43435`
+- Reviewed package SHA-256: `bb9c4f614d155e9d0e0d332eb2799a56320f1dbc9aaff3995e25188e5c466f93`
+- Disposition: accepted for repository intake
+- Review Agent score: 87/100
+
+CI、四项本地 gate、真实 Agent review 与人工视觉抽查通过；得分达到 60 分最低线，mandatory-rejection 为 pass，未发现原则性或法律法规阻断。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 统一 `manifest`、`metrics` 与 `assumptions` 的置信度表达，避免包级 `high` 与 provisional/low 空间指标冲突。
+2. 官方 polygon 发布后，通过既定生成链完整重跑几何、指标、分期、PNG、A3/A0、HTML、manifest 哈希和四项检查。
+3. 补充区域协同矩阵，明确与北纬社区、未来科学城、怀柔科学城、经开区及京津冀的资源流、接口和非承诺边界。
+4. 为 JZ-01 至 JZ-09 增加角色级 RACI、前置材料、准入表单、停止/恢复条件、资源类别和可审计 KPI。
+5. 完善公共空间组件库、双语品牌/导视规则和国际传播文案；正式底图与文保资料到位后深化三核空间原型。
+6. 对 A0 实体展板开展远距可读性和色彩对比测试，对 HTML 开展键盘、屏幕阅读器、替代文本和对比度人工检查。
+
+以上意见不阻断本次 intake；稿件更新后须重新核验 package SHA 与展示批准状态。


### PR DESCRIPTION
Adds the non-blocking maintainer feedback record for accepted intake PR #45, including the locked reviewed head, package SHA-256, Review Agent score, and follow-up priorities.\n\nValidation: PASS with maintainer bypass; only expected provisional-boundary warnings remain.