### PR TITLE
Handle successful validation reruns in review queue

### DIFF
--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -62,7 +62,7 @@ def ci_state(meta: dict[str, Any]) -> str:
     conclusions = check_conclusions(meta)
     if any(item == "FAILURE" for item in conclusions):
         return "failure"
-    if conclusions and all(item == PASS for item in conclusions):
+    if any(item == PASS for item in conclusions):
         return "success"
     return "pending"
 

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -86,6 +86,17 @@ class AutoReviewQueueTests(unittest.TestCase):
                 }
             ),
         )
+        self.assertEqual(
+            "success",
+            ci_state(
+                {
+                    "statusCheckRollup": [
+                        {"name": "submission-validation", "conclusion": "SKIPPED"},
+                        {"name": "submission-validation", "conclusion": "SUCCESS"},
+                    ]
+                }
+            ),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Treat a successful current submission-validation run as passing when an older duplicate run is marked skipped. Failure still takes precedence. Includes regression coverage.