### PR TITLE
fix: handle removed files and transient Contents 404s

### DIFF
--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -30,7 +30,10 @@ MAX_API_ATTEMPTS = 4
 MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024
 MAX_RETRY_DELAY_SECONDS = 30
 RETRYABLE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
-RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+# A fork's Contents API can briefly lag the PR event's head commit. Keep 404
+# retries bounded and limited to GETs; a permanent missing file still fails
+# with the path and head-specific download error after the retry budget.
+RETRYABLE_STATUS_CODES = frozenset({404, 429, 500, 502, 503, 504})
 
 
 def _http_error_message(error: urllib.error.HTTPError) -> str:
@@ -80,6 +83,15 @@ def _retry_delay_seconds(error: urllib.error.HTTPError, attempt: int) -> float:
         except ValueError:
             pass
     return min(MAX_RETRY_DELAY_SECONDS, float(2**attempt))
+
+
+def _is_download_not_found(error: Exception, path: str) -> bool:
+    """Recognize an optional manifest asset that is still absent after retries."""
+    if isinstance(error, urllib.error.HTTPError):
+        return error.code == 404
+    return isinstance(error, RuntimeError) and str(error).startswith(
+        f"GitHub API download {path} failed with HTTP 404:"
+    )
 
 
 class GitHubClient:
@@ -161,8 +173,6 @@ class GitHubClient:
                     break
             except urllib.error.HTTPError as error:
                 message = _http_error_message(error)
-                if error.code == 404:
-                    raise
                 if attempt + 1 >= MAX_API_ATTEMPTS or not _is_retryable_http_error(
                     "GET", error, message
                 ):
@@ -244,11 +254,11 @@ def proposal_paths_for(changed_files: list[str]) -> set[str]:
 
 
 def validation_paths_for(files: list[dict], maintainer_bypass: bool) -> list[str]:
-    """Exclude maintainer-authorized removals from content validation."""
+    """Return paths present in the PR checkout for content validation."""
     return [
         item["filename"]
         for item in files
-        if not (maintainer_bypass and item.get("status") == "removed")
+        if item.get("status") != "removed"
     ]
 
 
@@ -327,8 +337,8 @@ def hydrate_proposal_package(
                 head_sha,
                 destination,
             )
-        except urllib.error.HTTPError as exc:
-            if exc.code != 404:
+        except (urllib.error.HTTPError, RuntimeError) as exc:
+            if not _is_download_not_found(exc, f"{proposal_dir}/{relative}"):
                 raise
 
 
@@ -394,14 +404,19 @@ def main() -> int:
             validation.add_warning(
                 "non-submission code/docs/test PR; participant package validation was not applicable"
             )
-        elif not validation_files and maintainer_bypass:
+        elif not validation_files and (maintainer_bypass or queue_candidate):
             validation = ValidationReport(
                 changed_files=changed_files,
-                maintainer_bypass=True,
+                maintainer_bypass=maintainer_bypass,
             )
-            validation.add_warning(
-                "maintainer-authorized deletion-only PR; removed files were not executed or content-validated"
-            )
+            if maintainer_bypass:
+                validation.add_warning(
+                    "maintainer-authorized deletion-only PR; removed files were not executed or content-validated"
+                )
+            else:
+                validation.add_warning(
+                    "participant deletion-only PR; removed files were not content-validated"
+                )
         else:
             validation = validate_submission(worktree, pr_author, validation_files, bypass)
         validation_markdown = format_report(validation)

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -2,13 +2,14 @@ import sys
 import tempfile
 import unittest
 import json
+import os
 import subprocess
 import hashlib
 import io
 import re
 import urllib.error
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import jsonschema
 
@@ -31,6 +32,7 @@ from github_pr_validation import (  # noqa: E402
     _is_retryable_http_error,
     is_non_submission_pr,
     is_review_queue_candidate,
+    main,
     safe_manifest_paths,
     validation_paths_for,
 )
@@ -117,6 +119,36 @@ class GitHubApiResilienceTests(unittest.TestCase):
         self.assertEqual(1, urlopen.call_count)
         sleep.assert_not_called()
 
