### PR TITLE
fix: normalize registered package source schemas

### DIFF
--- a/scripts/score_submission.py
+++ b/scripts/score_submission.py
@@ -234,6 +234,19 @@ def reference_lines(reference_section: str) -> list[str]:
         if line.startswith("- "):
             value = line[2:].strip()
             if value:
+                # Structured package anchors are evidence pointers, not
+                # public-source citations. Keep a line when it also names a
+                # [source:...] record, but do not turn data/metric/standard/
+                # depth anchors into false public-source needs-work findings.
+                if (
+                    not re.search(r"\[source:\s*[^\]]+\]", value, re.IGNORECASE)
+                    and re.search(
+                        r"\[(?:standard|depth|data|metric):\s*[^\]]+\]",
+                        value,
+                        re.IGNORECASE,
+                    )
+                ):
+                    continue
                 lines.append(value)
     return lines
 
@@ -316,12 +329,56 @@ def package_source_is_eligible(repo_root: Path, source: Any) -> bool:
     if not https_urls and not any(valid_package_path(repo_root, path) for path in local_paths):
         return False
 
-    source_kind = " ".join(
+    source_class_text = " ".join(
         value
-        for field_name in ("source_type", "source_kind")
+        for field_name in (
+            "source_type",
+            "source_kind",
+        )
         for value in string_values(source.get(field_name))
-    ).lower()
-    if any(marker in source_kind for marker in ("provisional", "inferred", "private", "internal")):
+    ).lower().replace("-", "_").replace(" ", "_")
+    if any(
+        marker in source_class_text
+        for marker in (
+            "provisional",
+            "inferred",
+            "agent_generated",
+            "agent_inferred",
+            "private",
+            "internal",
+            "needs_review",
+            "restricted",
+            "background_only",
+            "provisional_only",
+            "not_for_formal",
+        )
+    ):
+        return False
+    usage_text = " ".join(
+        value
+        for field_name in ("usage", "usage_note", "use_boundary")
+        for value in string_values(source.get(field_name))
+    ).lower().replace("-", "_").replace(" ", "_")
+    if "does_not_upgrade_provisional" not in usage_text and "provisional" in usage_text and any(
+        marker in usage_text for marker in ("boundary", "geometry", "source", "only")
+    ):
+        return False
+    if any(marker in usage_text for marker in ("needs_review", "restricted", "private", "internal")):
+        return False
+    disabled_use_text = " ".join(
+        value
+        for field_name in ("not_usable_for", "disabled_uses")
+        for value in string_values(source.get(field_name))
+    ).lower().replace("-", "_").replace(" ", "_")
+    if any(
+        marker in disabled_use_text
+        for marker in (
+            "formal",
+            "official_boundary",
+            "official_redline",
+            "statutory_control",
+        )
+    ):
         return False
 
     for field_name in (

--- a/scripts/score_submission.py
+++ b/scripts/score_submission.py
@@ -127,6 +127,9 @@ class SelfCheckReport:
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "check_scope": "advisory_proposal_only",
+            "formal_readiness": "not_assessed",
+            "next_required_check": "scripts/self_check_submission.py",
             "proposal_path": self.proposal_path,
             "ready": self.ready,
             "summary": self.summary,
@@ -637,7 +640,15 @@ def format_report(report: SelfCheckReport) -> str:
         f"{summary.get(STATUS_MANUAL_REVIEW, 0)} manual-review"
     )
     lines.append("")
-    lines.append("> This self-check is advisory. It does not replace maintainer or expert review.")
+    lines.append(
+        "> This is advisory only: `pass` and a zero `--strict` exit code apply only to this "
+        "proposal-level check. They do not assess formal readiness."
+    )
+    lines.append(
+        "> Formal readiness: not assessed. Next run "
+        "`scripts/self_check_submission.py <submission-dir> --pr-author <github-login>` "
+        "for deterministic, spatial, visual, and professional evidence validation."
+    )
 
     if report.metadata_missing:
         lines.extend(["", "Missing metadata:"])
@@ -674,7 +685,7 @@ def main() -> int:
     parser.add_argument(
         "--strict",
         action="store_true",
-        help="Exit non-zero when any self-check dimension is missing.",
+        help="Exit non-zero when an advisory self-check dimension is missing; formal readiness is not assessed.",
     )
     args = parser.parse_args()
 

--- a/scripts/score_submission.py
+++ b/scripts/score_submission.py
@@ -365,19 +365,22 @@ def package_source_is_eligible(repo_root: Path, source: Any) -> bool:
         return False
     if any(marker in usage_text for marker in ("needs_review", "restricted", "private", "internal")):
         return False
