### PR TITLE
Pin formal spatial review command

### DIFF
--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -110,7 +110,7 @@
       "path": "report/narrative.md",
       "role": "narrative",
       "required": false,
-      "sha256": "54b9e3efb524420dd73296a345e1594e905dfd68c5dbd79de899bc271478a2b4"
+      "sha256": "b9582517306a63c7aa0c7de523499f261c20aa7d8cde1d25309c2494b1f6f9e5"
     },
     {
       "path": "report/copyright_statement.md",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/report/narrative.md
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/report/narrative.md
@@ -127,7 +127,7 @@ The record above validates only exact head `e71ff206…` and its raw manifest Gi
 ```powershell
 $pkg = 'submissions/xyh202131/jingzhang-ai-pilgrimage-belt'
 python scripts/score_submission.py "$pkg/proposal.md" --strict --json
-python scripts/spatial_review.py $pkg --json
+python scripts/spatial_review.py $pkg --stage formal --json
 python scripts/visual_review.py $pkg --json
 python scripts/professional_review.py $pkg --json
 python scripts/self_check_submission.py $pkg --pr-author xyh202131 --json


### PR DESCRIPTION
## Summary
- make the package-local spatial reproduction command explicit about `--stage formal`
- refresh the narrative and manifest hash only

## Validation
- participant preflight: PASS, no blockers or out-of-scope files
- self-check: `formal-review-ready`
- manifest: 47/47 non-manifest hashes match
- whitespace check: PASS

This is a documentation-only increment; it adds no planning, metric, geometry, approval, partner, operation, test, or rights-clearance claim.