### PR TITLE
fix: keep participant preflight UTF-8 safe on Windows

### DIFF
--- a/scripts/participant_preflight.py
+++ b/scripts/participant_preflight.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -17,6 +18,9 @@ LARGE_PACKAGE_WARNING = 200 * 1024 * 1024
 
 
 def run(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    environment = os.environ.copy()
+    environment["PYTHONUTF8"] = "1"
+    environment["PYTHONIOENCODING"] = "utf-8"
     return subprocess.run(
         command,
         cwd=cwd,
@@ -24,6 +28,7 @@ def run(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
         text=True,
         encoding="utf-8",
         errors="replace",
+        env=environment,
         check=False,
     )
 

--- a/scripts/participant_preflight.py
+++ b/scripts/participant_preflight.py
@@ -17,7 +17,15 @@ LARGE_PACKAGE_WARNING = 200 * 1024 * 1024
 
 
 def run(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(command, cwd=cwd, capture_output=True, text=True, check=False)
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
 
 
 def git_output(repo_root: Path, *args: str, allow_failure: bool = False) -> str:

--- a/tests/test_participant_preflight.py
+++ b/tests/test_participant_preflight.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "participant_preflight.py"
+SPEC = importlib.util.spec_from_file_location("participant_preflight", SCRIPT)
+assert SPEC and SPEC.loader
+participant_preflight = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(participant_preflight)
+
+
+class ParticipantPreflightEncodingTests(unittest.TestCase):
+    def test_run_decodes_utf8_non_ascii_subprocess_output(self) -> None:
+        completed = participant_preflight.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.stdout.buffer.write('海淀/路径\\n'.encode('utf-8'))",
+            ],
+            REPO_ROOT,
+        )
+
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual(completed.stdout, "海淀/路径\n")
+
+    def test_run_forces_utf8_and_replaces_invalid_bytes(self) -> None:
+        expected = subprocess.CompletedProcess(
+            ["git", "status"],
+            0,
+            stdout="海淀规划\n",
+            stderr="",
+        )
+        with patch.object(participant_preflight.subprocess, "run", return_value=expected) as mocked:
+            completed = participant_preflight.run(["git", "status"], REPO_ROOT)
+
+        mocked.assert_called_once_with(
+            ["git", "status"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+        self.assertEqual(completed.stdout, "海淀规划\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_participant_preflight.py
+++ b/tests/test_participant_preflight.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import subprocess
 import sys
 import unittest
@@ -30,7 +31,29 @@ class ParticipantPreflightEncodingTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 0)
         self.assertEqual(completed.stdout, "海淀/路径\n")
 
-    def test_run_forces_utf8_and_replaces_invalid_bytes(self) -> None:
+    def test_run_forces_python_child_tree_to_utf8_under_legacy_locale(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"PYTHONUTF8": "0", "PYTHONIOENCODING": "cp936"},
+        ):
+            completed = participant_preflight.run(
+                [sys.executable, "-c", "print('海淀路径')"],
+                REPO_ROOT,
+            )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(completed.stdout, "海淀路径\n")
+
+    def test_run_replaces_invalid_subprocess_bytes(self) -> None:
+        completed = participant_preflight.run(
+            [sys.executable, "-c", "import sys; sys.stdout.buffer.write(b'\\xff')"],
+            REPO_ROOT,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(completed.stdout, "\ufffd")
+
+    def test_run_passes_explicit_utf8_contract(self) -> None:
         expected = subprocess.CompletedProcess(
             ["git", "status"],
             0,
@@ -40,15 +63,17 @@ class ParticipantPreflightEncodingTests(unittest.TestCase):
         with patch.object(participant_preflight.subprocess, "run", return_value=expected) as mocked:
             completed = participant_preflight.run(["git", "status"], REPO_ROOT)
 
-        mocked.assert_called_once_with(
-            ["git", "status"],
-            cwd=REPO_ROOT,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            check=False,
-        )
+        mocked.assert_called_once()
+        args, kwargs = mocked.call_args
+        self.assertEqual((["git", "status"],), args)
+        self.assertEqual(REPO_ROOT, kwargs["cwd"])
+        self.assertTrue(kwargs["capture_output"])
+        self.assertTrue(kwargs["text"])
+        self.assertEqual("utf-8", kwargs["encoding"])
+        self.assertEqual("replace", kwargs["errors"])
+        self.assertFalse(kwargs["check"])
+        self.assertEqual("1", kwargs["env"]["PYTHONUTF8"])
+        self.assertEqual("utf-8", kwargs["env"]["PYTHONIOENCODING"])
         self.assertEqual(completed.stdout, "海淀规划\n")
 
 


### PR DESCRIPTION
## Summary

Closes #420.

- decode participant preflight subprocess output explicitly as UTF-8 with replacement for malformed bytes
- force PYTHONUTF8=1 and PYTHONIOENCODING=utf-8 through the child environment so self-check Python subprocess trees emit the same encoding
- add regressions for UTF-8 Chinese output, simulated legacy cp936 settings, malformed bytes, and subprocess argument contracts

This is the maintainer integration of #570 with an additional fix for the Python-child encoding mismatch found during independent review.

## Verification

- participant preflight encoding tests: 4 passed
- lightweight participant flow: 5 passed
- py_compile passed
- git diff --check passed