### PR TITLE
fix: render Markdown tables in proposal reports

### DIFF
--- a/scripts/render_proposal_html.py
+++ b/scripts/render_proposal_html.py
@@ -13,6 +13,7 @@ from pathlib import Path, PurePosixPath
 IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
 REFERENCE_RE = re.compile(r"\[(source|standard|depth|data|metric):([^\]\s]+)\]")
 INLINE_CODE_RE = re.compile(r"`([^`]+)`")
+TABLE_DELIMITER_CELL_RE = re.compile(r"^:?-{3,}:?$")
 
 
 def parse_front_matter(text: str) -> tuple[dict[str, str], str]:
@@ -56,6 +57,71 @@ def render_inline(text: str) -> str:
     return REFERENCE_RE.sub(replace_ref, escaped)
 
 
+def pipe_is_escaped(line: str, index: int) -> bool:
+    backslashes = 0
+    index -= 1
+    while index >= 0 and line[index] == "\\":
+        backslashes += 1
+        index -= 1
+    return backslashes % 2 == 1
+
+
+def has_unescaped_pipe(line: str) -> bool:
+    for index, char in enumerate(line):
+        if char == "|" and not pipe_is_escaped(line, index):
+            return True
+    return False
+
+
+def split_table_row(line: str) -> list[str]:
+    text = line.strip()
+    cells: list[str] = []
+    cell: list[str] = []
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char == "|" and pipe_is_escaped(text, index):
+            cell.pop()
+            cell.append("|")
+            index += 1
+            continue
+        if char == "|":
+            cells.append("".join(cell).strip())
+            cell = []
+        else:
+            cell.append(char)
+        index += 1
+    cells.append("".join(cell).strip())
+
+    if text.startswith("|"):
+        cells = cells[1:]
+    if text.endswith("|") and not pipe_is_escaped(text, len(text) - 1):
+        cells = cells[:-1]
+    return cells
+
+
+def parse_table_delimiter(line: str) -> list[str] | None:
+    cells = split_table_row(line)
+    if not cells or not all(TABLE_DELIMITER_CELL_RE.fullmatch(cell) for cell in cells):
+        return None
+    return cells
+
+
+def table_alignment(delimiter: str) -> str | None:
+    if delimiter.startswith(":") and delimiter.endswith(":"):
+        return "center"
+    if delimiter.endswith(":"):
+        return "right"
+    if delimiter.startswith(":"):
+        return "left"
+    return None
+
+
+def render_table_cell(tag: str, value: str, alignment: str | None) -> str:
+    alignment_class = f' class="align-{alignment}"' if alignment else ""
+    return f"<{tag}{alignment_class}>{render_inline(value)}</{tag}>"
+
+
 def render_markdown_body(submission_dir: Path, markdown: str) -> str:
     blocks: list[str] = []
     paragraph: list[str] = []
@@ -73,11 +139,73 @@ def render_markdown_body(submission_dir: Path, markdown: str) -> str:
             blocks.append("</ul>")
             in_list = False
 
