### PR TITLE
Raise trusted validator download cap to 10 MiB

### DIFF
--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -27,6 +27,7 @@ from validate_submission import ValidationReport, format_report, validate_submis
 COMMENT_MARKER = "<!-- haidian-submission-validation -->"
 API_ROOT = "https://api.github.com"
 MAX_API_ATTEMPTS = 4
+MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024
 MAX_RETRY_DELAY_SECONDS = 30
 RETRYABLE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
@@ -135,7 +136,7 @@ class GitHubClient:
         path: str,
         ref: str,
         destination: Path,
-        max_bytes: int = 6 * 1024 * 1024,
+        max_bytes: int = MAX_DOWNLOAD_BYTES,
     ) -> None:
         # Fetch raw bytes through the Contents API on api.github.com. Unlike the
         # github.com raw_url, this honors the Bearer token on private repos (the

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -27,6 +27,7 @@ from validate_submission import (  # noqa: E402
 )
 from github_pr_validation import (  # noqa: E402
     GitHubClient,
+    MAX_DOWNLOAD_BYTES,
     _is_retryable_http_error,
     is_non_submission_pr,
     is_review_queue_candidate,
@@ -137,6 +138,29 @@ class EmptyPdfDetectionTests(unittest.TestCase):
 
 
 class ManifestHydrationTests(unittest.TestCase):
+    def test_download_content_accepts_ten_mib_file(self) -> None:
+        client = GitHubClient("token", "owner/repo")
+        with tempfile.TemporaryDirectory() as tmp:
+            destination = Path(tmp) / "artifact.pdf"
+            with patch(
+                "github_pr_validation.urllib.request.urlopen",
+                return_value=_Response(b"x" * MAX_DOWNLOAD_BYTES),
+            ):
+                client.download_content("owner/repo", "artifact.pdf", "sha", destination)
+            self.assertEqual(MAX_DOWNLOAD_BYTES, destination.stat().st_size)
+
+    def test_download_content_rejects_file_over_ten_mib(self) -> None:
+        client = GitHubClient("token", "owner/repo")
+        with tempfile.TemporaryDirectory() as tmp:
+            destination = Path(tmp) / "artifact.pdf"
+            with patch(
+                "github_pr_validation.urllib.request.urlopen",
+                return_value=_Response(b"x" * (MAX_DOWNLOAD_BYTES + 1)),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "file exceeds download cap"):
+                    client.download_content("owner/repo", "artifact.pdf", "sha", destination)
+            self.assertFalse(destination.exists())
+
     def test_accepts_only_safe_relative_manifest_paths(self) -> None:
         manifest = {
             "files": [


### PR DESCRIPTION
Raises the trusted PR validator's per-file download cap from 6 MiB to 10 MiB. Adds exact boundary tests confirming that 10 MiB is accepted and 10 MiB + 1 byte is rejected.\n\nThis unblocks submission PR #639, whose largest artifact is about 6.15 MiB.\n\nTests: `python3 -m unittest tests.test_submission_workflow`