### PR TITLE
Process review backlog oldest first

### DIFF
--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -239,6 +239,7 @@ python3 scripts/auto_review_queue.py --limit 10 --apply --admin-merge
 合并前最后一次检查 head SHA/CI。低于 60 分标记 `review/low-quality`；CI 未成功的
 PR 不调用模型；draft 不进入队列。合并仅表示仓库 intake，展示、精选、正式评分与
 实施决定继续由 `gallery-publication.json` 的独立流程控制。
+worker 每轮按 PR 编号从旧到新处理，避免持续新增投稿使早期稿件饥饿。
 
 `submission-validation` 成功时会自动清除旧的 CI/修改/低质量标签并添加
 `review/queued`；投稿人推送修订后无需维护者手动重新排队。CI 失败时 workflow

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -300,14 +300,14 @@ def main() -> int:
             "--label",
             args.label,
             "--limit",
-            str(args.limit),
+            "1000",
             "--json",
             "number,author,headRefOid,state,isDraft,statusCheckRollup,labels",
         ],
         cwd=repo_root,
     )
     results = []
-    for meta in sorted(candidates, key=lambda item: int(item["number"])):
+    for meta in sorted(candidates, key=lambda item: int(item["number"]))[: args.limit]:
         try:
             results.append(process_pr(args, meta, repo_root))
         except WorkerError as exc:


### PR DESCRIPTION
Scan the full queued set, then apply the per-run limit after sorting by PR number. This prevents older submissions from starving while new PRs keep arriving. Targeted queue tests pass.