### PR TITLE
fix: skip stale pull request validation events

### DIFF
--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -94,6 +94,34 @@ def _is_download_not_found(error: Exception, path: str) -> bool:
     )
 
 
+def stale_pull_request_event_reason(
+    client: "GitHubClient", repository: str, pr_number: int, event_head_sha: str
+) -> str | None:
+    """Return why a queued PR event must not validate its no-longer-live head."""
+    try:
+        current, _ = client.request("GET", f"/repos/{repository}/pulls/{pr_number}")
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return f"PR #{pr_number} no longer exists"
+        raise
+    if not isinstance(current, dict):
+        raise RuntimeError(f"GitHub API PR #{pr_number} metadata response was malformed")
+    if current.get("state") != "open":
+        return f"PR #{pr_number} is no longer open"
+    if current.get("draft") is True:
+        return f"PR #{pr_number} is now a draft"
+    head = current.get("head")
+    live_head_sha = head.get("sha") if isinstance(head, dict) else None
+    if not isinstance(live_head_sha, str):
+        raise RuntimeError(f"GitHub API PR #{pr_number} is missing head.sha")
+    if live_head_sha != event_head_sha:
+        return (
+            f"PR #{pr_number} head advanced from {event_head_sha[:12]} "
+            f"to {live_head_sha[:12]}"
+        )
+    return None
+
+
 class GitHubClient:
     def __init__(self, token: str, repository: str) -> None:
         self.token = token
@@ -367,6 +395,11 @@ def main() -> int:
     head_repo = pull_request["head"]["repo"]["full_name"]
     head_sha = pull_request["head"]["sha"]
     client = GitHubClient(token, repository)
+
+    stale_reason = stale_pull_request_event_reason(client, repository, pr_number, head_sha)
+    if stale_reason:
+        print(f"Skipping stale submission-validation event: {stale_reason}")
+        return 0
 
     files = client.paginate(f"/repos/{repository}/pulls/{pr_number}/files?per_page=100")
     changed_files = [item["filename"] for item in files]

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -392,7 +392,6 @@ def main() -> int:
 
     pr_number = int(pull_request["number"])
     pr_author = pull_request["user"]["login"]
-    head_repo = pull_request["head"]["repo"]["full_name"]
     head_sha = pull_request["head"]["sha"]
     client = GitHubClient(token, repository)
 
@@ -401,6 +400,7 @@ def main() -> int:
         print(f"Skipping stale submission-validation event: {stale_reason}")
         return 0
 
+    head_repo = pull_request["head"]["repo"]["full_name"]
     files = client.paginate(f"/repos/{repository}/pulls/{pr_number}/files?per_page=100")
     changed_files = [item["filename"] for item in files]
     bypass = [

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -268,7 +268,7 @@ class ManifestHydrationTests(unittest.TestCase):
             "pull_request": {
                 "number": 685,
                 "user": {"login": "alice"},
-                "head": {"repo": {"full_name": "alice/haidian"}, "sha": "old-head-sha"},
+                "head": {"repo": None, "sha": "old-head-sha"},
             }
         }
         with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -34,6 +34,7 @@ from github_pr_validation import (  # noqa: E402
     is_review_queue_candidate,
     main,
     safe_manifest_paths,
+    stale_pull_request_event_reason,
     validation_paths_for,
 )
 from validate_local_submission import discover_submission_files  # noqa: E402
@@ -243,6 +244,10 @@ class ManifestHydrationTests(unittest.TestCase):
             json.dump(event, event_file)
             event_file.flush()
             client = MagicMock()
+            client.request.return_value = (
+                {"state": "open", "draft": False, "head": {"sha": "head-sha"}},
+                {},
+            )
             client.paginate.return_value = files
             with patch.dict(
                 os.environ,
@@ -257,6 +262,54 @@ class ManifestHydrationTests(unittest.TestCase):
         client.download_content.assert_not_called()
         comment = client.upsert_comment.call_args.args[1]
         self.assertIn("participant deletion-only PR", comment)
+
+    def test_stale_event_skips_before_file_enumeration(self) -> None:
+        event = {
+            "pull_request": {
+                "number": 685,
+                "user": {"login": "alice"},
+                "head": {"repo": {"full_name": "alice/haidian"}, "sha": "old-head-sha"},
+            }
+        }
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
+            json.dump(event, event_file)
+            event_file.flush()
+            client = MagicMock()
+            client.request.return_value = (
+                {"state": "open", "draft": False, "head": {"sha": "live-head-sha"}},
+                {},
+            )
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "token",
+                    "GITHUB_REPOSITORY": "open-city-ai/haidian",
+                    "GITHUB_EVENT_PATH": event_file.name,
+                },
+                clear=False,
+            ), patch("github_pr_validation.GitHubClient", return_value=client):
+                self.assertEqual(0, main())
+        client.paginate.assert_not_called()
+        client.download_content.assert_not_called()
+        client.upsert_comment.assert_not_called()
+
+    def test_stale_event_reason_skips_closed_pr(self) -> None:
+        client = MagicMock()
+        client.request.return_value = ({"state": "closed", "head": {"sha": "head-sha"}}, {})
+        self.assertEqual(
+            "PR #685 is no longer open",
+            stale_pull_request_event_reason(client, "open-city-ai/haidian", 685, "head-sha"),
+        )
+
+    def test_stale_event_reason_skips_missing_pr(self) -> None:
+        client = MagicMock()
+        client.request.side_effect = urllib.error.HTTPError(
+            "https://api.github.com/test", 404, "Not Found", {}, io.BytesIO(b"{}")
+        )
+        self.assertEqual(
+            "PR #685 no longer exists",
+            stale_pull_request_event_reason(client, "open-city-ai/haidian", 685, "head-sha"),
+        )
 
     def test_review_queue_candidate_is_one_author_owned_submission(self) -> None:
         self.assertTrue(


### PR DESCRIPTION
## Summary

- Fetch the live PR metadata before enumerating changed files.
- Exit successfully without downloads or comments when the queued event is stale: the PR is closed, converted to draft, deleted, or has advanced to a different head SHA.
- Add regression coverage for head advancement, closed/deleted PRs, and the no-enumeration/no-download guarantee.

## Root cause

A `pull_request_target` run can start after a contributor has force-pushed or rapidly renamed files. Its event SHA is then no longer reachable through the fork Contents API. The live example was [run 31273679202](https://github.com/open-city-ai/haidian/actions/runs/31273679202), which attempted to download a removed path at a stale SHA and received a permanent 404 after retries. That work needlessly held the shared validation queue.

The new metadata read is cheap and trusted. It skips only stale events; a validation for the current open, non-draft head continues unchanged.

## Validation

- `PYTHONPATH=scripts python3 -m unittest tests.test_submission_workflow -v` — 88 passed
- `python3 -m py_compile scripts/github_pr_validation.py`
- `git diff --check`
