### PR TITLE
fix: bound pending submission validation queue

### DIFF
--- a/.github/workflows/submission-validation.yml
+++ b/.github/workflows/submission-validation.yml
@@ -10,12 +10,12 @@ permissions:
   issues: write
 
 # Every validation run calls the GitHub API to enumerate and hydrate the PR.
-# Serializing those calls avoids secondary-rate-limit 403s when several
-# submissions arrive together.
+# Keep those calls serial, but retain only one pending run: a burst from one
+# branch must not delay every other contributor's validation for hours.
 concurrency:
   group: submission-validation
   cancel-in-progress: false
-  queue: max
+  queue: single
 
 jobs:
   submission-validation:


### PR DESCRIPTION
## Summary

- Preserve serialized access to the GitHub API in `submission-validation`.
- Limit the global concurrency group to one pending run instead of the current FIFO backlog of up to 100.

## Root cause

`queue: max` lets up to 100 `pull_request_target` validations wait in the shared group. A rapid push burst can therefore delay unrelated contributors for hours. On 2026-08-08, the workflow accumulated a large pending backlog while normal PRs, including #688 and #715, never received a job.

GitHub documents that `queue: single` (the default) retains one pending run and replaces earlier pending work; it keeps the API calls serialized without creating a long, floodable queue. See [GitHub Actions concurrency](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency).

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/submission-validation.yml")'`
- `PYTHONPATH=scripts python3 -m unittest tests.test_prelaunch_check.PrelaunchCheckTests.test_workflow_keeps_pull_request_target_safe tests.test_auto_review_queue.AutoReviewQueueTests.test_ci_state -v`

`tests.test_prelaunch_check` as a whole remains blocked by the current `main` checkout's already-stale generated `submissions-data.js`; this PR does not modify that file.