-    disabled_use_text = " ".join(
-        value
+    disabled_use_values = [
+        value.lower().replace("-", "_").replace(" ", "_")
         for field_name in ("not_usable_for", "disabled_uses")
         for value in string_values(source.get(field_name))
-    ).lower().replace("-", "_").replace(" ", "_")
+    ]
+    # A narrow prohibition such as "official redline" or "statutory
+    # planning control" is compatible with a source that is formally useful
+    # for a stated, smaller purpose. Only an explicit whole-source formal
+    # exclusion should keep the registered source unresolved; otherwise a
+    # package that documents the boundary is penalized for documenting it.
     if any(
-        marker in disabled_use_text
-        for marker in (
-            "formal",
-            "official_boundary",
-            "official_redline",
-            "statutory_control",
+        re.search(
+            r"(?:^|_)(?:formal_review|formal_evidence|formal_use|not_for_formal|official_boundary)(?:$|_)",
+            value,
         )
+        for value in disabled_use_values
     ):
         return False
 

--- a/scripts/score_submission.py
+++ b/scripts/score_submission.py
@@ -12,7 +12,7 @@ import argparse
 import json
 import re
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from validate_submission import PLACEHOLDERS, extract_headings, parse_front_matter
@@ -97,6 +97,7 @@ class SelfCheckReport:
     proposal_path: str
     checks: list[CheckResult]
     matched_sources: list[SourceMatch] = field(default_factory=list)
+    registered_external_or_package_sources: list[SourceMatch] = field(default_factory=list)
     unmatched_reference_lines: list[str] = field(default_factory=list)
     metadata_missing: list[str] = field(default_factory=list)
     required_sections_missing: list[str] = field(default_factory=list)
@@ -119,15 +120,15 @@ class SelfCheckReport:
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "check_scope": "advisory_proposal_only",
-            "formal_readiness": "not_assessed",
-            "next_required_check": "scripts/self_check_submission.py",
             "proposal_path": self.proposal_path,
             "ready": self.ready,
             "summary": self.summary,
             "metadata_missing": self.metadata_missing,
             "required_sections_missing": self.required_sections_missing,
             "matched_sources": [item.to_dict() for item in self.matched_sources],
+            "registered_external_or_package_sources": [
+                item.to_dict() for item in self.registered_external_or_package_sources
+            ],
             "unmatched_reference_lines": self.unmatched_reference_lines,
             "checks": [check.to_dict() for check in self.checks],
         }
