### PR TITLE
fix: cancel superseded validation heads without parallel API hydration

### DIFF
--- a/.github/workflows/submission-validation.yml
+++ b/.github/workflows/submission-validation.yml
@@ -9,19 +9,57 @@ permissions:
   pull-requests: write
   issues: write
 
-# Every validation run calls the GitHub API to enumerate and hydrate the PR.
-# Serializing those calls avoids secondary-rate-limit 403s when several
-# submissions arrive together.
+# Keep only the newest event for each PR. The global API lock below still
+# serializes hydration, but a synchronize event no longer leaves older heads
+# occupying that queue or publishing obsolete state.
 concurrency:
-  group: submission-validation
-  cancel-in-progress: false
-  queue: max
+  group: submission-validation-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
-  submission-validation:
-    name: submission-validation
+  head_guard:
+    name: reject stale validation events before API hydration
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    outputs:
+      current: ${{ steps.check-head.outputs.current }}
+    steps:
+      - name: Compare event head with the live pull request head
+        id: check-head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          pr_number="$(jq -r '.pull_request.number' "${GITHUB_EVENT_PATH}")"
+          event_head="$(jq -r '.pull_request | .head | .sha' "${GITHUB_EVENT_PATH}")"
+          read -r state draft current_head < <(
+            gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" \
+              --jq '[.state, (.draft | tostring), .head.sha] | @tsv'
+          )
+          if [[ "${state}" == "open" && "${draft}" == "false" && "${current_head}" == "${event_head}" ]]; then
+            echo "current=true" >> "${GITHUB_OUTPUT}"
+            echo "Current PR head is ${current_head}; validation may enter the serialized hydration queue."
+          else
+            echo "current=false" >> "${GITHUB_OUTPUT}"
+            echo "Skipping stale, closed, or draft validation event for PR #${pr_number}."
+          fi
+
+  submission-validation:
+    name: submission-validation
+    needs: head_guard
+    runs-on: ubuntu-latest
+    if: needs.head_guard.outputs.current == 'true'
+    timeout-minutes: 15
+    # Every validation calls the GitHub API to enumerate and hydrate the PR.
+    # Keep those calls serialized across PRs to avoid secondary-rate-limit
+    # 403s, while retaining one pending slot per PR at the workflow level.
+    # The API lock must keep all distinct PRs eligible; per-PR cancellation
+    # above already removes superseded heads before they reach this queue.
+    concurrency:
+      group: submission-validation-api
+      cancel-in-progress: false
+      queue: max
     steps:
       - name: Checkout current trusted default branch
         uses: actions/checkout@v4

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -259,6 +259,8 @@ def is_current_pull_request_head(
     )
     if not isinstance(payload, dict):
         raise RuntimeError("GitHub pull request response was not an object")
+    if payload.get("state") != "open" or payload.get("draft") is True:
+        return False
     head = payload.get("head")
     if not isinstance(head, dict) or not isinstance(head.get("sha"), str):
         raise RuntimeError("GitHub pull request response did not include head.sha")