-    for raw_line in markdown.splitlines():
-        line = raw_line.rstrip()
+    lines = markdown.splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index].rstrip()
+        stripped_line = line.strip()
+
+        if (
+            index + 1 < len(lines)
+            and stripped_line
+            and not line.startswith("#")
+            and not line.startswith("- ")
+            and not IMAGE_RE.fullmatch(stripped_line)
+            and (has_unescaped_pipe(line) or has_unescaped_pipe(lines[index + 1]))
+        ):
+            delimiter_cells = parse_table_delimiter(lines[index + 1].strip())
+            header_cells = split_table_row(line)
+            if delimiter_cells is not None and len(header_cells) == len(delimiter_cells):
+                flush_paragraph()
+                close_list()
+                alignments = [table_alignment(cell) for cell in delimiter_cells]
+                header = "".join(
+                    render_table_cell("th", cell, alignment)
+                    for cell, alignment in zip(header_cells, alignments)
+                )
+                index += 2
+                body_rows: list[str] = []
+                while index < len(lines):
+                    row = lines[index].rstrip()
+                    stripped = row.strip()
+                    if (
+                        not stripped
+                        or not has_unescaped_pipe(row)
+                        or stripped.startswith("#")
+                        or stripped.startswith("- ")
+                        or stripped.startswith("* ")
+                        or stripped.startswith("+ ")
+                        or stripped.startswith(">")
+                        or stripped.startswith("```")
+                        or stripped.startswith("~~~")
+                        or re.match(r"^\d{1,9}[.)]\s+", stripped)
+                        or IMAGE_RE.fullmatch(stripped)
+                    ):
+                        break
+                    cells = split_table_row(row)
+                    cells = (cells + [""] * len(header_cells))[: len(header_cells)]
+                    body_rows.append(
+                        "<tr>"
+                        + "".join(
+                            render_table_cell("td", cell, alignment)
+                            for cell, alignment in zip(cells, alignments)
+                        )
+                        + "</tr>"
+                    )
+                    index += 1
+                body = f"<tbody>{''.join(body_rows)}</tbody>" if body_rows else ""
+                blocks.append(
+                    '<div class="proposal-table"><table>'
+                    f"<thead><tr>{header}</tr></thead>"
+                    f"{body}"
+                    "</table></div>"
+                )
+                continue
+
         if not line.strip():
             flush_paragraph()
             close_list()
+            index += 1
             continue
 
         image_match = IMAGE_RE.fullmatch(line.strip())
@@ -92,6 +220,7 @@ def render_markdown_body(submission_dir: Path, markdown: str) -> str:
                 f"<figcaption>{alt}</figcaption>"
                 "</figure>"
             )
+            index += 1
             continue
 
         if line.startswith("#"):
@@ -100,6 +229,7 @@ def render_markdown_body(submission_dir: Path, markdown: str) -> str:
             level = min(len(line) - len(line.lstrip("#")), 4)
             title = line[level:].strip()
             blocks.append(f"<h{level}>{render_inline(title)}</h{level}>")
+            index += 1
             continue
 
         if line.startswith("- "):
@@ -108,9 +238,11 @@ def render_markdown_body(submission_dir: Path, markdown: str) -> str:
                 blocks.append("<ul>")
                 in_list = True
             blocks.append(f"<li>{render_inline(line[2:].strip())}</li>")
+            index += 1
             continue
 
         paragraph.append(line.strip())
+        index += 1
 
     flush_paragraph()
     close_list()
@@ -195,6 +327,24 @@ code {{
 }}
 .summary {{ color: var(--muted); font-size: 17px; }}
 .translation-link a {{ color: var(--accent); font-weight: 700; }}
