### PR TITLE
Clarify rights review order

### DIFF
--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -116,7 +116,7 @@
       "path": "report/copyright_statement.md",
       "role": "copyright_statement",
       "required": true,
-      "sha256": "8eae533db9619e8f4b628fce75299538cbd91d67f6eb8afaf007da097383d0f9"
+      "sha256": "1a2c919b15b7775c107add55be1c2168a46835181f2cca4961272bb53258c81d"
     },
     {
       "path": "drawings/a3-booklet.pdf",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/report/copyright_statement.md
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/report/copyright_statement.md
@@ -13,6 +13,8 @@
 
 本台账可以支持仓库评审中的事实披露，但不构成法律意见、所有权证明或公共发布许可。对外展示、专业深化或其他再利用前，必须完成台账中 `RIGHTS-OPEN-01`—`RIGHTS-OPEN-05` 里适用的事项，并由维护者或权利专业人员确认。
 
+建议按“来源与许可证 → 字体与生成工具 → 地图衍生与署名 → Logo/地标 → 可编辑源与再利用范围”的顺序复核；任一环节未确认时，整体状态继续保持 `not_fully_cleared`，不得用部分完成替代发布许可。
+
 ## English
 
 This package no longer claims that rights clearance is complete. `visual/assets/rights-clearance-ledger.json` groups every one of the 48 manifest paths and records its origin basis, current rights status, limits, and release gate. The number of completed independent file-level clearance audits is **0**, and the overall status is `not_fully_cleared`.
@@ -25,3 +27,5 @@ This package no longer claims that rights clearance is complete. `visual/assets/
 - The JZ geometric logo and landmark names are conceptual proposals pending trademark and production-brand review; they imply no corporate or government authorization.
 
 The ledger supports transparent repository review, but it is not legal advice, proof of ownership, or a public-release license. Before external display, professional deepening, or other reuse, the applicable `RIGHTS-OPEN-01`—`RIGHTS-OPEN-05` items must be completed and confirmed by maintainers or qualified rights professionals.
+
+Review in this order: sources and licenses → fonts and generation tools → map derivatives and attribution → logo and landmarks → editable sources and reuse scope. If any step is unconfirmed, the overall status remains `not_fully_cleared`; partial completion must not be treated as a release license.


### PR DESCRIPTION
## Summary
- clarify the existing rights-release review order in Chinese and English
- keep `not_fully_cleared` until every applicable gate is independently confirmed
- refresh only the copyright-statement manifest hash

## Validation
- deterministic validation: PASS (existing provisional/evidence-density warnings only)
- strict score: 8/8
- spatial, visual, professional review: PASS
- self-check: formal-review-ready
- staged/committed manifest hashes: 47/47 match

This is a package-local documentation clarification. It adds no approval, license, partner, operating result, metric, geometry, or planning claim.