--- a/tests/test_submission_validation_concurrency.py
+++ b/tests/test_submission_validation_concurrency.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "submission-validation.yml"
+
+
+class SubmissionValidationConcurrencyTests(unittest.TestCase):
+    def test_superseded_heads_cancel_without_parallelizing_api_hydration(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        workflow_scope, jobs_scope = workflow.split("\njobs:\n", 1)
+
+        self.assertIn(
+            "group: submission-validation-pr-${{ github.event.pull_request.number }}",
+            workflow_scope,
+        )
+        self.assertIn("cancel-in-progress: true", workflow_scope)
+        self.assertNotIn("queue: max", workflow_scope)
+
+        self.assertIn("head_guard:", jobs_scope)
+        self.assertIn("reject stale validation events before API hydration", jobs_scope)
+        self.assertIn("needs: head_guard", jobs_scope)
+        self.assertIn("if: needs.head_guard.outputs.current == 'true'", jobs_scope)
+        self.assertIn("GITHUB_EVENT_PATH", jobs_scope)
+        self.assertIn("gh api \"repos/${GITHUB_REPOSITORY}/pulls/${pr_number}\"", jobs_scope)
+
+        self.assertIn("group: submission-validation-api", jobs_scope)
+        self.assertIn("timeout-minutes: 15", jobs_scope)
+        self.assertIn("cancel-in-progress: false", jobs_scope)
+        self.assertIn("queue: max", jobs_scope)
+        self.assertNotIn("queue: single", jobs_scope)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -160,7 +160,10 @@ class PullRequestHeadGuardTests(unittest.TestCase):
         with patch.object(
             client,
             "request",
-            return_value=({"head": {"sha": "current-sha"}}, {}),
+            return_value=(
+                {"state": "open", "draft": False, "head": {"sha": "current-sha"}},
+                {},
+            ),
         ) as request:
             self.assertTrue(is_current_pull_request_head(client, 627, "current-sha"))
             self.assertFalse(is_current_pull_request_head(client, 627, "stale-sha"))
@@ -185,7 +188,10 @@ class PullRequestHeadGuardTests(unittest.TestCase):
             event_file.flush()
             client = MagicMock()
             client.repository = "open-city-ai/haidian"
-            client.request.return_value = ({"head": {"sha": "current-sha"}}, {})
+            client.request.return_value = (
+                {"state": "open", "draft": False, "head": {"sha": "current-sha"}},
+                {},
+            )
             with patch.dict(
                 os.environ,
                 {
@@ -219,8 +225,14 @@ class PullRequestHeadGuardTests(unittest.TestCase):
             client = MagicMock()
             client.repository = "open-city-ai/haidian"
             client.request.side_effect = [
-                ({"head": {"sha": "event-sha"}}, {}),
-                ({"head": {"sha": "newer-sha"}}, {}),
+                (
+                    {"state": "open", "draft": False, "head": {"sha": "event-sha"}},
+                    {},
+                ),
+                (
+                    {"state": "open", "draft": False, "head": {"sha": "newer-sha"}},
+                    {},
+                ),
             ]
             client.paginate.return_value = [{"filename": "docs/example.md"}]
             with patch.dict(
@@ -255,9 +267,18 @@ class PullRequestHeadGuardTests(unittest.TestCase):
             client = MagicMock()
             client.repository = "open-city-ai/haidian"
             client.request.side_effect = [
-                ({"head": {"sha": "event-sha"}}, {}),
-                ({"head": {"sha": "event-sha"}}, {}),
-                ({"head": {"sha": "newer-sha"}}, {}),
+                (
+                    {"state": "open", "draft": False, "head": {"sha": "event-sha"}},
+                    {},
+                ),
+                (
+                    {"state": "open", "draft": False, "head": {"sha": "event-sha"}},
+                    {},
+                ),
+                (
+                    {"state": "open", "draft": False, "head": {"sha": "newer-sha"}},
+                    {},
+                ),
             ]
             client.paginate.return_value = [{"filename": "docs/example.md"}]
             with patch.dict(
@@ -441,7 +462,10 @@ class ManifestHydrationTests(unittest.TestCase):
             event_file.flush()
             client = MagicMock()
             client.repository = "open-city-ai/haidian"
-            client.request.return_value = ({"head": {"sha": "head-sha"}}, {})
+            client.request.return_value = (
+                {"state": "open", "draft": False, "head": {"sha": "head-sha"}},
+                {},
+            )
             client.paginate.return_value = files
             with patch.dict(
                 os.environ,
@@ -469,12 +493,16 @@ class ManifestHydrationTests(unittest.TestCase):
             {"filename": "scripts/tool.py", "status": "modified"},
             {"filename": "tests/test_tool.py", "status": "modified"},
         ]
+
         with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
             json.dump(event, event_file)
             event_file.flush()
             client = MagicMock()
             client.repository = "open-city-ai/haidian"
-            client.request.return_value = ({"head": {"sha": "head-sha"}}, {})
+            client.request.return_value = (
+                {"state": "open", "draft": False, "head": {"sha": "head-sha"}},
+                {},
+            )
             client.paginate.return_value = files
             with patch.dict(
                 os.environ,
@@ -490,6 +518,62 @@ class ManifestHydrationTests(unittest.TestCase):
         client.fetch_content.assert_not_called()
         comment = client.upsert_comment.call_args.args[1]
         self.assertIn("non-submission code/docs/test PR", comment)
+
+    def test_closed_pr_short_circuits_before_hydration_or_side_effects(self) -> None:
+        event = {
+            "pull_request": {
+                "number": 736,
+                "user": {"login": "alice"},
+                "head": {"repo": {"full_name": "alice/haidian"}, "sha": "closed-head"},
+            }
+        }
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
+            json.dump(event, event_file)
+            event_file.flush()
+            client = MagicMock()
+            client.request.return_value = ({"state": "closed", "draft": False}, {})
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "token",
+                    "GITHUB_REPOSITORY": "open-city-ai/haidian",
+                    "GITHUB_EVENT_PATH": event_file.name,
+                },
+                clear=False,
+            ), patch("github_pr_validation.GitHubClient", return_value=client):
+                self.assertEqual(0, main())
+        client.paginate.assert_not_called()
+        client.download_content.assert_not_called()
+        client.upsert_comment.assert_not_called()
+        client.add_labels.assert_not_called()
+        client.remove_labels.assert_not_called()
+
+    def test_current_draft_pr_short_circuits_before_hydration_or_side_effects(self) -> None:
+        event = {
+            "pull_request": {
+                "number": 736,
+                "user": {"login": "alice"},
+                "head": {"repo": {"full_name": "alice/haidian"}, "sha": "draft-head"},
+            }
+        }
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
+            json.dump(event, event_file)
+            event_file.flush()
+            client = MagicMock()
+            client.request.return_value = ({"state": "open", "draft": True}, {})
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "token",
+                    "GITHUB_REPOSITORY": "open-city-ai/haidian",
+                    "GITHUB_EVENT_PATH": event_file.name,
+                },
+                clear=False,
+            ), patch("github_pr_validation.GitHubClient", return_value=client):
+                self.assertEqual(0, main())
+        client.paginate.assert_not_called()
+        client.download_content.assert_not_called()
+        client.upsert_comment.assert_not_called()
 
     def test_review_queue_candidate_is_one_author_owned_submission(self) -> None:
         self.assertTrue(


### PR DESCRIPTION
## Summary

- Cancel superseded validation workflows per PR using a PR-number concurrency group.
- Retain a separate global job-level API hydration lock, so different PRs serialize GitHub API enumeration and downloads.
- Keep up to 100 pending cross-PR jobs in FIFO order with `queue: max`; this is deliberate so a burst of distinct valid PRs is not silently discarded.

## Why

A rapid synchronize burst previously produced many historical `pull_request_target` runs. They could occupy shared API capacity long after a PR head had changed, contributing to installation-level GitHub API 403 failures.

The workflow-level group drops obsolete heads for the same PR. The job-level group protects the installation quota across distinct PRs, while `queue: max` gives each still-current PR a bounded chance to run once capacity returns. This complements the stale-event guard in #648.

## Verification

- Rebased onto `main@2c6ae754438c26e95cd0d8c3e1ea1e24eb4563e5`.
- `python3 -m unittest -v tests.test_submission_validation_concurrency tests.test_submission_workflow` — 92 passed.
- `python3 -m py_compile scripts/github_pr_validation.py`.
- `git diff --check`.

The head is `9c6df7402290b99b3b873e23ceab377efe24fe91`. Its remote check failed at `GET /pulls/665/files` because the GitHub App installation quota was already exhausted; as this is a `pull_request_target` workflow, that run executes the default-branch validator and cannot exercise this PR’s new concurrency configuration before merge.