+.proposal-table {{ margin: 20px 0 26px; overflow-x: auto; }}
+.proposal-table table {{
+  border-collapse: collapse;
+  width: 100%;
+  min-width: 520px;
+  font-size: 15px;
+}}
+.proposal-table th, .proposal-table td {{
+  border: 1px solid var(--line);
+  padding: 9px 12px;
+  text-align: left;
+  vertical-align: top;
+  line-height: 1.6;
+}}
+.proposal-table th {{ background: #eef2f7; color: var(--ink); font-weight: 700; }}
+.proposal-table tbody tr:nth-child(even) {{ background: #fafcfe; }}
+.proposal-table .align-center {{ text-align: center; }}
+.proposal-table .align-right {{ text-align: right; }}
 .proposal-figure {{
   margin: 22px 0 28px;
   border: 1px solid var(--line);

--- a/tests/test_render_proposal_html.py
+++ b/tests/test_render_proposal_html.py
@@ -50,6 +50,111 @@ summary: "离线阅读版"
             self.assertIn('../assets/figures/site-overview.png', html)
             self.assertIn('class="evidence evidence-source"', html)
 
+    def test_render_html_renders_markdown_tables(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission_dir = Path(tmp)
+            (submission_dir / "proposal.md").write_text(
+                """---
+title: "测试方案"
+summary: "离线阅读版"
+---
+
+# 测试方案
+
+| ID | 场景 | 无AI兜底 |
+| --- | :---: | ---: |
+| SCN-01 | 模型红队交接台 | 人工评审 [metric:scenario_node_count] |
+| SCN-02 | 机器人路权沙盒 | 安全员物理停机 |
+
+表后正文。
+""",
+                encoding="utf-8",
+            )
+
+            html = render_html(submission_dir)
+
+            self.assertIn('<div class="proposal-table"><table>', html)
+            self.assertIn("<th>ID</th>", html)
+            self.assertIn('<th class="align-center">场景</th>', html)
+            self.assertIn('<td class="align-right">人工评审 ', html)
+            self.assertIn("<td>SCN-01</td>", html)
+            self.assertIn('class="evidence evidence-metric"', html)
+            self.assertNotIn("<p>| ID |", html)
+            self.assertIn("<p>表后正文。</p>", html)
+
+    def test_render_html_supports_optional_outer_and_escaped_pipes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission_dir = Path(tmp)
+            (submission_dir / "proposal.md").write_text(
+                """名称 | 表达式
+--- | ---
+逻辑或 | `a \\| b`
+""",
+                encoding="utf-8",
+            )
+
+            html = render_html(submission_dir)
+
+            self.assertIn("<th>名称</th><th>表达式</th>", html)
+            self.assertIn("<td>逻辑或</td><td><code>a | b</code></td>", html)
+
+    def test_render_html_does_not_treat_a_heading_as_a_table_header(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission_dir = Path(tmp)
+            (submission_dir / "proposal.md").write_text(
+                "# 标题 | 补充\n--- | ---\n",
+                encoding="utf-8",
+            )
+
+            html = render_html(submission_dir)
+
+            self.assertNotIn("<table>", html)
+            self.assertIn("<h1>标题 | 补充</h1>", html)
+
+    def test_render_html_stops_a_table_before_following_block_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission_dir = Path(tmp)
+            (submission_dir / "proposal.md").write_text(
+                """| A | B |
+| --- | --- |
+| x | y |
+1. 后续步骤
+""",
+                encoding="utf-8",
+            )
+
+            html = render_html(submission_dir)
+
+            self.assertIn("<td>x</td><td>y</td>", html)
+            self.assertNotIn("<td>1. 后续步骤</td>", html)
+            self.assertIn("<p>1. 后续步骤</p>", html)
+
+    def test_render_html_rejects_mismatched_table_header_and_delimiter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission_dir = Path(tmp)
+            (submission_dir / "proposal.md").write_text(
+                "| A | B |\n| --- |\n| value |\n",
+                encoding="utf-8",
+            )
+
+            html = render_html(submission_dir)
+
+            self.assertNotIn("<table>", html)
+            self.assertIn("<p>| A | B | | --- | | value |</p>", html)
+
+    def test_render_html_keeps_non_table_pipe_lines_in_the_paragraph(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission_dir = Path(tmp)
+            (submission_dir / "proposal.md").write_text(
+                "|仅一行没有分隔行|\n后续正文。\n",
+                encoding="utf-8",
+            )
+
+            html = render_html(submission_dir)
+
+            self.assertNotIn("<table>", html)
+            self.assertIn("<p>|仅一行没有分隔行| 后续正文。</p>", html)
+
     def test_render_html_rejects_remote_images(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             submission_dir = Path(tmp)


### PR DESCRIPTION
## Summary
- render Markdown pipe tables as semantic HTML tables
- support alignment, optional outer pipes, escaped pipes, and inline evidence markers
- preserve non-table pipe text and stop before following block content
- add regression coverage for valid and invalid table forms

## Tests
- python3 -m unittest tests.test_render_proposal_html tests.test_agent_scaffold_and_self_check tests.test_submission_workflow
- python3 -m py_compile scripts/render_proposal_html.py tests/test_render_proposal_html.py
- git diff --check origin/main...HEAD

Closes #446