### PR TITLE
fix: validate non-submission code PRs without package rules

### DIFF
--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -178,11 +178,20 @@ def is_review_queue_candidate(changed_files: list[str], pr_author: str) -> bool:
     return bool(changed_files) and len(roots) == 1
 
 
-def is_non_submission_pr(changed_files: list[str]) -> bool:
-    """Return true for a code, test, docs, or configuration PR outside submissions/."""
-    return bool(changed_files) and all(
-        filename.split("/", 1)[0] != "submissions" for filename in changed_files
-    )
+def is_non_submission_pr(files: list[dict] | list[str]) -> bool:
+    """Return true only when current and renamed paths are outside submissions/."""
+    paths: list[str] = []
+    for item in files:
+        if isinstance(item, dict):
+            filename = item.get("filename")
+            if isinstance(filename, str):
+                paths.append(filename)
+            previous_filename = item.get("previous_filename")
+            if isinstance(previous_filename, str):
+                paths.append(previous_filename)
+        elif isinstance(item, str):
+            paths.append(item)
+    return bool(paths) and all(filename.split("/", 1)[0] != "submissions" for filename in paths)
 
 
 def safe_manifest_paths(manifest: object) -> set[str]:
@@ -295,7 +304,7 @@ def main() -> int:
             )
 
         queue_candidate = is_review_queue_candidate(changed_files, pr_author)
-        if is_non_submission_pr(changed_files):
+        if is_non_submission_pr(files):
             validation = ValidationReport(changed_files=changed_files)
             validation.add_warning(
                 "non-submission code/docs/test PR; participant package validation was not applicable"

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -178,6 +178,13 @@ def is_review_queue_candidate(changed_files: list[str], pr_author: str) -> bool:
     return bool(changed_files) and len(roots) == 1
 
 
+def is_non_submission_pr(changed_files: list[str]) -> bool:
+    """Return true for a code, test, docs, or configuration PR outside submissions/."""
+    return bool(changed_files) and all(
+        filename.split("/", 1)[0] != "submissions" for filename in changed_files
+    )
+
+
 def safe_manifest_paths(manifest: object) -> set[str]:
     """Return inert, proposal-relative file paths declared by a manifest."""
     if not isinstance(manifest, dict) or not isinstance(manifest.get("files"), list):
@@ -287,7 +294,13 @@ def main() -> int:
                 proposal_path,
             )
 
-        if not validation_files and maintainer_bypass:
+        queue_candidate = is_review_queue_candidate(changed_files, pr_author)
+        if is_non_submission_pr(changed_files):
+            validation = ValidationReport(changed_files=changed_files)
+            validation.add_warning(
+                "non-submission code/docs/test PR; participant package validation was not applicable"
+            )
+        elif not validation_files and maintainer_bypass:
             validation = ValidationReport(
                 changed_files=changed_files,
                 maintainer_bypass=True,
@@ -308,7 +321,6 @@ def main() -> int:
         write_step_summary(comment)
         client.upsert_comment(pr_number, comment)
 
-        queue_candidate = is_review_queue_candidate(changed_files, pr_author)
         if validation.ok and queue_candidate:
             client.remove_labels(
                 pr_number,

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -121,6 +121,17 @@ class ManifestHydrationTests(unittest.TestCase):
         self.assertFalse(
             is_non_submission_pr(["submissions/alice/design/proposal.md", "scripts/tool.py"])
         )
+        self.assertFalse(
+            is_non_submission_pr(
+                [
+                    {
+                        "filename": "scripts/tool.py",
+                        "previous_filename": "submissions/alice/design/proposal.md",
+                        "status": "renamed",
+                    }
+                ]
+            )
+        )
 
     def test_local_full_package_check_ignores_existing_maintainer_feedback(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -22,6 +22,7 @@ from validate_submission import (  # noqa: E402
     validate_submission,
 )
 from github_pr_validation import (  # noqa: E402
+    is_non_submission_pr,
     is_review_queue_candidate,
     safe_manifest_paths,
     validation_paths_for,
@@ -111,6 +112,14 @@ class ManifestHydrationTests(unittest.TestCase):
                 ],
                 "alice",
             )
+        )
+
+    def test_non_submission_code_pr_is_not_sent_to_package_validator(self) -> None:
+        self.assertTrue(is_non_submission_pr(["scripts/tool.py", "tests/test_tool.py"]))
+        self.assertTrue(is_non_submission_pr(["docs/design.md"]))
+        self.assertFalse(is_non_submission_pr([]))
+        self.assertFalse(
+            is_non_submission_pr(["submissions/alice/design/proposal.md", "scripts/tool.py"])
         )
 
     def test_local_full_package_check_ignores_existing_maintainer_feedback(self) -> None:


### PR DESCRIPTION
## Problem

The trusted `pull_request_target` validator sends every contributor PR to participant-package validation. A normal PR that changes only `scripts/` and `tests/` is therefore rejected with `participant PRs may only change submissions/<login>/`, even when it is a valid repository code fix. This blocks the fix for #420 in PR #570.

## Fix

- Detect PRs whose changed paths are entirely outside `submissions/`.
- Return a deterministic PASS with an explicit warning that participant-package validation is not applicable.
- Preserve the strict submission validator for submission-only and mixed-scope PRs.
- Add unit coverage for code-only, empty, and mixed-scope changes.

## Validation

- 72 `test_submission_workflow.py` tests passed
- 5 participant-flow tests passed
- `py_compile` and `git diff --check` passed

Because the workflow intentionally checks out the trusted base branch, this PR's own existing validator job may still report the old false failure until this change is merged; the local tests exercise the changed decision path.
