### PR TITLE
Do not fail local review on existing maintainer feedback

### DIFF
--- a/scripts/validate_local_submission.py
+++ b/scripts/validate_local_submission.py
@@ -43,12 +43,16 @@ def discover_submission_files(submission_dir: Path, repo_root: Path) -> list[str
     files = [
         repo_relative(path, repo_root)
         for path in sorted(submission_dir.rglob("*"))
-        # exhibit.json is organizer-generated, gitignored showcase output. A
-        # contributor-supplied copy is still rejected when it appears in a PR
-        # changed-file list handled by validate_submission.py.
+        # exhibit.json and FEEDBACK.md are organizer-owned files rather than
+        # participant package inputs. A contributor-supplied change is still
+        # rejected when it appears in the GitHub PR changed-file list handled
+        # directly by validate_submission.py.
         if path.is_file()
         and path.name != ".DS_Store"
-        and not (path.parent == submission_dir and path.name == "exhibit.json")
+        and not (
+            path.parent == submission_dir
+            and path.name in {"exhibit.json", "FEEDBACK.md"}
+        )
     ]
     if not files:
         raise SystemExit(f"{submission_dir}: no files found")

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -21,6 +21,7 @@ from github_pr_validation import (  # noqa: E402
     safe_manifest_paths,
     validation_paths_for,
 )
+from validate_local_submission import discover_submission_files  # noqa: E402
 
 
 class EmptyPdfDetectionTests(unittest.TestCase):
@@ -106,6 +107,18 @@ class ManifestHydrationTests(unittest.TestCase):
                 "alice",
             )
         )
+
+    def test_local_full_package_check_ignores_existing_maintainer_feedback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission = root / "submissions" / "alice" / "design"
+            submission.mkdir(parents=True)
+            (submission / "proposal.md").write_text("# Design\n", encoding="utf-8")
+            (submission / "FEEDBACK.md").write_text("# Maintainer feedback\n", encoding="utf-8")
+            self.assertEqual(
+                ["submissions/alice/design/proposal.md"],
+                discover_submission_files(submission, root),
+            )
 
 
 REFERENCE_BLOCK = (


### PR DESCRIPTION
## Summary
- exclude existing maintainer-owned FEEDBACK.md from full-package local validation
- keep GitHub PR validation unchanged, so participant attempts to add or edit FEEDBACK.md are still rejected
- add regression coverage for revised submissions that inherit maintainer feedback

## Verification
- full suite passed
- prelaunch check passed
- diff check passed