### PR TITLE
fix: retry transient GitHub API read failures

### DIFF
--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -14,6 +14,7 @@ import os
 import shutil
 import sys
 import tempfile
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -25,12 +26,48 @@ from validate_submission import ValidationReport, format_report, validate_submis
 
 COMMENT_MARKER = "<!-- haidian-submission-validation -->"
 API_ROOT = "https://api.github.com"
+RETRYABLE_METHODS = {"GET", "HEAD", "OPTIONS"}
+RETRYABLE_HTTP_STATUS_CODES = {403, 429, 500, 502, 503, 504}
+MAX_HTTP_RETRIES = 3
 
 
 class GitHubClient:
     def __init__(self, token: str, repository: str) -> None:
         self.token = token
         self.repository = repository
+
+    @staticmethod
+    def _retry_delay(error: urllib.error.HTTPError, attempt: int) -> float:
+        retry_after = error.headers.get("Retry-After") if error.headers else None
+        if retry_after:
+            try:
+                return max(0.0, min(float(retry_after), 60.0))
+            except ValueError:
+                pass
+        return float(min(2**attempt, 30))
+
+    def _open(self, request: urllib.request.Request):
+        """Open a safe read request with bounded retries for transient API denials."""
+        for attempt in range(MAX_HTTP_RETRIES + 1):
+            try:
+                return urllib.request.urlopen(request, timeout=60)
+            except urllib.error.HTTPError as exc:
+                retryable = (
+                    request.method in RETRYABLE_METHODS
+                    and exc.code in RETRYABLE_HTTP_STATUS_CODES
+                    and attempt < MAX_HTTP_RETRIES
+                )
+                if not retryable:
+                    raise
+                delay = self._retry_delay(exc, attempt)
+                print(
+                    f"GitHub API {request.method} returned HTTP {exc.code}; "
+                    f"retrying in {delay:g}s ({attempt + 1}/{MAX_HTTP_RETRIES})",
+                    file=sys.stderr,
+                )
+                exc.close()
+                time.sleep(delay)
+        raise AssertionError("unreachable")
 
     def request(self, method: str, url: str, data: dict | None = None) -> tuple[Any, dict[str, str]]:
         if url.startswith("/"):
@@ -47,7 +84,7 @@ class GitHubClient:
                 "X-GitHub-Api-Version": "2022-11-28",
             },
         )
-        with urllib.request.urlopen(request, timeout=60) as response:
+        with self._open(request) as response:
             raw = response.read().decode("utf-8")
             parsed = json.loads(raw) if raw else None
             return parsed, dict(response.headers.items())
@@ -85,7 +122,7 @@ class GitHubClient:
                 "X-GitHub-Api-Version": "2022-11-28",
             },
         )
-        with urllib.request.urlopen(request, timeout=60) as response:
+        with self._open(request) as response:
             content = response.read(max_bytes + 1)
         if len(content) > max_bytes:
             raise RuntimeError(f"{destination}: file exceeds download cap")

--- a/tests/test_github_pr_validation_client.py
+++ b/tests/test_github_pr_validation_client.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import io
+import sys
+import unittest
+import urllib.error
+from email.message import Message
+from pathlib import Path
+from unittest import mock
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from github_pr_validation import GitHubClient  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, payload: bytes, headers: dict[str, str] | None = None) -> None:
+        self.payload = payload
+        self.headers = headers or {}
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.payload
+
+
+def forbidden_error(retry_after: str | None = None) -> urllib.error.HTTPError:
+    headers = Message()
+    if retry_after is not None:
+        headers["Retry-After"] = retry_after
+    return urllib.error.HTTPError(
+        "https://api.github.com/repos/open-city-ai/haidian/pulls/1/files",
+        403,
+        "Forbidden",
+        headers,
+        io.BytesIO(b"rate limit exceeded"),
+    )
+
+
+class GitHubClientRetryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = GitHubClient("token", "open-city-ai/haidian")
+
+    def test_get_retries_transient_403_then_returns_response(self) -> None:
+        with (
+            mock.patch(
+                "github_pr_validation.urllib.request.urlopen",
+                side_effect=[forbidden_error("0"), FakeResponse(b'{"ok": true}')],
+            ) as urlopen,
+            mock.patch("github_pr_validation.time.sleep") as sleep,
+        ):
+            result, headers = self.client.request("GET", "/repos/open-city-ai/haidian/pulls/1/files")
+
+        self.assertEqual({"ok": True}, result)
+        self.assertEqual({}, headers)
+        self.assertEqual(2, urlopen.call_count)
+        sleep.assert_called_once_with(0.0)
+
+    def test_get_stops_after_bounded_retries(self) -> None:
+        error = forbidden_error()
+        with (
+            mock.patch("github_pr_validation.urllib.request.urlopen", side_effect=error) as urlopen,
+            mock.patch("github_pr_validation.time.sleep") as sleep,
+        ):
+            with self.assertRaises(urllib.error.HTTPError):
+                self.client.request("GET", "/repos/open-city-ai/haidian/pulls/1/files")
+
+        self.assertEqual(4, urlopen.call_count)
+        self.assertEqual([mock.call(1.0), mock.call(2.0), mock.call(4.0)], sleep.call_args_list)
+
+    def test_mutating_request_does_not_retry_403(self) -> None:
+        error = forbidden_error()
+        with (
+            mock.patch("github_pr_validation.urllib.request.urlopen", side_effect=error) as urlopen,
+            mock.patch("github_pr_validation.time.sleep") as sleep,
+        ):
+            with self.assertRaises(urllib.error.HTTPError):
+                self.client.request("POST", "/repos/open-city-ai/haidian/issues/1/comments", {})
+
+        urlopen.assert_called_once()
+        sleep.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

submission-validation intermittently fails before reading PR files. #583/#584/#586/#587 all failed at GET /pulls/{pr}/files with HTTP 403; other nearby runs passed and local gh api access works. This turns an infrastructure transient into a content check failure.

## Fix

- retry bounded transient errors (403, 429, 500, 502, 503, 504) for idempotent GET/HEAD/OPTIONS requests
- honor numeric Retry-After, otherwise exponential 1/2/4 second backoff, max 3 retries
- apply the same safe retry path to PR-file pagination and content downloads
- never retry POST/PATCH/DELETE to avoid duplicate comments/labels
- add client-level tests for success after retry, bounded failure, and mutating-request behavior

Closes #589.

## Validation

- 3 test_github_pr_validation_client.py tests passed
- 71 test_submission_workflow.py tests passed
- 5 participant-flow tests passed
- py_compile and git diff --check passed

The prelaunch test still reports the separate stale submissions-data.js issue tracked in #588.