@@ -195,40 +196,17 @@ def load_source_index(repo_root: Path, index_path: Path | None = None) -> list[d
     return sources if isinstance(sources, list) else []
 
 
-def load_package_source_index(proposal_path: Path) -> list[dict[str, Any]]:
-    """Load the formal package-local source registry when one is present.
-
-    Proposal format v2 keeps the human-readable proposal beside a package
-    ``sources.json``.  The advisory score should recognize those citations in
-    addition to the repository-wide lightweight index; otherwise a valid
-    formal package is reported as having no source coverage.
-    """
-    package_index_path = proposal_path.parent / "sources.json"
-    if not package_index_path.exists():
+def load_submission_source_index(proposal_path: Path) -> list[dict[str, Any]]:
+    """Load the proposal package's own source register when it is present."""
+    source_path = proposal_path.parent / "sources.json"
+    if not source_path.is_file():
         return []
     try:
-        index_data = json.loads(package_index_path.read_text(encoding="utf-8"))
+        source_data = json.loads(source_path.read_text(encoding="utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError):
         return []
-    raw_sources = index_data.get("sources") if isinstance(index_data, dict) else []
-    if not isinstance(raw_sources, list):
-        return []
-
-    sources: list[dict[str, Any]] = []
-    for source in raw_sources:
-        if not isinstance(source, dict):
-            continue
-        normalized = dict(source)
-        if not normalized.get("id") and normalized.get("registry_source_id"):
-            normalized["id"] = normalized["registry_source_id"]
-        if not normalized.get("citation"):
-            for key in ("url", "path", "title"):
-                value = normalized.get(key)
-                if isinstance(value, str) and value.strip():
-                    normalized["citation"] = value.strip()
-                    break
-        sources.append(normalized)
-    return sources
+    sources = source_data.get("sources") if isinstance(source_data, dict) else []
+    return sources if isinstance(sources, list) else []
 
 
 def reference_lines(reference_section: str) -> list[str]:
@@ -242,25 +220,163 @@ def reference_lines(reference_section: str) -> list[str]:
     return lines
 
 
+def string_values(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value.strip()] if value.strip() else []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return []
+
+
+def source_id_value(source: dict[str, Any]) -> str:
+    for field_name in ("id", "source_id"):
+        values = string_values(source.get(field_name))
+        if values:
+            return values[0]
+    return ""
+
+
+def source_candidates(source: dict[str, Any]) -> list[str]:
+    values: list[str] = []
+    for field_name in ("id", "source_id", "citation", "path", "url", "local_paths"):
+        for value in string_values(source.get(field_name)):
+            if value not in values:
+                values.append(value)
+    return values
+
+
+def source_use_values(source: dict[str, Any]) -> list[str]:
+    values: list[str] = []
+    for field_name in ("usage", "usage_note", "use_boundary", "usable_for", "allowed_uses"):
+        for value in string_values(source.get(field_name)):
+            if value not in values:
+                values.append(value)
+    return values
+
+
+def source_location_values(source: dict[str, Any]) -> tuple[list[str], list[str]]:
+    """Return safe local paths and HTTPS URLs declared by a package source."""
+    local_paths: list[str] = []
+    https_urls: list[str] = []
+    for field_name in ("path", "local_paths"):
+        for value in string_values(source.get(field_name)):
+            if value not in local_paths:
+                local_paths.append(value)
+    for value in string_values(source.get("url")):
+        if value.startswith("https://"):
+            if value not in https_urls:
+                https_urls.append(value)
+        elif value not in local_paths:
+            # Some packages use `url` for a repository-local snapshot path.
+            local_paths.append(value)
+    return local_paths, https_urls
+
+
+def valid_package_path(repo_root: Path, value: str) -> bool:
+    normalized = value.strip().replace("\\", "/")
+    pure_path = PurePosixPath(normalized)
+    candidate = repo_root / pure_path
+    return bool(
+        normalized
+        and "://" not in normalized
+        and not pure_path.is_absolute()
+        and ".." not in pure_path.parts
+        and candidate.exists()
+        and candidate.resolve().is_relative_to(repo_root)
+    )
+
+
+def package_source_is_eligible(repo_root: Path, source: Any) -> bool:
+    """Require identity, traceability, and an explicit positive use boundary."""
+    if not isinstance(source, dict):
+        return False
+    source_id = source_id_value(source)
+    if not source_id or not source_use_values(source):
+        return False
+
+    local_paths, https_urls = source_location_values(source)
+    if not https_urls and not any(valid_package_path(repo_root, path) for path in local_paths):
+        return False
+
+    source_kind = " ".join(
+        value
+        for field_name in ("source_type", "source_kind")
+        for value in string_values(source.get(field_name))
+    ).lower()
+    if any(marker in source_kind for marker in ("provisional", "inferred", "private", "internal")):
+        return False
+
+    for field_name in (
+        "review_status",
+        "usable_for_formal",
+        "formal_status",
+        "public_status",
+        "status",
+        "availability",
+        "public_access_status",
+    ):
+        for value in string_values(source.get(field_name)):
+            normalized = value.lower().replace("-", "_").replace(" ", "_")
+            if normalized in {
+                "no",
+                "disabled",
+                "rejected",
+                "needs_review",
+                "review_pending",
+                "background_only",
+                "provisional_only",
+                "restricted",
+                "private",
+                "unknown",
+            }:
+                return False
+    return True
+
+
+def match_registered_package_sources(
+    repo_root: Path,
+    proposal_path: Path,
+    reference_section: str,
+) -> tuple[list[SourceMatch], set[str]]:
+    """Match only eligible package registrations against the reference section."""
+    lines = reference_lines(reference_section)
+    reference_text = reference_section.replace("`", "")
+    matched: list[SourceMatch] = []
+    matched_tokens: set[str] = set()
+    for source in load_submission_source_index(proposal_path):
+        if not package_source_is_eligible(repo_root, source):
+            continue
+        candidates = source_candidates(source)
+        matching_tokens = {
+            candidate
+            for candidate in candidates
+            if candidate in reference_text
+        }
+        if not matching_tokens:
+            continue
+        source_id = source_id_value(source)
+        citation_values = string_values(source.get("citation"))
+        local_paths, https_urls = source_location_values(source)
+        fallback = (citation_values + local_paths + https_urls + candidates)[0]
+        matched.append(SourceMatch(source_id, citation_values[0] if citation_values else fallback))
+        matched_tokens.update(matching_tokens)
+    return matched, matched_tokens
+
+
 def match_sources(text: str, reference_section: str, sources: list[dict[str, Any]]) -> tuple[list[SourceMatch], list[str]]:
     haystack = f"{text}\n{reference_section}"
     matched: list[SourceMatch] = []
-    matched_ids: set[str] = set()
     matched_tokens: set[str] = set()
     for source in sources:
         if not isinstance(source, dict):
             continue
-        source_id = str(source.get("id") or "").strip()
-        registry_source_id = str(source.get("registry_source_id") or "").strip()
+        source_id = str(source.get("id", "")).strip()
         citation = str(source.get("citation", "")).strip()
         path = str(source.get("path", "")).strip()
         url = str(source.get("url", "")).strip()
-        candidates = [item for item in [source_id, registry_source_id, citation, path, url] if item]
+        candidates = [item for item in [source_id, citation, path, url] if item]
         if any(candidate in haystack for candidate in candidates):
-            match_id = source_id or registry_source_id or citation or path or url
-            if match_id not in matched_ids:
-                matched.append(SourceMatch(match_id, citation or path or url))
-                matched_ids.add(match_id)
+            matched.append(SourceMatch(source_id, citation or path or url))
             matched_tokens.update(candidates)
 
     unmatched = []
@@ -396,19 +512,27 @@ def score_proposal(
 
     reference_section = find_section(sections, REFERENCE_SECTION_ALIASES)
     sources = load_source_index(repo_root, sources_index_path)
-    sources.extend(load_package_source_index(proposal_path))
     matched_sources, unmatched_references = match_sources(text, reference_section, sources)
+    registered_package_sources, registered_tokens = match_registered_package_sources(
+        repo_root, proposal_path, reference_section
+    )
+    if registered_tokens:
+        unmatched_references = [
+            line
+            for line in unmatched_references
+            if not any(token and token in line.replace("`", "") for token in registered_tokens)
+        ]
     if not reference_section:
         source_status = STATUS_MISSING
         source_message = "缺少参考资料章节内容。"
-    elif matched_sources:
+    elif matched_sources or registered_package_sources:
         source_status = STATUS_PASS if not unmatched_references else STATUS_NEEDS_WORK
-        source_message = "已引用全局或方案包来源索引内资料。"
+        source_message = "已引用公开资料索引内资料或投稿包已登记来源。"
         if unmatched_references:
-            source_message += " 未匹配的资料需要说明来源和公开性。"
+            source_message += " 未登记的索引外资料需要说明来源和公开性。"
     else:
         source_status = STATUS_NEEDS_WORK
-        source_message = "未匹配到来源索引内资料；轻量方案建议引用 brief/public-brief.md，正式 v2 包建议提供可匹配的 sources.json。"
+        source_message = "未匹配到公开资料索引内资料；建议至少引用 brief/public-brief.md。"
     checks.append(build_check("公开资料引用", source_status, source_message))
 
     ordered_checks = sorted(checks, key=lambda item: DIMENSION_ORDER.index(item.dimension))
@@ -416,6 +540,7 @@ def score_proposal(
         proposal_path=display_path,
         checks=ordered_checks,
         matched_sources=matched_sources,
+        registered_external_or_package_sources=registered_package_sources,
         unmatched_reference_lines=unmatched_references,
         metadata_missing=missing_metadata,
         required_sections_missing=missing_sections,
@@ -434,15 +559,7 @@ def format_report(report: SelfCheckReport) -> str:
         f"{summary.get(STATUS_MANUAL_REVIEW, 0)} manual-review"
     )
     lines.append("")
-    lines.append(
-        "> This is advisory only: `pass` and a zero `--strict` exit code apply only to this "
-        "proposal-level check. They do not assess formal readiness."
-    )
-    lines.append(
-        "> Formal readiness: not assessed. Next run "
-        "`scripts/self_check_submission.py <submission-dir> --pr-author <github-login>` "
-        "for deterministic, spatial, visual, and professional evidence validation."
-    )
+    lines.append("> This self-check is advisory. It does not replace maintainer or expert review.")
 
     if report.metadata_missing:
         lines.extend(["", "Missing metadata:"])
@@ -456,8 +573,13 @@ def format_report(report: SelfCheckReport) -> str:
         lines.append(f"- [{check.status}] {check.dimension}: {' '.join(check.messages)}")
 
     if report.matched_sources:
-        lines.extend(["", "Matched indexed sources:"])
+        lines.extend(["", "Matched public sources:"])
         lines.extend(f"- {item.id}: {item.citation}" for item in report.matched_sources)
+    if report.registered_external_or_package_sources:
+        lines.extend(["", "Registered external or package sources:"])
+        lines.extend(
+            f"- {item.id}: {item.citation}" for item in report.registered_external_or_package_sources
+        )
     if report.unmatched_reference_lines:
         lines.extend(["", "References needing source/public-status notes:"])
         lines.extend(f"- {item}" for item in report.unmatched_reference_lines)
@@ -474,7 +596,7 @@ def main() -> int:
     parser.add_argument(
         "--strict",
         action="store_true",
-        help="Exit non-zero when an advisory self-check dimension is missing; formal readiness is not assessed.",
+        help="Exit non-zero when any self-check dimension is missing.",
     )
     args = parser.parse_args()
 

--- a/scripts/score_submission.py
+++ b/scripts/score_submission.py
@@ -56,6 +56,13 @@ AI_SECTION_ALIASES = ["AI 治理与创新场景", "AI 创新生态"]
 LANDING_SECTION_ALIASES = ["落地路径", "更新项目清单", "实施政策", "分期"]
 RISK_SECTION_ALIASES = ["风险与合规", "风险、版权", "风险"]
 REFERENCE_SECTION_ALIASES = ["参考资料"]
+SOURCE_REGISTER_SECTION_ALIASES = [
+    "完整来源",
+    "来源与证据",
+    "complete sources",
+    "evidence register",
+    "source register",
+]
 
 TASK_TERMS = ["百年京张", "京张", "海淀", "AI", "人工智能", "创新带", "中关村", "城市"]
 ORIGINALITY_TERMS = ["概念", "机制", "模式", "体系", "网络", "平台", "社区", "场景", "环"]
@@ -172,6 +179,17 @@ def find_section(sections: dict[str, str], aliases: list[str]) -> str:
         if any(alias in title for alias in aliases):
             return content
     return ""
+
+
+def reference_content(sections: dict[str, str]) -> str:
+    """Combine lightweight references with an explicit package source register."""
+    aliases = [*REFERENCE_SECTION_ALIASES, *SOURCE_REGISTER_SECTION_ALIASES]
+    contents = [
+        content
+        for title, content in sections.items()
+        if any(alias.lower() in title.lower() for alias in aliases)
+    ]
+    return "\n\n".join(contents)
 
 
 def status_from_term_count(count: int, pass_at: int = 3, needs_at: int = 1) -> str:
@@ -510,7 +528,7 @@ def score_proposal(
         completeness_message = "结构完整，正文长度达到基础自检阈值。"
     checks.append(build_check("表达完整度", completeness_status, completeness_message))
 
-    reference_section = find_section(sections, REFERENCE_SECTION_ALIASES)
+    reference_section = reference_content(sections)
     sources = load_source_index(repo_root, sources_index_path)
     matched_sources, unmatched_references = match_sources(text, reference_section, sources)
     registered_package_sources, registered_tokens = match_registered_package_sources(

--- a/tests/test_score_submission.py
+++ b/tests/test_score_submission.py
@@ -129,6 +129,22 @@ class ScoreSubmissionTests(unittest.TestCase):
             self.assertEqual(checks["公开资料引用"], STATUS_PASS)
             self.assertEqual({item.id for item in report.matched_sources}, {"brief-public-brief", "brief-public-boundary"})
 
+    def test_structured_evidence_anchor_is_not_public_source_unmatched(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write_source_index(root)
+            body = VALID_BODY + (
+                "\n- [standard:PROJECT-STANDARD]\n"
+                "- [depth:metrics_recalculation] [data:geometry/site_boundary.geojson#SITE-001] "
+                "[metric:site_area_sqm]\n"
+            )
+            proposal = self.write_proposal(root, body)
+
+            report = score_proposal(root, proposal)
+
+            self.assertEqual(self.check_map(report)["公开资料引用"], STATUS_PASS)
+            self.assertEqual(report.unmatched_reference_lines, [])
+
     def test_missing_required_section_is_reported(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -292,6 +308,59 @@ class ScoreSubmissionTests(unittest.TestCase):
                         "path": "brief/provisional-map.geojson",
                         "source_kind": "provisional_repository_data",
                         "usage": "Temporary design geometry only.",
+                    }
+                ],
+            )
+
+            report = score_proposal(root, proposal)
+            checks = self.check_map(report)
+
+            self.assertEqual(checks["公开资料引用"], STATUS_NEEDS_WORK)
+            self.assertEqual(report.registered_external_or_package_sources, [])
+
+    def test_inferred_boundary_source_type_remains_unresolved(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            body = VALID_BODY.replace(
+                "- `brief/public-brief.md`\n- `brief/README.md`",
+                "- [source:inferred-boundary]",
+            )
+            proposal = self.write_proposal(root, body)
+            self.write_package_sources(
+                root,
+                [
+                    {
+                        "id": "inferred-boundary",
+                        "path": "brief/inferred-boundary.geojson",
+                        "source_type": "agent_inferred_from_public_data",
+                        "usage": "Submitted site boundary geometry source (provisional); not an official redline.",
+                    }
+                ],
+            )
+
+            report = score_proposal(root, proposal)
+            checks = self.check_map(report)
+
+            self.assertEqual(checks["公开资料引用"], STATUS_NEEDS_WORK)
+            self.assertEqual(report.registered_external_or_package_sources, [])
+
+    def test_source_disabled_for_formal_use_remains_unresolved(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            body = VALID_BODY.replace(
+                "- `brief/public-brief.md`\n- `brief/README.md`",
+                "- [source:background-map]",
+            )
+            proposal = self.write_proposal(root, body)
+            self.write_package_sources(
+                root,
+                [
+                    {
+                        "id": "background-map",
+                        "url": "https://example.org/map",
+                        "source_type": "official_public",
+                        "usage": "Public context only.",
+                        "not_usable_for": ["formal review", "official boundary"],
                     }
                 ],
             )

--- a/tests/test_score_submission.py
+++ b/tests/test_score_submission.py
@@ -371,6 +371,39 @@ class ScoreSubmissionTests(unittest.TestCase):
             self.assertEqual(checks["公开资料引用"], STATUS_NEEDS_WORK)
             self.assertEqual(report.registered_external_or_package_sources, [])
 
+    def test_narrow_disabled_scope_does_not_disqualify_registered_source(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            body = VALID_BODY.replace(
+                "- `brief/public-brief.md`\n- `brief/README.md`",
+                "- [source:official-method]",
+            )
+            proposal = self.write_proposal(root, body)
+            self.write_package_sources(
+                root,
+                [
+                    {
+                        "id": "official-method",
+                        "url": "https://example.org/method",
+                        "source_type": "official_public",
+                        "usage": "Design principles and method reference only.",
+                        "not_usable_for": [
+                            "official redline",
+                            "statutory planning control",
+                            "engineering approval",
+                        ],
+                    }
+                ],
+            )
+
+            report = score_proposal(root, proposal)
+
+            self.assertEqual(self.check_map(report)["公开资料引用"], STATUS_PASS)
+            self.assertEqual(
+                [item.id for item in report.registered_external_or_package_sources],
+                ["official-method"],
+            )
+
     def test_weak_landing_path_needs_work(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_score_submission.py
+++ b/tests/test_score_submission.py
@@ -186,6 +186,40 @@ class ScoreSubmissionTests(unittest.TestCase):
             )
             self.assertEqual(report.unmatched_reference_lines, [])
 
+    def test_complete_source_register_is_scanned_with_references(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            body = VALID_BODY.replace(
+                "- `brief/public-brief.md`\n- `brief/README.md`",
+                "- [source:external-standard]",
+            )
+            body += "\n## 完整来源与证据登记\n\n- [source:external-standard]\n"
+            proposal = self.write_proposal(root, body)
+            self.write_package_sources(
+                root,
+                [
+                    {
+                        "id": "external-standard",
+                        "title": "Official public standard snapshot",
+                        "publisher": "Public standards body",
+                        "accessed_date": "2026-08-08",
+                        "url": "https://example.org/standard",
+                        "usable_for": ["Design principles only"],
+                        "not_usable_for": ["Project approval"],
+                    }
+                ],
+            )
+
+            report = score_proposal(root, proposal)
+            checks = self.check_map(report)
+
+            self.assertEqual(checks["公开资料引用"], STATUS_PASS)
+            self.assertEqual(
+                [item.id for item in report.registered_external_or_package_sources],
+                ["external-standard"],
+            )
+            self.assertEqual(report.unmatched_reference_lines, [])
+
     def test_package_source_schema_variants_are_normalized(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_score_submission.py
+++ b/tests/test_score_submission.py
@@ -429,7 +429,21 @@ class ScoreSubmissionTests(unittest.TestCase):
 
             self.assertIn("Proposal self-check", markdown)
             self.assertIn("advisory", markdown)
+            self.assertIn("Formal readiness: not assessed", markdown)
+            self.assertIn("scripts/self_check_submission.py", markdown)
             self.assertIn("Matched public sources", markdown)
+
+    def test_json_preserves_advisory_scope_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write_source_index(root)
+            proposal = self.write_proposal(root)
+
+            payload = score_proposal(root, proposal).to_dict()
+
+            self.assertEqual(payload["check_scope"], "advisory_proposal_only")
+            self.assertEqual(payload["formal_readiness"], "not_assessed")
+            self.assertEqual(payload["next_required_check"], "scripts/self_check_submission.py")
 
 
 if __name__ == "__main__":

--- a/tests/test_score_submission.py
+++ b/tests/test_score_submission.py
@@ -90,21 +90,24 @@ class ScoreSubmissionTests(unittest.TestCase):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(index, ensure_ascii=False), encoding="utf-8")
 
-    def write_package_source_index(self, proposal: Path) -> None:
-        index = {
-            "schema_version": "0.1.0",
-            "package_id": "ai-urban-loop",
-            "sources": [
-                {
-                    "id": "OFFICIAL-ANNOUNCEMENT",
-                    "registry_source_id": "DATA-SRC-OFFICIAL-ANNOUNCEMENT-20260509",
-                    "title": "公开征集公告",
-                    "url": "https://example.com/announcement",
-                }
-            ],
-        }
-        (proposal.parent / "sources.json").write_text(
-            json.dumps(index, ensure_ascii=False), encoding="utf-8"
+    def write_package_sources(self, root: Path, sources: list[dict]) -> None:
+        package_dir = root / "submissions" / "alice" / "ai-urban-loop"
+        package_dir.mkdir(parents=True, exist_ok=True)
+        for source in sources:
+            locations = []
+            for field_name in ("path", "local_paths"):
+                value = source.get(field_name)
+                if isinstance(value, str):
+                    locations.append(value)
+                elif isinstance(value, list):
+                    locations.extend(value)
+            for location in locations:
+                source_path = root / location
+                source_path.parent.mkdir(parents=True, exist_ok=True)
+                source_path.write_text("registered source", encoding="utf-8")
+        (package_dir / "sources.json").write_text(
+            json.dumps({"schema_version": "0.1.0", "sources": sources}, ensure_ascii=False),
+            encoding="utf-8",
         )
 
     def check_map(self, report):
@@ -152,25 +155,118 @@ class ScoreSubmissionTests(unittest.TestCase):
             self.assertEqual(checks["公开资料引用"], STATUS_NEEDS_WORK)
             self.assertEqual(report.matched_sources, [])
 
-    def test_formal_package_source_registry_is_used_for_v2_markers(self) -> None:
+    def test_registered_package_source_is_reported_separately(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             body = VALID_BODY.replace(
                 "- `brief/public-brief.md`\n- `brief/README.md`",
-                "- `[source:OFFICIAL-ANNOUNCEMENT]`\n- `[source:DATA-SRC-OFFICIAL-ANNOUNCEMENT-20260509]`",
+                "- [source:external-weather]",
             )
             proposal = self.write_proposal(root, body)
-            self.write_package_source_index(proposal)
+            self.write_package_sources(
+                root,
+                [
+                    {
+                        "id": "external-weather",
+                        "url": "https://example.org/weather",
+                        "source_type": "official_public",
+                        "usage": "Background context only; no site-specific values are claimed.",
+                    }
+                ],
+            )
+
+            report = score_proposal(root, proposal)
+            checks = self.check_map(report)
+
+            self.assertEqual(checks["公开资料引用"], STATUS_PASS)
+            self.assertEqual(report.matched_sources, [])
+            self.assertEqual(
+                [item.id for item in report.registered_external_or_package_sources],
+                ["external-weather"],
+            )
+            self.assertEqual(report.unmatched_reference_lines, [])
+
+    def test_package_source_schema_variants_are_normalized(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            body = VALID_BODY.replace(
+                "- `brief/public-brief.md`\n- `brief/README.md`",
+                "- [source:DATA-SRC-OFFICIAL-ANNOUNCEMENT-20260509]",
+            )
+            proposal = self.write_proposal(root, body)
+            self.write_package_sources(
+                root,
+                [
+                    {
+                        "source_id": "DATA-SRC-OFFICIAL-ANNOUNCEMENT-20260509",
+                        "url": "brief/site-package/standards/references/official.md",
+                        "local_paths": ["brief/site-package/standards/references/official.md"],
+                        "allowed_uses": ["project_name", "design_tasks"],
+                        "review_status": "approved",
+                        "usable_for_formal": "yes",
+                    }
+                ],
+            )
 
             report = score_proposal(root, proposal)
             checks = self.check_map(report)
 
             self.assertEqual(checks["公开资料引用"], STATUS_PASS)
             self.assertEqual(
-                [item.id for item in report.matched_sources],
-                ["OFFICIAL-ANNOUNCEMENT"],
+                [item.id for item in report.registered_external_or_package_sources],
+                ["DATA-SRC-OFFICIAL-ANNOUNCEMENT-20260509"],
             )
-            self.assertEqual(report.unmatched_reference_lines, [])
+
+    def test_package_source_without_use_boundary_is_not_upgraded(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            body = VALID_BODY.replace(
+                "- `brief/public-brief.md`\n- `brief/README.md`",
+                "- [source:external-weather]",
+            )
+            proposal = self.write_proposal(root, body)
+            self.write_package_sources(
+                root,
+                [
+                    {
+                        "id": "external-weather",
+                        "url": "https://example.org/weather",
+                        "source_type": "official_public",
+                    }
+                ],
+            )
+
+            report = score_proposal(root, proposal)
+            checks = self.check_map(report)
+
+            self.assertEqual(checks["公开资料引用"], STATUS_NEEDS_WORK)
+            self.assertEqual(report.registered_external_or_package_sources, [])
+
+    def test_provisional_package_source_remains_unresolved(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            body = VALID_BODY.replace(
+                "- `brief/public-brief.md`\n- `brief/README.md`",
+                "- [source:provisional-map]",
+            )
+            proposal = self.write_proposal(root, body)
+            self.write_package_sources(
+                root,
+                [
+                    {
+                        "id": "provisional-map",
+                        "path": "brief/provisional-map.geojson",
+                        "source_kind": "provisional_repository_data",
+                        "usage": "Temporary design geometry only.",
+                    }
+                ],
+            )
+
+            report = score_proposal(root, proposal)
+            checks = self.check_map(report)
+
+            self.assertEqual(checks["公开资料引用"], STATUS_NEEDS_WORK)
+            self.assertEqual(report.registered_external_or_package_sources, [])
 
     def test_weak_landing_path_needs_work(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -197,21 +293,7 @@ class ScoreSubmissionTests(unittest.TestCase):
 
             self.assertIn("Proposal self-check", markdown)
             self.assertIn("advisory", markdown)
-            self.assertIn("Formal readiness: not assessed", markdown)
-            self.assertIn("scripts/self_check_submission.py", markdown)
-            self.assertIn("Matched indexed sources", markdown)
-
-    def test_json_marks_formal_readiness_as_not_assessed(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            self.write_source_index(root)
-            proposal = self.write_proposal(root)
-
-            payload = score_proposal(root, proposal).to_dict()
-
-            self.assertEqual(payload["check_scope"], "advisory_proposal_only")
-            self.assertEqual(payload["formal_readiness"], "not_assessed")
-            self.assertEqual(payload["next_required_check"], "scripts/self_check_submission.py")
+            self.assertIn("Matched public sources", markdown)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Issue #485 exposed a false negative in scripts/score_submission.py: a submission package can register a source in sources.json, but the advisory scorer only understands the lightweight public index. Existing packages also use more than one registration schema.

## Fix

- recognize both id and source_id identities;
- recognize positive use boundaries in usage, usage_note, use_boundary, usable_for, and allowed_uses;
- recognize HTTPS URLs plus repository-local path/local_paths snapshots, including packages that store a local snapshot under url;
- require a retraceable location, reject traversal/symlink escapes, and reject provisional/private/inferred/internal or review-pending/background-only states;
- match package registrations from the complete 参考资料 section and report them separately as advisory evidence;
- keep unresolved references as needs-work and do not promote package registrations into the repository public index.

## Validation

- exact head `6d8fa02b` local targeted suite: 91 passed;
- real-package replay recognizes Hanyu 24, TryWorld 2, and 147228 9 eligible registrations while leaving unresolved references as needs-work;
- py_compile and git diff --check passed;
- remote run [31263217574](https://github.com/open-city-ai/haidian/actions/runs/31263217574) is PASS and classifies this as a non-submission code/docs/test PR after #574 merged.

Closes #485.