### PR TITLE
fix: allow participant package deletions

### DIFF
--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -251,6 +251,23 @@ def validation_paths_for(files: list[dict], maintainer_bypass: bool) -> list[str
     ]
 
 
+def deletion_only_report(changed_files: list[str], maintainer_bypass: bool) -> ValidationReport:
+    """Report a deletion-only PR without trying to validate absent files."""
+    validation = ValidationReport(
+        changed_files=changed_files,
+        maintainer_bypass=maintainer_bypass,
+    )
+    if maintainer_bypass:
+        validation.add_warning(
+            "maintainer-authorized deletion-only PR; removed files were not executed or content-validated"
+        )
+    else:
+        validation.add_warning(
+            "participant deletion-only PR; removed files were not executed or content-validated"
+        )
+    return validation
+
+
 def is_review_queue_candidate(changed_files: list[str], pr_author: str) -> bool:
     """Return true only for a single participant-owned submission directory."""
     roots: set[str] = set()
@@ -393,14 +410,8 @@ def main() -> int:
             validation.add_warning(
                 "non-submission code/docs/test PR; participant package validation was not applicable"
             )
-        elif not validation_files and maintainer_bypass:
-            validation = ValidationReport(
-                changed_files=changed_files,
-                maintainer_bypass=True,
-            )
-            validation.add_warning(
-                "maintainer-authorized deletion-only PR; removed files were not executed or content-validated"
-            )
+        elif not validation_files:
+            validation = deletion_only_report(changed_files, maintainer_bypass)
         else:
             validation = validate_submission(worktree, pr_author, validation_files, bypass)
         validation_markdown = format_report(validation)

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -410,7 +410,7 @@ def main() -> int:
             validation.add_warning(
                 "non-submission code/docs/test PR; participant package validation was not applicable"
             )
-        elif not validation_files:
+        elif not validation_files and (maintainer_bypass or queue_candidate):
             validation = deletion_only_report(changed_files, maintainer_bypass)
         else:
             validation = validate_submission(worktree, pr_author, validation_files, bypass)

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -243,11 +243,11 @@ def proposal_paths_for(changed_files: list[str]) -> set[str]:
 
 
 def validation_paths_for(files: list[dict], maintainer_bypass: bool) -> list[str]:
-    """Exclude maintainer-authorized removals from content validation."""
+    """Exclude removed paths from content validation for every author."""
     return [
         item["filename"]
         for item in files
-        if not (maintainer_bypass and item.get("status") == "removed")
+        if item.get("status") != "removed"
     ]
 
 

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -2,13 +2,14 @@ import sys
 import tempfile
 import unittest
 import json
+import os
 import subprocess
 import hashlib
 import io
 import re
 import urllib.error
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import jsonschema
 
@@ -31,6 +32,7 @@ from github_pr_validation import (  # noqa: E402
     _is_retryable_http_error,
     is_non_submission_pr,
     is_review_queue_candidate,
+    main,
     safe_manifest_paths,
     validation_paths_for,
 )
@@ -189,6 +191,36 @@ class ManifestHydrationTests(unittest.TestCase):
         )
         self.assertTrue(report.ok)
         self.assertIn("maintainer-authorized deletion-only PR", report.warnings[0])
+
+    def test_participant_cannot_delete_another_author_package_as_warning_only(self) -> None:
+        event = {
+            "pull_request": {
+                "number": 668,
+                "user": {"login": "alice"},
+                "head": {"repo": {"full_name": "alice/haidian"}, "sha": "head-sha"},
+            }
+        }
+        files = [
+            {"filename": "submissions/bob/design/obsolete.png", "status": "removed"}
+        ]
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
+            json.dump(event, event_file)
+            event_file.flush()
+            client = MagicMock()
+            client.paginate.return_value = files
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "token",
+                    "GITHUB_REPOSITORY": "open-city-ai/haidian",
+                    "GITHUB_EVENT_PATH": event_file.name,
+                },
+                clear=False,
+            ), patch("github_pr_validation.GitHubClient", return_value=client):
+                self.assertEqual(1, main())
+        comment = client.upsert_comment.call_args.args[1]
+        self.assertIn("Result: FAIL", comment)
+        client.add_labels.assert_not_called()
 
     def test_review_queue_candidate_is_one_author_owned_submission(self) -> None:
         self.assertTrue(

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -168,12 +168,9 @@ class ManifestHydrationTests(unittest.TestCase):
         ]
         self.assertEqual(["docs/note.md"], validation_paths_for(files, True))
 
-    def test_participant_removals_remain_in_validation_scope(self) -> None:
+    def test_participant_removals_are_not_revalidated_as_missing_files(self) -> None:
         files = [{"filename": "submissions/alice/design/proposal.md", "status": "removed"}]
-        self.assertEqual(
-            ["submissions/alice/design/proposal.md"],
-            validation_paths_for(files, False),
-        )
+        self.assertEqual([], validation_paths_for(files, False))
 
     def test_review_queue_candidate_is_one_author_owned_submission(self) -> None:
         self.assertTrue(

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -26,6 +26,7 @@ from validate_submission import (  # noqa: E402
     validate_submission,
 )
 from github_pr_validation import (  # noqa: E402
+    deletion_only_report,
     GitHubClient,
     _is_retryable_http_error,
     is_non_submission_pr,
@@ -171,6 +172,23 @@ class ManifestHydrationTests(unittest.TestCase):
     def test_participant_removals_are_not_revalidated_as_missing_files(self) -> None:
         files = [{"filename": "submissions/alice/design/proposal.md", "status": "removed"}]
         self.assertEqual([], validation_paths_for(files, False))
+
+    def test_participant_deletion_only_pr_is_warning_only(self) -> None:
+        report = deletion_only_report(
+            ["submissions/alice/design/obsolete.png"],
+            False,
+        )
+        self.assertTrue(report.ok)
+        self.assertFalse(report.errors)
+        self.assertIn("participant deletion-only PR", report.warnings[0])
+
+    def test_maintainer_deletion_only_pr_keeps_maintainer_warning(self) -> None:
+        report = deletion_only_report(
+            ["submissions/alice/design/obsolete.png"],
+            True,
+        )
+        self.assertTrue(report.ok)
+        self.assertIn("maintainer-authorized deletion-only PR", report.warnings[0])
 
     def test_review_queue_candidate_is_one_author_owned_submission(self) -> None:
         self.assertTrue(


### PR DESCRIPTION
## Problem
Issue #647 identifies a deterministic gap: removed files are skipped during download for every author, but participant removals remain in validation_paths_for. A participant deleting a file from their own package therefore gets a guaranteed missing-file validation failure.

## Change
- Exclude status=removed paths from content validation for all authors.
- Keep the full changed-file list for author-scope and queue-candidate checks, so deleting outside the participant package remains rejected.
- Keep the maintainer deletion-only warning path unchanged.

## Verification
- python3 -m unittest tests.test_submission_workflow -v — 80 passed.
- py_compile and git diff --check passed.

Closes #647.