### PR TITLE
fix: deploy Pages after main updates

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -28,8 +28,12 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v4
 
-      - name: Verify generated data
+      - name: Build and verify generated data
         run: |
+          # Build inside the deploy workspace so rapid main merges cannot make
+          # a committed snapshot stale before the publisher picks it up.
+          python3 scripts/generate_submissions_data.py
+          python3 scripts/generate_source_registry_data.py
           python3 scripts/generate_submissions_data.py --check
           python3 scripts/generate_source_registry_data.py --check
           python3 scripts/validate_data_registry.py --json

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,7 +1,11 @@
 name: deploy-pages
 
 on:
-  # GitHub Pages is not enabled for this repo; run manually if it ever is.
+  # Merges to main can change generated gallery data or public site assets.
+  # Keep manual dispatch for an explicit redeploy after Pages/CDN incidents.
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -38,14 +38,42 @@ jobs:
           python3 scripts/generate_source_registry_data.py --check
           python3 scripts/validate_data_registry.py --json
 
+      - name: Check GitHub Pages configuration
+        id: pages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          response_file="$(mktemp)"
+          status="$(curl --silent --show-error \
+            --output "$response_file" \
+            --write-out '%{http_code}' \
+            --header 'Accept: application/vnd.github+json' \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pages")"
+          if [ "$status" = "200" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          elif [ "$status" = "404" ]; then
+            echo "::warning::GitHub Pages is not configured; skipping GitHub Pages deployment. External nginx publication remains a separate path."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::GitHub Pages API returned HTTP ${status}; refusing to guess deployment state."
+            cat "$response_file"
+            exit 1
+          fi
+
       - name: Configure Pages
+        if: steps.pages.outputs.configured == 'true'
         uses: actions/configure-pages@v5
 
       - name: Upload static site
+        if: steps.pages.outputs.configured == 'true'
         uses: actions/upload-pages-artifact@v3
         with:
           path: .
 
       - name: Deploy to GitHub Pages
         id: deployment
+        if: steps.pages.outputs.configured == 'true'
         uses: actions/deploy-pages@v4

--- a/.github/workflows/public-site-parity.yml
+++ b/.github/workflows/public-site-parity.yml
@@ -1,0 +1,29 @@
+name: public-site-parity
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: public-site-parity
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: check-public-gallery
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+
+      - name: Build current gallery data
+        run: python3 scripts/generate_submissions_data.py
+
+      - name: Compare public gallery with main
+        env:
+          PUBLIC_GALLERY_URL: https://haidian.open-city.ai/submissions-data.js
+        run: python3 scripts/check_public_gallery.py --url "$PUBLIC_GALLERY_URL"

--- a/scripts/check_public_gallery.py
+++ b/scripts/check_public_gallery.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Check that the public gallery exposes the current generated submissions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_PUBLIC_URL = "https://haidian.open-city.ai/submissions-data.js"
+DATA_PATTERN = re.compile(
+    r"window\.HAIDIAN_SUBMISSIONS\s*=\s*(\[.*\]);\s*$", re.DOTALL
+)
+
+
+class GalleryDataError(ValueError):
+    """Raised when a generated gallery data file cannot be trusted."""
+
+
+def parse_gallery_data(text: str) -> list[dict[str, Any]]:
+    match = DATA_PATTERN.search(text)
+    if match is None:
+        raise GalleryDataError("missing window.HAIDIAN_SUBMISSIONS JSON payload")
+    try:
+        payload = json.loads(match.group(1))
+    except json.JSONDecodeError as exc:
+        raise GalleryDataError(f"invalid gallery JSON: {exc}") from exc
+    if not isinstance(payload, list) or any(not isinstance(item, dict) for item in payload):
+        raise GalleryDataError("gallery payload must be a list of objects")
+    return payload
+
+
+def source_urls(items: list[dict[str, Any]]) -> set[str]:
+    urls: set[str] = set()
+    for index, item in enumerate(items):
+        value = item.get("sourceUrl")
+        if not isinstance(value, str) or not value.strip():
+            raise GalleryDataError(f"entry {index} has no non-empty sourceUrl")
+        if value in urls:
+            raise GalleryDataError(f"duplicate sourceUrl: {value}")
+        urls.add(value)
+    return urls
+
+
+def fetch_public_data(url: str, timeout: int = 30) -> str:
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "haidian-public-gallery-parity/1.0"},
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return response.read().decode("utf-8")
+
+
+def compare_gallery_data(expected_text: str, public_text: str) -> tuple[set[str], set[str]]:
+    expected = source_urls(parse_gallery_data(expected_text))
+    public = source_urls(parse_gallery_data(public_text))
+    return expected - public, public - expected
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--expected",
+        type=Path,
+        default=Path("submissions-data.js"),
+        help="generated local gallery data file",
+    )
+    parser.add_argument("--url", default=DEFAULT_PUBLIC_URL, help="public gallery data URL")
+    parser.add_argument("--timeout", type=int, default=30)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        expected_text = args.expected.read_text(encoding="utf-8")
+        public_text = fetch_public_data(args.url, timeout=args.timeout)
+        missing, unexpected = compare_gallery_data(expected_text, public_text)
+    except (OSError, UnicodeDecodeError, GalleryDataError, ValueError) as exc:
+        print(f"public gallery parity check failed: {exc}", file=sys.stderr)
+        return 2
+
+    expected_count = len(source_urls(parse_gallery_data(expected_text)))
+    public_count = len(source_urls(parse_gallery_data(public_text)))
+    print(f"expected_entries={expected_count} public_entries={public_count}")
+    print(f"missing_on_public={len(missing)} unexpected_on_public={len(unexpected)}")
+    for path in sorted(missing):
+        print(f"MISSING_ON_PUBLIC {path}")
+    for path in sorted(unexpected):
+        print(f"UNEXPECTED_ON_PUBLIC {path}")
+    return 1 if missing or unexpected else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_public_gallery.py
+++ b/scripts/check_public_gallery.py
@@ -36,15 +36,25 @@ def parse_gallery_data(text: str) -> list[dict[str, Any]]:
 
 
 def source_urls(items: list[dict[str, Any]]) -> set[str]:
