### PR TITLE
Use current trusted validator for queued PR checks

### DIFF
--- a/.github/workflows/submission-validation.yml
+++ b/.github/workflows/submission-validation.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
-      - name: Checkout trusted base branch
+      - name: Checkout current trusted default branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Run deterministic submission validation
         env:

--- a/scripts/prelaunch_check.py
+++ b/scripts/prelaunch_check.py
@@ -197,8 +197,8 @@ def check_workflow_trusted_base(repo_root: Path, checks: list[dict[str, Any]]) -
     failures = []
     if "pull_request_target" not in text:
         failures.append("workflow must use pull_request_target")
-    if "github.event.pull_request.base.sha" not in text:
-        failures.append("workflow must checkout the trusted base SHA")
+    if "github.event.repository.default_branch" not in text:
+        failures.append("workflow must checkout the current trusted default branch")
     if "github.event.pull_request.head.sha" in text or "pull_request.head.sha" in text:
         failures.append("workflow must not checkout the PR head SHA")
     if "python3 scripts/github_pr_validation.py" not in text:

--- a/tests/test_prelaunch_check.py
+++ b/tests/test_prelaunch_check.py
@@ -86,7 +86,7 @@ class PrelaunchCheckTests(unittest.TestCase):
     def test_workflow_keeps_pull_request_target_safe(self) -> None:
         workflow = (ROOT / ".github" / "workflows" / "submission-validation.yml").read_text(encoding="utf-8")
         self.assertIn("pull_request_target", workflow)
-        self.assertIn("github.event.pull_request.base.sha", workflow)
+        self.assertIn("github.event.repository.default_branch", workflow)
         self.assertNotIn("github.event.pull_request.head.sha", workflow)
         self.assertIn("python3 scripts/github_pr_validation.py", workflow)
 


### PR DESCRIPTION
Old pull requests keep their original `pull_request.base.sha`, so reopened or long-queued checks can execute an obsolete validator. Checkout the repository's protected default branch instead, while continuing to use `pull_request_target` and never checking out contributor code.\n\nThis is required for #639 to use the newly merged 10 MiB download limit.\n\nTests: 15 targeted workflow-safety, API-resilience, and download-boundary tests pass.