+    def test_download_404_retries_then_succeeds(self) -> None:
+        client = GitHubClient("token", "open-city-ai/haidian")
+        not_found = self._error(404, b'{"message":"Not Found"}')
+        with tempfile.TemporaryDirectory() as temp_dir, patch(
+            "github_pr_validation.urllib.request.urlopen",
+            side_effect=[not_found, _Response(b"payload")],
+        ), patch("github_pr_validation.time.sleep") as sleep:
+            destination = Path(temp_dir) / "asset.bin"
+            client.download_content("fork/repo", "asset.bin", "head-sha", destination)
+            self.assertEqual(b"payload", destination.read_bytes())
+        sleep.assert_called_once_with(1.0)
+
+    def test_download_404_exhaustion_reports_path(self) -> None:
+        client = GitHubClient("token", "open-city-ai/haidian")
+        errors = [self._error(404, b'{"message":"Not Found"}') for _ in range(4)]
+        with tempfile.TemporaryDirectory() as temp_dir, patch(
+            "github_pr_validation.urllib.request.urlopen",
+            side_effect=errors,
+        ), patch("github_pr_validation.time.sleep"):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"GitHub API download submissions/alice/design/asset.bin failed with HTTP 404",
+            ):
+                client.download_content(
+                    "fork/repo",
+                    "submissions/alice/design/asset.bin",
+                    "head-sha",
+                    Path(temp_dir) / "asset.bin",
+                )
+
 
 class EmptyPdfDetectionTests(unittest.TestCase):
     def test_zero_count_placeholder_is_empty(self) -> None:
@@ -192,12 +224,39 @@ class ManifestHydrationTests(unittest.TestCase):
         ]
         self.assertEqual(["docs/note.md"], validation_paths_for(files, True))
 
-    def test_participant_removals_remain_in_validation_scope(self) -> None:
+    def test_removed_paths_are_excluded_from_validation_scope(self) -> None:
         files = [{"filename": "submissions/alice/design/proposal.md", "status": "removed"}]
-        self.assertEqual(
-            ["submissions/alice/design/proposal.md"],
-            validation_paths_for(files, False),
-        )
+        self.assertEqual([], validation_paths_for(files, False))
+
+    def test_participant_deletion_only_pr_is_warning_not_missing_file_failure(self) -> None:
+        event = {
+            "pull_request": {
+                "number": 647,
+                "user": {"login": "alice"},
+                "head": {"repo": {"full_name": "alice/haidian"}, "sha": "head-sha"},
+            }
+        }
+        files = [
+            {"filename": "submissions/alice/design/obsolete.png", "status": "removed"}
+        ]
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
+            json.dump(event, event_file)
+            event_file.flush()
+            client = MagicMock()
+            client.paginate.return_value = files
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "token",
+                    "GITHUB_REPOSITORY": "open-city-ai/haidian",
+                    "GITHUB_EVENT_PATH": event_file.name,
+                },
+                clear=False,
+            ), patch("github_pr_validation.GitHubClient", return_value=client):
+                self.assertEqual(0, main())
+        client.download_content.assert_not_called()
+        comment = client.upsert_comment.call_args.args[1]
+        self.assertIn("participant deletion-only PR", comment)
 
     def test_review_queue_candidate_is_one_author_owned_submission(self) -> None:
         self.assertTrue(


### PR DESCRIPTION
## Summary

Addresses #647 and #658.

- Exclude GitHub `removed` paths from content validation for every PR author, because deleted files are not present in the PR checkout.
- Treat a participant-owned, deletion-only submission PR as a passing validation with an explicit warning; the existing single-author/single-submission-root gate still controls the review queue.
- Retry transient Contents API `404` responses with the existing bounded GET retry budget. A permanent missing download fails with the path in the error; optional manifest assets retain their previous non-blocking behavior.

## Validation

- `python3 -m pytest -q tests/test_submission_workflow.py tests/test_lightweight_participant_flow.py` — 88 passed
- `python3 -m py_compile scripts/github_pr_validation.py tests/test_submission_workflow.py` — passed
- `git diff --check` — passed
- `python3 -m pytest -q` — 232 passed, 5 pre-existing gallery freshness failures because `submissions-data.js` does not yet include the latest merged `tianmengchu/jingzhang-public-foyer` submission

The workflow continues to download contributor files as inert data and does not execute contributor code.
