### PR TITLE
Use trusted scripts for automated reviews

### DIFF
--- a/scripts/review_submission.py
+++ b/scripts/review_submission.py
@@ -92,9 +92,10 @@ def infer_author(submission_dir: Path, repo_root: Path) -> str:
 
 
 def script_path(repo_root: Path, name: str) -> Path:
-    candidate = repo_root / "scripts" / name
-    if candidate.exists():
-        return candidate
+    # Review a participant checkout with the maintainer worker's trusted
+    # validation code.  The checkout can predate a validator fix (or contain
+    # participant-controlled scripts), so it must never supply executables to
+    # the review process.
     return SCRIPT_DIR / name
 
 

--- a/scripts/self_check_submission.py
+++ b/scripts/self_check_submission.py
@@ -18,9 +18,8 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 
 
 def script_path(repo_root: Path, name: str) -> Path:
-    candidate = repo_root / "scripts" / name
-    if candidate.exists():
-        return candidate
+    # Keep every subprocess on the same trusted validator version as this
+    # entrypoint.  repo_root may be an untrusted or older PR checkout.
     return SCRIPT_DIR / name
 
 

--- a/tests/test_trusted_review_scripts.py
+++ b/tests/test_trusted_review_scripts.py
@@ -1,0 +1,39 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import review_submission  # noqa: E402
+import self_check_submission  # noqa: E402
+
+
+class TrustedReviewScriptTests(unittest.TestCase):
+    def test_review_never_executes_script_from_submission_checkout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            untrusted = Path(tmp)
+            candidate = untrusted / "scripts" / "self_check_submission.py"
+            candidate.parent.mkdir()
+            candidate.write_text("raise RuntimeError('untrusted')\n", encoding="utf-8")
+
+            resolved = review_submission.script_path(untrusted, candidate.name)
+
+            self.assertEqual(REPO_ROOT / "scripts" / candidate.name, resolved)
+
+    def test_self_check_keeps_subprocesses_on_trusted_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            untrusted = Path(tmp)
+            candidate = untrusted / "scripts" / "validate_local_submission.py"
+            candidate.parent.mkdir()
+            candidate.write_text("raise RuntimeError('untrusted')\n", encoding="utf-8")
+
+            resolved = self_check_submission.script_path(untrusted, candidate.name)
+
+            self.assertEqual(REPO_ROOT / "scripts" / candidate.name, resolved)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- execute validation subprocesses from the maintainer worker checkout
- never execute stale or participant-controlled scripts from a PR worktree
- add regression coverage for both review entrypoints

## Verification
- python3 -m unittest tests.test_trusted_review_scripts tests.test_review_submission tests.test_agent_scaffold_and_self_check