### PR TITLE
Bound source-registry authority

### DIFF
--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -49,7 +49,7 @@
       "path": "sources.json",
       "role": "sources",
       "required": true,
-      "sha256": "c81652dc2676a1004112de49e48458f1cbc622cdac66e74579854b50b508d3e2"
+      "sha256": "34457d03b7864f45d4afc7f756c66423fa38247c1966ee3147bf6ebb7455dadf"
     },
     {
       "path": "self_check.json",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
@@ -31,7 +31,8 @@
         "source status"
       ],
       "not_usable_for": [
-        "creating new authority"
+        "creating new authority",
+        "legal rights clearance"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- state that the source registry reports status but is not legal rights clearance
- refresh the source-registry manifest hash

## Validation
- deterministic validation: PASS
- self-check: `formal-review-ready`
- manifest: 47/47 non-manifest hashes match
- scope and whitespace checks: PASS

No new authority, approval, metric, geometry, partner, operation, test, or license claim was added.