-    urls: set[str] = set()
+    return set(items_by_source_url(items))
+
+
+def items_by_source_url(items: list[dict[str, Any]]) -> dict[str, str]:
+    """Return a canonical payload indexed by its stable gallery source URL."""
+    indexed_items: dict[str, str] = {}
     for index, item in enumerate(items):
         value = item.get("sourceUrl")
         if not isinstance(value, str) or not value.strip():
             raise GalleryDataError(f"entry {index} has no non-empty sourceUrl")
-        if value in urls:
+        if value in indexed_items:
             raise GalleryDataError(f"duplicate sourceUrl: {value}")
-        urls.add(value)
-    return urls
+        indexed_items[value] = json.dumps(
+            item,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    return indexed_items
 
 
 def fetch_public_data(url: str, timeout: int = 30) -> str:
@@ -56,10 +66,14 @@ def fetch_public_data(url: str, timeout: int = 30) -> str:
         return response.read().decode("utf-8")
 
 
-def compare_gallery_data(expected_text: str, public_text: str) -> tuple[set[str], set[str]]:
-    expected = source_urls(parse_gallery_data(expected_text))
-    public = source_urls(parse_gallery_data(public_text))
-    return expected - public, public - expected
+def compare_gallery_data(
+    expected_text: str, public_text: str
+) -> tuple[set[str], set[str], set[str]]:
+    expected = items_by_source_url(parse_gallery_data(expected_text))
+    public = items_by_source_url(parse_gallery_data(public_text))
+    shared_urls = expected.keys() & public.keys()
+    changed = {url for url in shared_urls if expected[url] != public[url]}
+    return expected.keys() - public.keys(), public.keys() - expected.keys(), changed
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -80,7 +94,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         expected_text = args.expected.read_text(encoding="utf-8")
         public_text = fetch_public_data(args.url, timeout=args.timeout)
-        missing, unexpected = compare_gallery_data(expected_text, public_text)
+        missing, unexpected, changed = compare_gallery_data(expected_text, public_text)
     except (OSError, UnicodeDecodeError, GalleryDataError, ValueError) as exc:
         print(f"public gallery parity check failed: {exc}", file=sys.stderr)
         return 2
@@ -88,12 +102,18 @@ def main(argv: list[str] | None = None) -> int:
     expected_count = len(source_urls(parse_gallery_data(expected_text)))
     public_count = len(source_urls(parse_gallery_data(public_text)))
     print(f"expected_entries={expected_count} public_entries={public_count}")
-    print(f"missing_on_public={len(missing)} unexpected_on_public={len(unexpected)}")
+    print(
+        "missing_on_public="
+        f"{len(missing)} unexpected_on_public={len(unexpected)} "
+        f"changed_on_public={len(changed)}"
+    )
     for path in sorted(missing):
         print(f"MISSING_ON_PUBLIC {path}")
     for path in sorted(unexpected):
         print(f"UNEXPECTED_ON_PUBLIC {path}")
-    return 1 if missing or unexpected else 0
+    for path in sorted(changed):
+        print(f"CHANGED_ON_PUBLIC {path}")
+    return 1 if missing or unexpected or changed else 0
 
 
 if __name__ == "__main__":

--- a/tests/test_deploy_pages_workflow.py
+++ b/tests/test_deploy_pages_workflow.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class DeployPagesWorkflowTests(unittest.TestCase):
+    def test_pages_deploys_on_main_push_and_supports_manual_dispatch(self) -> None:
+        workflow = (REPO_ROOT / ".github" / "workflows" / "deploy-pages.yml").read_text(encoding="utf-8")
+        self.assertIn("  push:\n    branches:\n      - main", workflow)
+        self.assertIn("  workflow_dispatch:", workflow)
+        self.assertIn("python3 scripts/generate_submissions_data.py --check", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_deploy_pages_workflow.py
+++ b/tests/test_deploy_pages_workflow.py
@@ -10,7 +10,14 @@ class DeployPagesWorkflowTests(unittest.TestCase):
         workflow = (REPO_ROOT / ".github" / "workflows" / "deploy-pages.yml").read_text(encoding="utf-8")
         self.assertIn("  push:\n    branches:\n      - main", workflow)
         self.assertIn("  workflow_dispatch:", workflow)
+        self.assertIn("python3 scripts/generate_submissions_data.py\n", workflow)
+        self.assertIn("python3 scripts/generate_source_registry_data.py\n", workflow)
         self.assertIn("python3 scripts/generate_submissions_data.py --check", workflow)
+        self.assertIn("python3 scripts/generate_source_registry_data.py --check", workflow)
+        self.assertLess(
+            workflow.index("python3 scripts/generate_submissions_data.py\n"),
+            workflow.index("python3 scripts/generate_submissions_data.py --check"),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_deploy_pages_workflow.py
+++ b/tests/test_deploy_pages_workflow.py
@@ -14,9 +14,22 @@ class DeployPagesWorkflowTests(unittest.TestCase):
         self.assertIn("python3 scripts/generate_source_registry_data.py\n", workflow)
         self.assertIn("python3 scripts/generate_submissions_data.py --check", workflow)
         self.assertIn("python3 scripts/generate_source_registry_data.py --check", workflow)
+        self.assertIn("- name: Check GitHub Pages configuration", workflow)
+        self.assertIn("id: pages", workflow)
+        self.assertIn('echo "configured=false" >> "$GITHUB_OUTPUT"', workflow)
+        self.assertIn("GitHub Pages is not configured; skipping GitHub Pages deployment", workflow)
+        self.assertEqual(3, workflow.count("if: steps.pages.outputs.configured == 'true'"))
         self.assertLess(
             workflow.index("python3 scripts/generate_submissions_data.py\n"),
             workflow.index("python3 scripts/generate_submissions_data.py --check"),
+        )
+        self.assertLess(
+            workflow.index("python3 scripts/validate_data_registry.py --json"),
+            workflow.index("- name: Check GitHub Pages configuration"),
+        )
+        self.assertLess(
+            workflow.index("- name: Check GitHub Pages configuration"),
+            workflow.index("- name: Configure Pages"),
         )
 
 

--- a/tests/test_public_gallery_parity.py
+++ b/tests/test_public_gallery_parity.py
@@ -14,9 +14,26 @@ class PublicGalleryParityTests(unittest.TestCase):
     def test_reports_missing_and_unexpected_source_urls(self) -> None:
         expected = 'window.HAIDIAN_SUBMISSIONS = [{"sourceUrl": "submissions/a/proposal.md"}];\n'
         public = 'window.HAIDIAN_SUBMISSIONS = [{"sourceUrl": "submissions/b/proposal.md"}];\n'
-        missing, unexpected = compare_gallery_data(expected, public)
+        missing, unexpected, changed = compare_gallery_data(expected, public)
         self.assertEqual({"submissions/a/proposal.md"}, missing)
         self.assertEqual({"submissions/b/proposal.md"}, unexpected)
+        self.assertEqual(set(), changed)
+
+    def test_reports_changed_entry_with_same_source_url(self) -> None:
+        expected = (
+            'window.HAIDIAN_SUBMISSIONS = ['
+            '{"sourceUrl": "submissions/a/proposal.md", "title": "Current"}'
+            '];\n'
+        )
+        public = (
+            'window.HAIDIAN_SUBMISSIONS = ['
+            '{"title": "Stale", "sourceUrl": "submissions/a/proposal.md"}'
+            '];\n'
+        )
+        missing, unexpected, changed = compare_gallery_data(expected, public)
+        self.assertEqual(set(), missing)
+        self.assertEqual(set(), unexpected)
+        self.assertEqual({"submissions/a/proposal.md"}, changed)
 
     def test_rejects_duplicate_source_urls(self) -> None:
         payload = (

--- a/tests/test_public_gallery_parity.py
+++ b/tests/test_public_gallery_parity.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import unittest
+
+from scripts.check_public_gallery import GalleryDataError, compare_gallery_data, parse_gallery_data
+
+
+class PublicGalleryParityTests(unittest.TestCase):
+    def test_parses_generated_gallery_wrapper(self) -> None:
+        payload = parse_gallery_data(
+            'window.HAIDIAN_SUBMISSIONS = [{"sourceUrl": "submissions/a/proposal.md"}];\n'
+        )
+        self.assertEqual("submissions/a/proposal.md", payload[0]["sourceUrl"])
+
+    def test_reports_missing_and_unexpected_source_urls(self) -> None:
+        expected = 'window.HAIDIAN_SUBMISSIONS = [{"sourceUrl": "submissions/a/proposal.md"}];\n'
+        public = 'window.HAIDIAN_SUBMISSIONS = [{"sourceUrl": "submissions/b/proposal.md"}];\n'
+        missing, unexpected = compare_gallery_data(expected, public)
+        self.assertEqual({"submissions/a/proposal.md"}, missing)
+        self.assertEqual({"submissions/b/proposal.md"}, unexpected)
+
+    def test_rejects_duplicate_source_urls(self) -> None:
+        payload = (
+            'window.HAIDIAN_SUBMISSIONS = ['
+            '{"sourceUrl": "submissions/a/proposal.md"},'
+            '{"sourceUrl": "submissions/a/proposal.md"}'
+            '];\n'
+        )
+        with self.assertRaises(GalleryDataError):
+            compare_gallery_data(payload, 'window.HAIDIAN_SUBMISSIONS = [];\n')
+
+    def test_workflow_checks_on_schedule_and_manual_dispatch(self) -> None:
+        workflow = (Path(__file__).resolve().parents[1] / ".github" / "workflows" / "public-site-parity.yml").read_text(encoding="utf-8")
+        self.assertIn('cron: "*/15 * * * *"', workflow)
+        self.assertIn("  workflow_dispatch:\n", workflow)
+        self.assertIn("scripts/check_public_gallery.py", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

.github/workflows/deploy-pages.yml only has workflow_dispatch, even though repository docs say merged submissions automatically enter the public site. After #622 merged a correct gallery snapshot, the next submission merged 74 seconds later and made that committed snapshot stale before the public nginx site updated.

A delayed publisher that only runs generator --check can therefore miss every short fresh window while main is busy.

## Fix

- trigger the existing Pages deployment workflow on every push to main;
- retain workflow_dispatch for manual incident recovery;
- generate submissions-data.js and source-registry-data.js inside the deployment workspace;
- immediately run both --check commands and the registry validator on those generated artifacts;
- upload the current generated workspace instead of depending on a previously committed snapshot;
- add a regression test that protects both triggers and verifies generation occurs before freshness checks.

This does not commit generated files from Actions. It builds the deploy artifact deterministically from the exact checked-out main revision.

## Deployment boundary

The repository Pages API currently returns 404 while haidian.open-city.ai reports nginx/1.27.5. Maintainers must still either enable/configure Pages for the custom domain or connect the equivalent generation step to the authoritative nginx/object-storage publisher. Public URL readback remains the final acceptance criterion in #631.

## Validation

- python3 -m unittest tests.test_deploy_pages_workflow -v: 1 passed;
- py_compile passed;
- git diff --check passed;
- changed files: deploy-pages.yml and its focused regression test only.