### PR TITLE
Queue validated submissions automatically

### DIFF
--- a/docs/github-settings.md
+++ b/docs/github-settings.md
@@ -51,6 +51,7 @@
 ## AI 评审边界
 
 required CI 不接入 AI，也不配置模型密钥。它只做确定性的路径、格式、文件类型、文件大小、提交阶段语义、基础 GeoJSON 字段和明显红线预检。
+校验通过后 workflow 自动添加 `review/queued`；失败则添加 `review/ci-failed`，受信任 worker 只消费前者。
 
 可信空间复核和 AI 评审 agent 应作为独立的受信任 worker 运行，不应替代 `submission-validation` 这个硬门禁。worker 只能在 required CI 成功后读取固定 PR head SHA，不执行投稿代码，并在 review 与 merge 前再次核对 SHA 和 CI。当前 intake 政策允许四项 gate 与强制退件检查通过且 Review Agent 得分不低于 60/100 时自动合并；合并不代表公开展示、精选、正式评分、实施批准或政府背书。完整 SOP 见 [maintainer-workflow.md](maintainer-workflow.md)。
 

--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -240,6 +240,10 @@ python3 scripts/auto_review_queue.py --limit 10 --apply --admin-merge
 PR 不调用模型；draft 不进入队列。合并仅表示仓库 intake，展示、精选、正式评分与
 实施决定继续由 `gallery-publication.json` 的独立流程控制。
 
+`submission-validation` 成功时会自动清除旧的 CI/修改/低质量标签并添加
+`review/queued`；投稿人推送修订后无需维护者手动重新排队。CI 失败时 workflow
+移除 queued 并添加 `review/ci-failed`，因此不会产生付费模型调用。
+
 审计材料保存在 `.maintainer-review/queue/pr-<number>/<head-sha>/`，worktree 默认在
 `.pr-worktree/auto-review/` 并在单稿完成后删除。建议用 launchd/systemd timer 每
 5–10 分钟运行一次，并以进程锁保证同一时间只有一个 worker。执行账号应使用

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -120,6 +120,22 @@ class GitHubClient:
                 return
         self.request("POST", f"/repos/{self.repository}/issues/{issue_number}/comments", {"body": body})
 
+    def add_labels(self, issue_number: int, labels: list[str]) -> None:
+        self.request(
+            "POST",
+            f"/repos/{self.repository}/issues/{issue_number}/labels",
+            {"labels": labels},
+        )
+
+    def remove_labels(self, issue_number: int, labels: list[str]) -> None:
+        for label in labels:
+            encoded = urllib.parse.quote(label, safe="")
+            try:
+                self.request("DELETE", f"/repos/{self.repository}/issues/{issue_number}/labels/{encoded}")
+            except urllib.error.HTTPError as exc:
+                if exc.code != 404:
+                    raise
+
 
 def next_link(link_header: str) -> str | None:
     for part in link_header.split(","):
@@ -149,6 +165,17 @@ def validation_paths_for(files: list[dict], maintainer_bypass: bool) -> list[str
         for item in files
         if not (maintainer_bypass and item.get("status") == "removed")
     ]
+
+
+def is_review_queue_candidate(changed_files: list[str], pr_author: str) -> bool:
+    """Return true only for a single participant-owned submission directory."""
+    roots: set[str] = set()
+    for filename in changed_files:
+        parts = filename.split("/")
+        if len(parts) < 4 or parts[0] != "submissions" or parts[1].casefold() != pr_author.casefold():
+            return False
+        roots.add("/".join(parts[:3]))
+    return bool(changed_files) and len(roots) == 1
 
 
 def safe_manifest_paths(manifest: object) -> set[str]:
@@ -280,6 +307,17 @@ def main() -> int:
         )
         write_step_summary(comment)
         client.upsert_comment(pr_number, comment)
+
+        queue_candidate = is_review_queue_candidate(changed_files, pr_author)
+        if validation.ok and queue_candidate:
+            client.remove_labels(
+                pr_number,
+                ["review/ci-failed", "review/changes-requested", "review/low-quality"],
+            )
+            client.add_labels(pr_number, ["review/queued"])
+        elif queue_candidate:
+            client.remove_labels(pr_number, ["review/queued"])
+            client.add_labels(pr_number, ["review/ci-failed"])
 
         return 0 if validation.ok else 1
     finally:

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -16,7 +16,11 @@ from validate_submission import (  # noqa: E402
     is_empty_pdf,
     validate_submission,
 )
-from github_pr_validation import safe_manifest_paths, validation_paths_for  # noqa: E402
+from github_pr_validation import (  # noqa: E402
+    is_review_queue_candidate,
+    safe_manifest_paths,
+    validation_paths_for,
+)
 
 
 class EmptyPdfDetectionTests(unittest.TestCase):
@@ -75,6 +79,32 @@ class ManifestHydrationTests(unittest.TestCase):
         self.assertEqual(
             ["submissions/alice/design/proposal.md"],
             validation_paths_for(files, False),
+        )
+
+    def test_review_queue_candidate_is_one_author_owned_submission(self) -> None:
+        self.assertTrue(
+            is_review_queue_candidate(
+                [
+                    "submissions/Alice/design/proposal.md",
+                    "submissions/Alice/design/agent.json",
+                ],
+                "alice",
+            )
+        )
+        self.assertFalse(
+            is_review_queue_candidate(
+                ["submissions/alice/design/proposal.md", "README.md"],
+                "alice",
+            )
+        )
+        self.assertFalse(
+            is_review_queue_candidate(
+                [
+                    "submissions/alice/design-a/proposal.md",
+                    "submissions/alice/design-b/proposal.md",
+                ],
+                "alice",
+            )
         )
 
 


### PR DESCRIPTION
## Summary
- label valid single-submission PRs as `review/queued`
- clear stale CI/change/low-quality labels when an author pushes a valid revision
- mark invalid submission PRs `review/ci-failed` without sending them to the paid review worker
- avoid queueing maintainer and infrastructure PRs

## Verification
- 189 unit tests passed
- prelaunch check passed
- diff check passed