### PR TITLE
Bound site-package authority

### DIFF
--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -49,7 +49,7 @@
       "path": "sources.json",
       "role": "sources",
       "required": true,
-      "sha256": "c81652dc2676a1004112de49e48458f1cbc622cdac66e74579854b50b508d3e2"
+      "sha256": "90c00377847b3eb3f19819dac2ea4816de516b0dc085a8a353b51f2625f898d6"
     },
     {
       "path": "self_check.json",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
@@ -16,7 +16,8 @@
         "provisional intake"
       ],
       "not_usable_for": [
-        "statutory approval"
+        "statutory approval",
+        "construction authorization"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- record `construction authorization` as outside the public site package authority
- keep the source registry boundary explicit and refresh its manifest hash

## Validation
- deterministic validation: PASS
- self-check: `formal-review-ready`
- manifest: 47/47 non-manifest hashes match
- scope and whitespace checks: PASS

No project, geometry, metric, partner, approval, operation, test, or clearance result was added.