### PR TITLE
fix: skip stale validation events

### DIFF
--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -244,6 +244,21 @@ def next_link(link_header: str) -> str | None:
     return None
 
 
+def is_current_pull_request_head(
+    client: GitHubClient, issue_number: int, expected_sha: str
+) -> bool:
+    """Return whether the event SHA is still the PR's current head."""
+    payload, _ = client.request(
+        "GET", f"/repos/{client.repository}/pulls/{issue_number}"
+    )
+    if not isinstance(payload, dict):
+        raise RuntimeError("GitHub pull request response was not an object")
+    head = payload.get("head")
+    if not isinstance(head, dict) or not isinstance(head.get("sha"), str):
+        raise RuntimeError("GitHub pull request response did not include head.sha")
+    return head["sha"] == expected_sha
+
+
 def proposal_paths_for(changed_files: list[str]) -> set[str]:
     proposals = set()
     for filename in changed_files:
@@ -368,6 +383,13 @@ def main() -> int:
     head_sha = pull_request["head"]["sha"]
     client = GitHubClient(token, repository)
 
+    if not is_current_pull_request_head(client, pr_number, head_sha):
+        print(
+            f"Skipping stale validation event for PR #{pr_number}: "
+            f"event head {head_sha} no longer matches the current PR head."
+        )
+        return 0
+
     files = client.paginate(f"/repos/{repository}/pulls/{pr_number}/files?per_page=100")
     changed_files = [item["filename"] for item in files]
     bypass = [
@@ -420,6 +442,13 @@ def main() -> int:
         else:
             validation = validate_submission(worktree, pr_author, validation_files, bypass)
         validation_markdown = format_report(validation)
+
+        if not is_current_pull_request_head(client, pr_number, head_sha):
+            print(
+                f"Skipping stale validation side effects for PR #{pr_number}: "
+                f"event head {head_sha} no longer matches the current PR head."
+            )
+            return 0
 
         comment = (
             f"{COMMENT_MARKER}\n"

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -244,19 +244,33 @@ def next_link(link_header: str) -> str | None:
     return None
 
 
-def is_current_pull_request_head(
+def stale_pull_request_event_reason(
     client: GitHubClient, issue_number: int, expected_sha: str
-) -> bool:
-    """Return whether the event SHA is still the PR's current head."""
-    payload, _ = client.request(
-        "GET", f"/repos/{client.repository}/pulls/{issue_number}"
-    )
+) -> str | None:
+    """Return why a queued PR event must not validate its no-longer-live head."""
+    try:
+        payload, _ = client.request(
+            "GET", f"/repos/{client.repository}/pulls/{issue_number}"
+        )
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return f"PR #{issue_number} no longer exists"
+        raise
     if not isinstance(payload, dict):
         raise RuntimeError("GitHub pull request response was not an object")
+    if payload.get("state") != "open":
+        return f"PR #{issue_number} is no longer open"
+    if payload.get("draft") is True:
+        return f"PR #{issue_number} is now a draft"
     head = payload.get("head")
     if not isinstance(head, dict) or not isinstance(head.get("sha"), str):
         raise RuntimeError("GitHub pull request response did not include head.sha")
-    return head["sha"] == expected_sha
+    if head["sha"] != expected_sha:
+        return (
+            f"PR #{issue_number} head advanced from {expected_sha[:12]} "
+            f"to {head['sha'][:12]}"
+        )
+    return None
 
 
 def proposal_paths_for(changed_files: list[str]) -> set[str]:
@@ -379,17 +393,15 @@ def main() -> int:
 
     pr_number = int(pull_request["number"])
     pr_author = pull_request["user"]["login"]
-    head_repo = pull_request["head"]["repo"]["full_name"]
     head_sha = pull_request["head"]["sha"]
     client = GitHubClient(token, repository)
 
-    if not is_current_pull_request_head(client, pr_number, head_sha):
-        print(
-            f"Skipping stale validation event for PR #{pr_number}: "
-            f"event head {head_sha} no longer matches the current PR head."
-        )
+    stale_reason = stale_pull_request_event_reason(client, pr_number, head_sha)
+    if stale_reason:
+        print(f"Skipping stale validation event: {stale_reason}")
         return 0
 
+    head_repo = pull_request["head"]["repo"]["full_name"]
     files = client.paginate(f"/repos/{repository}/pulls/{pr_number}/files?per_page=100")
     changed_files = [item["filename"] for item in files]
     bypass = [
@@ -443,11 +455,9 @@ def main() -> int:
             validation = validate_submission(worktree, pr_author, validation_files, bypass)
         validation_markdown = format_report(validation)
 
-        if not is_current_pull_request_head(client, pr_number, head_sha):
-            print(
-                f"Skipping stale validation side effects for PR #{pr_number}: "
-                f"event head {head_sha} no longer matches the current PR head."
-            )
+        stale_reason = stale_pull_request_event_reason(client, pr_number, head_sha)
+        if stale_reason:
+            print(f"Skipping stale validation side effects: {stale_reason}")
             return 0
 
         comment = (

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -30,11 +30,11 @@ from github_pr_validation import (  # noqa: E402
     GitHubClient,
     MAX_DOWNLOAD_BYTES,
     _is_retryable_http_error,
-    is_current_pull_request_head,
     is_non_submission_pr,
     is_review_queue_candidate,
     main,
     safe_manifest_paths,
+    stale_pull_request_event_reason,
     validation_paths_for,
 )
 from validate_local_submission import discover_submission_files  # noqa: E402
@@ -157,10 +157,13 @@ class PullRequestHeadGuardTests(unittest.TestCase):
         with patch.object(
             client,
             "request",
-            return_value=({"head": {"sha": "current-sha"}}, {}),
+            return_value=({"state": "open", "draft": False, "head": {"sha": "current-sha"}}, {}),
         ) as request:
-            self.assertTrue(is_current_pull_request_head(client, 627, "current-sha"))
-            self.assertFalse(is_current_pull_request_head(client, 627, "stale-sha"))
+            self.assertIsNone(stale_pull_request_event_reason(client, 627, "current-sha"))
+            self.assertIn(
+                "head advanced",
+                stale_pull_request_event_reason(client, 627, "stale-sha") or "",
+            )
         self.assertEqual(2, request.call_count)
         request.assert_called_with(
             "GET", "/repos/open-city-ai/haidian/pulls/627"
@@ -182,7 +185,10 @@ class PullRequestHeadGuardTests(unittest.TestCase):
             event_file.flush()
             client = unittest.mock.MagicMock()
             client.repository = "open-city-ai/haidian"
-            client.request.return_value = ({"head": {"sha": "current-sha"}}, {})
+            client.request.return_value = (
+                {"state": "open", "draft": False, "head": {"sha": "current-sha"}},
+                {},
+            )
             with patch.dict(
                 os.environ,
                 {
@@ -216,8 +222,8 @@ class PullRequestHeadGuardTests(unittest.TestCase):
             client = unittest.mock.MagicMock()
             client.repository = "open-city-ai/haidian"
             client.request.side_effect = [
-                ({"head": {"sha": "event-sha"}}, {}),
-                ({"head": {"sha": "newer-sha"}}, {}),
+                ({"state": "open", "draft": False, "head": {"sha": "event-sha"}}, {}),
+                ({"state": "open", "draft": False, "head": {"sha": "newer-sha"}}, {}),
             ]
             client.paginate.return_value = [{"filename": "docs/example.md"}]
             with patch.dict(
@@ -233,6 +239,47 @@ class PullRequestHeadGuardTests(unittest.TestCase):
         client.upsert_comment.assert_not_called()
         client.add_labels.assert_not_called()
         client.remove_labels.assert_not_called()
+
+    def test_missing_pr_is_a_safe_stale_event(self) -> None:
+        client = MagicMock()
+        client.request.side_effect = urllib.error.HTTPError(
+            "https://api.github.com/test", 404, "Not Found", {}, io.BytesIO(b"{}")
+        )
+        self.assertEqual(
+            "PR #627 no longer exists",
+            stale_pull_request_event_reason(client, 627, "event-sha"),
+        )
+
+    def test_stale_event_skips_before_accessing_deleted_fork(self) -> None:
+        event = {
+            "pull_request": {
+                "number": 627,
+                "user": {"login": "147228"},
+                "head": {"repo": None, "sha": "stale-sha"},
+            }
+        }
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
+            json.dump(event, event_file)
+            event_file.flush()
+            client = MagicMock()
+            client.repository = "open-city-ai/haidian"
+            client.request.return_value = (
+                {"state": "open", "draft": False, "head": {"sha": "current-sha"}},
+                {},
+            )
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "token",
+                    "GITHUB_REPOSITORY": "open-city-ai/haidian",
+                    "GITHUB_EVENT_PATH": event_file.name,
+                },
+                clear=False,
+            ), patch("github_pr_validation.GitHubClient", return_value=client):
+                self.assertEqual(0, main())
+        client.paginate.assert_not_called()
+        client.download_content.assert_not_called()
+        client.upsert_comment.assert_not_called()
 
 
 class EmptyPdfDetectionTests(unittest.TestCase):
@@ -329,7 +376,10 @@ class ManifestHydrationTests(unittest.TestCase):
             event_file.flush()
             client = MagicMock()
             client.repository = "open-city-ai/haidian"
-            client.request.return_value = ({"head": {"sha": "head-sha"}}, {})
+            client.request.return_value = (
+                {"state": "open", "draft": False, "head": {"sha": "head-sha"}},
+                {},
+            )
             client.paginate.return_value = files
             with patch.dict(
                 os.environ,

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -30,6 +30,7 @@ from github_pr_validation import (  # noqa: E402
     GitHubClient,
     MAX_DOWNLOAD_BYTES,
     _is_retryable_http_error,
+    is_current_pull_request_head,
     is_non_submission_pr,
     is_review_queue_candidate,
     main,
@@ -148,6 +149,90 @@ class GitHubApiResilienceTests(unittest.TestCase):
                     "head-sha",
                     Path(temp_dir) / "asset.bin",
                 )
+
+
+class PullRequestHeadGuardTests(unittest.TestCase):
+    def test_head_guard_compares_event_sha_with_current_pr(self) -> None:
+        client = GitHubClient("token", "open-city-ai/haidian")
+        with patch.object(
+            client,
+            "request",
+            return_value=({"head": {"sha": "current-sha"}}, {}),
+        ) as request:
+            self.assertTrue(is_current_pull_request_head(client, 627, "current-sha"))
+            self.assertFalse(is_current_pull_request_head(client, 627, "stale-sha"))
+        self.assertEqual(2, request.call_count)
+        request.assert_called_with(
+            "GET", "/repos/open-city-ai/haidian/pulls/627"
+        )
+
+    def test_stale_event_skips_file_listing_and_side_effects(self) -> None:
+        event = {
+            "pull_request": {
+                "number": 627,
+                "user": {"login": "147228"},
+                "head": {
+                    "repo": {"full_name": "147228/haidian"},
+                    "sha": "stale-sha",
+                },
+            }
+        }
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
+            json.dump(event, event_file)
+            event_file.flush()
+            client = unittest.mock.MagicMock()
+            client.repository = "open-city-ai/haidian"
+            client.request.return_value = ({"head": {"sha": "current-sha"}}, {})
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "token",
+                    "GITHUB_REPOSITORY": "open-city-ai/haidian",
+                    "GITHUB_EVENT_PATH": event_file.name,
+                },
+                clear=False,
+            ), patch("github_pr_validation.GitHubClient", return_value=client):
+                self.assertEqual(0, main())
+        client.paginate.assert_not_called()
+        client.download_content.assert_not_called()
+        client.upsert_comment.assert_not_called()
+        client.add_labels.assert_not_called()
+        client.remove_labels.assert_not_called()
+
+    def test_head_change_during_validation_skips_side_effects(self) -> None:
+        event = {
+            "pull_request": {
+                "number": 627,
+                "user": {"login": "147228"},
+                "head": {
+                    "repo": {"full_name": "147228/haidian"},
+                    "sha": "event-sha",
+                },
+            }
+        }
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
+            json.dump(event, event_file)
+            event_file.flush()
+            client = unittest.mock.MagicMock()
+            client.repository = "open-city-ai/haidian"
+            client.request.side_effect = [
+                ({"head": {"sha": "event-sha"}}, {}),
+                ({"head": {"sha": "newer-sha"}}, {}),
+            ]
+            client.paginate.return_value = [{"filename": "docs/example.md"}]
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "token",
+                    "GITHUB_REPOSITORY": "open-city-ai/haidian",
+                    "GITHUB_EVENT_PATH": event_file.name,
+                },
+                clear=False,
+            ), patch("github_pr_validation.GitHubClient", return_value=client):
+                self.assertEqual(0, main())
+        client.upsert_comment.assert_not_called()
+        client.add_labels.assert_not_called()
+        client.remove_labels.assert_not_called()
 
 
 class EmptyPdfDetectionTests(unittest.TestCase):

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -328,6 +328,8 @@ class ManifestHydrationTests(unittest.TestCase):
             json.dump(event, event_file)
             event_file.flush()
             client = MagicMock()
+            client.repository = "open-city-ai/haidian"
+            client.request.return_value = ({"head": {"sha": "head-sha"}}, {})
             client.paginate.return_value = files
             with patch.dict(
                 os.environ,


### PR DESCRIPTION
## Summary

- Read the live PR metadata before enumerating or downloading files, then re-check it before writing comments or labels.
- Treat an event as a successful no-op if its PR was deleted, closed, converted to draft, or advanced to another head SHA.
- Delay access to `head.repo` until after that guard, so a deleted fork with `head.repo = null` cannot crash validation.

## Why

`pull_request_target` events can wait behind the shared validation lock. A rapid force-push or rename can make an older event's SHA unreachable by the Contents API; retrying that permanent 404 consumes the serialized slot and can overwrite feedback for a newer head.

The live metadata request is trusted and cheap. It only suppresses obsolete events; current open, non-draft heads follow the existing validation and review-label flow unchanged.

## Verification

- Rebased onto current `main` before this update.
- `PYTHONPATH=scripts python3 -m unittest tests.test_submission_workflow -v` — 90 passed.
- `python3 -m py_compile scripts/github_pr_validation.py`.
- `git diff --check`.

Regression coverage includes a head change before file listing, a head change during validation, a closed or missing PR, and a deleted fork with `head.repo = null`.
