### PR TITLE
Bound OSM evidence use

### DIFF
--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -49,7 +49,7 @@
       "path": "sources.json",
       "role": "sources",
       "required": true,
-      "sha256": "c81652dc2676a1004112de49e48458f1cbc622cdac66e74579854b50b508d3e2"
+      "sha256": "5551025bb522bb4dc81f8b55d040383616d472c44ad23949c862108b89c60939"
     },
     {
       "path": "self_check.json",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
@@ -127,13 +127,14 @@
       "authority_level": "open_background",
       "license": "ODbL",
       "usable_for": [
-        "background orientation"
+        "background orientation only"
       ],
       "not_usable_for": [
         "road redlines",
         "rail protection zones",
         "water blue lines",
-        "official boundary"
+        "official boundary",
+        "engineering design"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- clarify that OSM is for background orientation only
- explicitly exclude engineering design in the source registry
- refresh the single source-record hash in the manifest

## Validation
- deterministic validation: PASS (existing package warnings only)
- professional review: PASS
- self-check: `formal-review-ready`
- manifest: 47/47 non-manifest hashes match
- scope/whitespace checks: PASS

No geometry, metric, approval, partner, or implementation claim was added.