### PR TITLE
fix: keep protected gallery data behind maintainer gate

### DIFF
--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -21,7 +21,13 @@ import urllib.request
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-from validate_submission import ValidationReport, format_report, validate_submission
+from validate_submission import (
+    PARTICIPANT_PROTECTED_GLOBAL_FILES,
+    PROTECTED_REVIEW_ARTIFACT_PREFIXES,
+    ValidationReport,
+    format_report,
+    validate_submission,
+)
 
 
 COMMENT_MARKER = "<!-- haidian-submission-validation -->"
@@ -274,7 +280,11 @@ def is_review_queue_candidate(changed_files: list[str], pr_author: str) -> bool:
 
 
 def is_non_submission_pr(files: list[dict] | list[str]) -> bool:
-    """Return true only when current and renamed paths are outside submissions/."""
+    """Return true only for ordinary non-submission paths.
+
+    Maintainer-controlled gallery data and local review artifacts must still
+    enter the strict validator even though they live outside submissions/.
+    """
     paths: list[str] = []
     for item in files:
         if isinstance(item, dict):
@@ -286,7 +296,12 @@ def is_non_submission_pr(files: list[dict] | list[str]) -> bool:
                 paths.append(previous_filename)
         elif isinstance(item, str):
             paths.append(item)
-    return bool(paths) and all(filename.split("/", 1)[0] != "submissions" for filename in paths)
+    return bool(paths) and all(
+        filename.split("/", 1)[0] != "submissions"
+        and filename not in PARTICIPANT_PROTECTED_GLOBAL_FILES
+        and not filename.startswith(PROTECTED_REVIEW_ARTIFACT_PREFIXES)
+        for filename in paths
+    )
 
 
 def safe_manifest_paths(manifest: object) -> set[str]:

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -315,6 +315,41 @@ class ManifestHydrationTests(unittest.TestCase):
                 discover_submission_files(submission, root),
             )
 
+    def test_maintainer_controlled_paths_are_not_treated_as_code_only(self) -> None:
+        protected_paths = [
+            "submissions-data.js",
+            "gallery-publication.json",
+            "submissions/README.md",
+            ".maintainer-review/alice/review-summary.json",
+            "docs/reviews/alice.md",
+        ]
+        for path in protected_paths:
+            with self.subTest(path=path):
+                self.assertFalse(is_non_submission_pr([path]))
+
+        self.assertFalse(
+            is_non_submission_pr(
+                [
+                    {
+                        "filename": "scripts/generated-gallery.js",
+                        "previous_filename": "submissions-data.js",
+                        "status": "renamed",
+                    }
+                ]
+            )
+        )
+        self.assertFalse(
+            is_non_submission_pr(
+                [
+                    {
+                        "filename": "submissions-data.js",
+                        "previous_filename": "scripts/generated-gallery.js",
+                        "status": "renamed",
+                    }
+                ]
+            )
+        )
+
 
 class ProposalSchemaTests(unittest.TestCase):
     def test_english_contract_accepts_english_section_headings(self) -> None:


### PR DESCRIPTION
## Problem

The code-only shortcut added for ordinary scripts, tests, and docs currently treats every path outside submissions/ as non-submission code. That includes maintainer-controlled submissions-data.js and gallery-publication.json, plus local review artifacts. PR #615 demonstrated the regression by receiving a PASS even though participants are explicitly prohibited from editing the generated gallery index.

## Fix

- keep ordinary scripts, tests, and docs on the code-only validation path;
- route submissions-data.js and gallery-publication.json back through strict validation;
- route .maintainer-review/ and docs/reviews/ artifacts back through strict validation;
- inspect both current and previous paths for renames so protected files cannot be moved around the gate;
- preserve maintainer bypass behavior inside validate_submission.

## Validation

- tests/test_submission_workflow.py: 78 passed;
- tests/test_lightweight_participant_flow.py: 5 passed;
- py_compile and git diff --check passed;
- exact head af2ed4b6.

This is intentionally separate from the actual gallery refresh. Maintainers can still regenerate and commit the index through their trusted path.