### PR TITLE
fix: retry transient content download 404s

### DIFF
--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -27,6 +27,7 @@ from validate_submission import ValidationReport, format_report, validate_submis
 COMMENT_MARKER = "<!-- haidian-submission-validation -->"
 API_ROOT = "https://api.github.com"
 MAX_API_ATTEMPTS = 4
+MAX_CONTENT_NOT_FOUND_ATTEMPTS = 3
 MAX_RETRY_DELAY_SECONDS = 30
 RETRYABLE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
@@ -79,6 +80,18 @@ def _retry_delay_seconds(error: urllib.error.HTTPError, attempt: int) -> float:
         except ValueError:
             pass
     return min(MAX_RETRY_DELAY_SECONDS, float(2**attempt))
+
+
+class DownloadNotFoundError(RuntimeError):
+    def __init__(self, repo: str, path: str, ref: str, attempts: int, message: str) -> None:
+        self.repo = repo
+        self.path = path
+        self.ref = ref
+        self.attempts = attempts
+        super().__init__(
+            f"GitHub API download {repo}/{path} at ref {ref} returned HTTP 404 "
+            f"after {attempts} attempts: {message}"
+        )
 
 
 class GitHubClient:
@@ -161,7 +174,16 @@ class GitHubClient:
             except urllib.error.HTTPError as error:
                 message = _http_error_message(error)
                 if error.code == 404:
-                    raise
+                    if attempt + 1 >= MAX_CONTENT_NOT_FOUND_ATTEMPTS:
+                        raise DownloadNotFoundError(
+                            repo,
+                            path,
+                            ref,
+                            attempt + 1,
+                            message,
+                        ) from error
+                    time.sleep(_retry_delay_seconds(error, attempt))
+                    continue
                 if attempt + 1 >= MAX_API_ATTEMPTS or not _is_retryable_http_error(
                     "GET", error, message
                 ):
@@ -326,6 +348,8 @@ def hydrate_proposal_package(
                 head_sha,
                 destination,
             )
+        except DownloadNotFoundError:
+            pass
         except urllib.error.HTTPError as exc:
             if exc.code != 404:
                 raise

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -7,7 +7,7 @@ import hashlib
 import io
 import urllib.error
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import jsonschema
 
@@ -25,6 +25,7 @@ from validate_submission import (  # noqa: E402
     validate_submission,
 )
 from github_pr_validation import (  # noqa: E402
+    DownloadNotFoundError,
     GitHubClient,
     _is_retryable_http_error,
     is_non_submission_pr,
@@ -114,6 +115,60 @@ class GitHubApiResilienceTests(unittest.TestCase):
                 client.request("POST", "/test", {"body": "comment"})
         self.assertEqual(1, urlopen.call_count)
         sleep.assert_not_called()
+
+    def test_request_404_remains_non_retryable_for_optional_content(self) -> None:
+        error = self._error(404, b'{"message":"Not Found"}')
+        client = GitHubClient("token", "open-city-ai/haidian")
+        with patch(
+            "github_pr_validation.urllib.request.urlopen",
+            side_effect=[error, _Response(b'{"ok":true}')],
+        ) as urlopen, patch("github_pr_validation.time.sleep") as sleep:
+            with self.assertRaises(urllib.error.HTTPError):
+                client.request("GET", "/test")
+        self.assertEqual(1, urlopen.call_count)
+        sleep.assert_not_called()
+
+    def test_download_retries_transient_404_then_succeeds(self) -> None:
+        error = self._error(404, b'{"message":"Not Found"}')
+        client = GitHubClient("token", "open-city-ai/haidian")
+        with tempfile.TemporaryDirectory() as tmp:
+            destination = Path(tmp) / "proposal.md"
+            with patch(
+                "github_pr_validation.urllib.request.urlopen",
+                side_effect=[error, _Response(b"proposal")],
+            ) as urlopen, patch("github_pr_validation.time.sleep") as sleep:
+                client.download_content(
+                    "alice/haidian",
+                    "submissions/alice/design/proposal.md",
+                    "head-sha",
+                    destination,
+                )
+            self.assertEqual(2, urlopen.call_count)
+            sleep.assert_called_once_with(1.0)
+            self.assertEqual(b"proposal", destination.read_bytes())
+
+    def test_download_404_retries_are_bounded_and_include_context(self) -> None:
+        errors = [self._error(404, b'{"message":"Not Found"}') for _ in range(3)]
+        client = GitHubClient("token", "open-city-ai/haidian")
+        with tempfile.TemporaryDirectory() as tmp:
+            destination = Path(tmp) / "missing.md"
+            with patch(
+                "github_pr_validation.urllib.request.urlopen",
+                side_effect=errors,
+            ) as urlopen, patch("github_pr_validation.time.sleep") as sleep:
+                with self.assertRaisesRegex(
+                    DownloadNotFoundError,
+                    r"alice/haidian/submissions/alice/design/missing\.md.*head-sha.*3 attempts",
+                ):
+                    client.download_content(
+                        "alice/haidian",
+                        "submissions/alice/design/missing.md",
+                        "head-sha",
+                        destination,
+                    )
+            self.assertEqual(3, urlopen.call_count)
+            self.assertEqual([call(1.0), call(2.0)], sleep.call_args_list)
+            self.assertFalse(destination.exists())
 
 
 class EmptyPdfDetectionTests(unittest.TestCase):


### PR DESCRIPTION
## Problem
Issue #658 documents fork PR validation runs that fail while downloading a changed file from the Contents API with HTTP 404, even though the PR files API and local checks are valid. The existing retry policy covers transient GET 403 and 5xx responses, but content downloads immediately re-raised 404.

## Change
- Retry only the raw file download path on HTTP 404, with a bounded three-attempt window and the existing exponential backoff.
- Keep the general API request 404 behavior unchanged so optional manifest probing still treats a missing file as absent.
- Raise a context-rich DownloadNotFoundError after the bounded window, including repository, path, ref, and attempt count.
- Preserve the existing optional manifest-asset behavior by ignoring the new typed error during package hydration.

## Verification
- python3 -m unittest tests.test_submission_workflow -v — 80 passed.
- Added tests for transient 404 recovery, bounded permanent 404 failure, contextual error text, and unchanged request-level 404 semantics.
- py_compile and git diff --check passed.

Closes #658.