### PR TITLE
fix: include public source index in lightweight workspaces

### DIFF
--- a/scripts/bootstrap_participant_workspace.py
+++ b/scripts/bootstrap_participant_workspace.py
@@ -22,12 +22,14 @@ DEFAULT_SPARSE_PATHS = (
     "schema",
     "scripts",
     "skills",
+    "sources",
     "templates",
 )
 REQUIRED_FILES = (
     "skills/urban-design-ai-submission/SKILL.md",
     "brief/site-package/agent_taskbook.json",
     "data/source_registry.json",
+    "sources/public-sources.json",
     "scripts/scaffold_ai_submission.py",
     "scripts/self_check_submission.py",
     "requirements-review.txt",

--- a/skills/urban-design-ai-submission/references/lightweight-workspace.md
+++ b/skills/urban-design-ai-submission/references/lightweight-workspace.md
@@ -32,7 +32,7 @@ Use these commands when the helper cannot run:
 git clone --filter=blob:none --sparse --depth=50 \
   https://github.com/<github-login>/haidian.git haidian
 cd haidian
-git sparse-checkout set .github brief data docs schema scripts skills templates
+git sparse-checkout set .github brief data docs schema scripts skills sources templates
 git remote add upstream https://github.com/open-city-ai/haidian.git
 git fetch --filter=blob:none --depth=50 upstream main
 git switch -C main upstream/main
@@ -41,6 +41,8 @@ git switch -c submission/<github-login>/<proposal-slug>
 ```
 
 Do not replace this with a plain full clone or sparse checkout without `--filter=blob:none`. Sparse checkout alone reduces visible working files but can still download large proposal blobs into `.git`.
+
+The `sources/` directory is part of the lightweight workspace because `scripts/score_submission.py` reads `sources/public-sources.json`. Omitting it makes the advisory public-source check silently behave as if no lightweight index were available.
 
 ## Read Peer Work Progressively
 

--- a/tests/test_lightweight_participant_flow.py
+++ b/tests/test_lightweight_participant_flow.py
@@ -36,9 +36,11 @@ class LightweightParticipantFlowTests(unittest.TestCase):
         self.assertTrue(report["ok"])
         self.assertEqual(report["partial_clone_filter"], "blob:none")
         self.assertEqual(report["depth"], 50)
+        self.assertIn("sources", report["sparse_paths"])
         flattened = [token for command in report["commands"] for token in command]
         self.assertIn("--filter=blob:none", flattened)
         self.assertIn("sparse-checkout", flattened)
+        self.assertIn("sources", flattened)
         self.assertIn("submissions/octocat/agent-city", flattened)
         self.assertIn("submission/octocat/agent-city", flattened)
         self.assertIn("upstream", flattened)


### PR DESCRIPTION
## Problem

The lightweight bootstrap helper omits the top-level `sources/` directory from its sparse checkout. A participant workspace created through the documented helper therefore lacks `sources/public-sources.json`; `scripts/score_submission.py` silently treats that as an empty index and reports misleading public-source matches.

## Fix

- include `sources/` in the helper’s default sparse paths
- require `sources/public-sources.json` in the post-bootstrap required-file check
- update the transparent Git instructions to match the helper
- add regression assertions to the lightweight bootstrap flow test

Closes #485.

## Validation

- `test_lightweight_participant_flow.py`: 5 passed
- `test_score_submission.py`: 5 passed
- `test_public_sources.py`: 5 passed
- `scripts/validate_sources.py --json`: ok=true
- bootstrap dry-run confirms `sources` is in the sparse path
- `git diff --check`: passed

This is intentionally scoped to the participant workspace bootstrap. It does not broaden the public-source policy or promote `data/source_registry.json` into the lightweight index.