### PR TITLE
Add feedback for accepted intake batch

### DIFF
--- a/submissions/Abelonx/open-rail/FEEDBACK.md
+++ b/submissions/Abelonx/open-rail/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#83](https://github.com/open-city-ai/haidian/pull/83)
+- Reviewed head: `b901b88d8bd57a5df0a7073002ed59f71674b423`
+- Reviewed package SHA-256: `c40d00246b4e31e07a256f0c1519aa9ed64ef1ad6eb5ecedfb8fb800e1f18832`
+- Disposition: accepted for repository intake
+- Review Agent score: 80/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 补齐逐资产权利链、区域协同图、可执行试点卡和双语传播资产。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/Currrrrrry/jingzhang-response/FEEDBACK.md
+++ b/submissions/Currrrrrry/jingzhang-response/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#68](https://github.com/open-city-ai/haidian/pull/68)
+- Reviewed head: `397c8e025a46c0fc6559ff0257240c67469d3d8e`
+- Reviewed package SHA-256: `a016553375d8f40af6929fa16355dec7a29a510e81cd257e43134ef2f5ca703e`
+- Disposition: accepted for repository intake
+- Review Agent score: 75/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 补齐逐资产授权和可见专项成果，并加强实施矩阵与人工视觉 QA。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/Empress7211/open-jingzhang/FEEDBACK.md
+++ b/submissions/Empress7211/open-jingzhang/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#72](https://github.com/open-city-ai/haidian/pull/72)
+- Reviewed head: `fcbe4abd66805d63edf9f9a3105606eab8d63f65`
+- Reviewed package SHA-256: `d5f26d5dac826385a8190f72840681c8c64071812c53f0975989f52f45128f35`
+- Disposition: accepted for repository intake
+- Review Agent score: 89/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 补齐字体与逐资产许可，完善区域协同、试点协议和无障碍 QA。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/KerryChia/jingzhang-symbiotic-rail/FEEDBACK.md
+++ b/submissions/KerryChia/jingzhang-symbiotic-rail/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#76](https://github.com/open-city-ai/haidian/pull/76)
+- Reviewed head: `42e367e486ab3d2c5c945f72fbe3cdafd6f98c9c`
+- Reviewed package SHA-256: `817b5893a5c2c8f942e3791c506bf608cb2cc4da8e0f37255001365ced2ae407`
+- Disposition: accepted for repository intake
+- Review Agent score: 66/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 优先修复 PDF 中文缺字和近空白页，补齐权利台账与视觉成果。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/LangQi99/jingzhang-commonline/FEEDBACK.md
+++ b/submissions/LangQi99/jingzhang-commonline/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#64](https://github.com/open-city-ai/haidian/pull/64)
+- Reviewed head: `ffeb9133331dbd308f22cde62b9fb26226d1b156`
+- Reviewed package SHA-256: `5cc707b8ba33b457a701afc6fc98734e4fbfe15ed28209eb7396f8f91c5175e3`
+- Disposition: accepted for repository intake
+- Review Agent score: 71/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 补齐权利链、场景组件和运营责任，并修复 A0/A3 可读性。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/abakane1/jingzhang-civic-agent-os/FEEDBACK.md
+++ b/submissions/abakane1/jingzhang-civic-agent-os/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#78](https://github.com/open-city-ai/haidian/pull/78)
+- Reviewed head: `e87ef1dd54b2fc614ff5762fb39c1f6ad3b06b57`
+- Reviewed package SHA-256: `cffeb284a509ed721c09059af8ac02c0d62cc2bb36caa7feda3238b6309690b9`
+- Disposition: accepted for repository intake
+- Review Agent score: 70/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 修复 A0/A3 缺字、标签重叠和过小文字，补齐权利与实施矩阵。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/baobao-byte/jingzhang-civic-ai-loop/FEEDBACK.md
+++ b/submissions/baobao-byte/jingzhang-civic-ai-loop/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#70](https://github.com/open-city-ai/haidian/pull/70)
+- Reviewed head: `35c374556239def4654582fdfd4378caac8ce57c`
+- Reviewed package SHA-256: `b460d68b84b4d6f1f61995f7ac95ada9792509b384247550ae57d9cd57624906`
+- Disposition: accepted for repository intake
+- Review Agent score: 71/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 修复 A0 与 mobility 图的裁切/重叠，统一状态，并补齐版权来源。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/c0ld1nk/jz-ai-spine/FEEDBACK.md
+++ b/submissions/c0ld1nk/jz-ai-spine/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#79](https://github.com/open-city-ai/haidian/pull/79)
+- Reviewed head: `6f3452b40c988fdbd30656562f7c168bff049191`
+- Reviewed package SHA-256: `1fddf73484b1c75acf7c2edb744f7f1079926ed8d51af39bd55b18b8e5a01a7b`
+- Disposition: accepted for repository intake
+- Review Agent score: 64/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 修复裁切、叠压、版本冲突与无效留白，补齐权利和项目责任证据。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/hotraygroup/jingzhang-ai-pulse/FEEDBACK.md
+++ b/submissions/hotraygroup/jingzhang-ai-pulse/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#46](https://github.com/open-city-ai/haidian/pull/46)
+- Reviewed head: `ad9c4ba8a16b39b95da4d8037d20312a74cdee25`
+- Reviewed package SHA-256: `f35ae8b01e473e6c2b27e50fcf9ebb0d7ceaa9af3714492cd48cb4f3b832687e`
+- Disposition: accepted for repository intake
+- Review Agent score: 68/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 统一用地比例与指标口径，修复图纸表达，并补齐逐资产权利证明。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/i5shuyi/jingzhang-ai-commons/FEEDBACK.md
+++ b/submissions/i5shuyi/jingzhang-ai-commons/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#47](https://github.com/open-city-ai/haidian/pull/47)
+- Reviewed head: `b297bc379b9793730e85fa52a23bde05fe6b4868`
+- Reviewed package SHA-256: `1a8e9a4f019f877b239fa58d7952164db406f67415b4797abaefa4d4412c1849`
+- Disposition: accepted for repository intake
+- Review Agent score: 73/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 补齐字体、图像、数据与代码许可，并改善图纸可读性和专业深化接口。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/jukkakakaka/jingzhang-commons/FEEDBACK.md
+++ b/submissions/jukkakakaka/jingzhang-commons/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#59](https://github.com/open-city-ai/haidian/pull/59)
+- Reviewed head: `13cf289207f0787f4d9087cea9e3bf1092c82ab5`
+- Reviewed package SHA-256: `038b4106c1e7d0456ba828624f47a94830642f0ad2f92d3a251bce3763c27545`
+- Disposition: accepted for repository intake
+- Review Agent score: 73/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 补齐版权来源，修复空间图与格式问题，并完善实施和运营矩阵。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/kylin985ti/jingzhang-bluegreen-link/FEEDBACK.md
+++ b/submissions/kylin985ti/jingzhang-bluegreen-link/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#75](https://github.com/open-city-ai/haidian/pull/75)
+- Reviewed head: `4b826f47d79597f6fe3c8829797c0dea019ef34a`
+- Reviewed package SHA-256: `5d4aa0c52fba9617754f76255c285442a43fe4387fb84449163de5861db71c0d`
+- Disposition: accepted for repository intake
+- Review Agent score: 81/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 补齐字体、OSM、程序化图形和代码许可，统一品牌并优化 A0/A3。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/liweinan0423/jingzhang-ai-commons-loop/FEEDBACK.md
+++ b/submissions/liweinan0423/jingzhang-ai-commons-loop/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#63](https://github.com/open-city-ai/haidian/pull/63)
+- Reviewed head: `4a19ea4f301a9be02104db6dd2217cc00f5e919d`
+- Reviewed package SHA-256: `17590de62cc222b17b288afe05054f976048d44cf15def45ac13768327ba92a2`
+- Disposition: accepted for repository intake
+- Review Agent score: 67/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 补齐权利与品牌证据，深化空间、区域协同和长期运营内容。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/quantong1990/jingzhang-comind-loop/FEEDBACK.md
+++ b/submissions/quantong1990/jingzhang-comind-loop/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#71](https://github.com/open-city-ai/haidian/pull/71)
+- Reviewed head: `781dfe551a52ad2ae8527542bfa321a9f148dd3d`
+- Reviewed package SHA-256: `c8e5c48090e5aff04202f94b4f16b4a442bc9f179b4cf31149a0d63020dc70a3`
+- Disposition: accepted for repository intake
+- Review Agent score: 70/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 重排 A0/A3、补齐任务书可视成果和逐资产权利链。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/ryanuo/twin-rails-ai-belt/FEEDBACK.md
+++ b/submissions/ryanuo/twin-rails-ai-belt/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#82](https://github.com/open-city-ai/haidian/pull/82)
+- Reviewed head: `367a7ff031c60d17705eabf2ec3d4a4f25cba3b4`
+- Reviewed package SHA-256: `f2b0061ad35cd3d56fc2856d1622b37f1374282a474f959a4802741aeed8eba2`
+- Disposition: accepted for repository intake
+- Review Agent score: 69/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 修复公共空间/建筑指标冲突、方向与裁切问题，并补齐来源与权利证明。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/smartzhanghb/origin-pulse-belt/FEEDBACK.md
+++ b/submissions/smartzhanghb/origin-pulse-belt/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#57](https://github.com/open-city-ai/haidian/pull/57)
+- Reviewed head: `42afe45aa9004d060a48fe0dc40be4e90436825f`
+- Reviewed package SHA-256: `9f4ebacbec7a8d9dca67ea45283935c099ebb3d0802f5bc508d3734dd3703f42`
+- Disposition: accepted for repository intake
+- Review Agent score: 71/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 补齐逐资产权利证据，修复 A0/A3 排版和缺字，并加强空间可读性。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/takeItIzzy/jingzhang-open-commons-loop/FEEDBACK.md
+++ b/submissions/takeItIzzy/jingzhang-open-commons-loop/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#53](https://github.com/open-city-ai/haidian/pull/53)
+- Reviewed head: `d8a9c472d0e28fd1c385187e96037f483b17ab81`
+- Reviewed package SHA-256: `60b6d31ac1db627293d93a22b5b999e8f0e012728705851af1f34995084288bb`
+- Disposition: accepted for repository intake
+- Review Agent score: 81/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 补齐可核验权利链，修复缺字字符，并完成印刷与无障碍复核。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/teddyli18000/jingzhang-ai-kernel/FEEDBACK.md
+++ b/submissions/teddyli18000/jingzhang-ai-kernel/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#61](https://github.com/open-city-ai/haidian/pull/61)
+- Reviewed head: `82b2f48851da79553d66803770aab16d9347a7ed`
+- Reviewed package SHA-256: `fcb75fcc051e8282c23ba0900918b288cbcc153aa9e627dcb3b943aefcba6c2c`
+- Disposition: accepted for repository intake
+- Review Agent score: 76/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 补齐权利证明，优化 A0 信息密度与图层重叠，并加强节点级空间表达。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/titanwings/jingzhang-ai-pulse/FEEDBACK.md
+++ b/submissions/titanwings/jingzhang-ai-pulse/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#44](https://github.com/open-city-ai/haidian/pull/44)
+- Reviewed head: `24e70bd6d2690fa00d0cb9bd019d7ec3fa4670df`
+- Reviewed package SHA-256: `e501e69a3325d95188d08e6dc1ab48ed78578758127477f4a97c38f02a56356f`
+- Disposition: accepted for repository intake
+- Review Agent score: 67/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 补齐逐资产权利台账，修复视觉可读性，并深化空间与运营证据。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/xiayuzizhuo666/jingzhang-ai-zhimai-belt/FEEDBACK.md
+++ b/submissions/xiayuzizhuo666/jingzhang-ai-zhimai-belt/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#80](https://github.com/open-city-ai/haidian/pull/80)
+- Reviewed head: `b936ae36a8e8374837d13f66f2be1231c095c236`
+- Reviewed package SHA-256: `dcfb9073af9a3361aadc0833e7a94527cca8b98cf370363d7ee62e83b616a32d`
+- Disposition: accepted for repository intake
+- Review Agent score: 68/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 统一空间指标与单位，修复近空白图纸，补齐缺失场景卡和权利台账。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+

--- a/submissions/xuhong992/jingzhang-ai-smart-belt/FEEDBACK.md
+++ b/submissions/xuhong992/jingzhang-ai-smart-belt/FEEDBACK.md
@@ -1,0 +1,22 @@
+# Maintainer feedback / 维护者反馈
+
+- Reviewer: `open-city-ai-maintainers`
+- Submission PR: [#77](https://github.com/open-city-ai/haidian/pull/77)
+- Reviewed head: `e83eca286da041acd8a6d36fc2ec427424cb8de2`
+- Reviewed package SHA-256: `64950f8660c4c00da79fe0d92aa85e3fd3ef8d7a839e013f6d13eb9f163cc893`
+- Disposition: accepted for repository intake
+- Review Agent score: 67/100
+
+CI、四项本地 gate 与真实多模态 Review Agent 已完成；得分达到 60 分 intake 最低线，mandatory-rejection 为 pass，未发现必须拒绝的原则性内容。
+
+接收入库不等于公开展示、精选、正式评分、官方审定或现实实施批准。
+
+## Non-blocking priorities / 非阻断改进建议
+
+1. 重做近空白 A0、统一状态与指标表述，并补齐逐资产权利证明。
+2. 官方几何到位后统一替换相关图层，重算指标并更新 PNG、PDF、HTML、矩阵与版本差异记录。
+3. 后续修订应继续保持概念建议、非政府决定、临时边界和人工最终判断等边界声明。
+4. 公开展示前仍须通过人工视觉、无障碍、来源和版权专项审核。
+
+详细七维评分、数据缺口和逐项整改要求见原投稿 PR 的 Review Agent 评论。以上意见不阻断本次 intake；稿件更新后须重新核验 head、package SHA 与展示批准状态。
+


### PR DESCRIPTION
Adds maintainer-owned FEEDBACK.md files for the submissions accepted from PRs #44 through #83 under the revised repository-intake threshold. Each file locks the reviewed head, package SHA-256, and Review Agent score. This does not publish or feature any submission.