### PR TITLE
Bound processed-pack authority

### DIFF
--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -49,7 +49,7 @@
       "path": "sources.json",
       "role": "sources",
       "required": true,
-      "sha256": "c81652dc2676a1004112de49e48458f1cbc622cdac66e74579854b50b508d3e2"
+      "sha256": "07151cfbf9e705603435c1cbb6e42a6c8ee46dc1b33fcd4d90ccb6b33d54d407"
     },
     {
       "path": "self_check.json",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
@@ -46,7 +46,8 @@
         "navigation"
       ],
       "not_usable_for": [
-        "new factual authority"
+        "new factual authority",
+        "original-document verification"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- clarify that the processed fact pack is navigation, not original-document verification
- refresh the source-registry manifest hash

## Validation
- deterministic validation: PASS
- self-check: `formal-review-ready`
- manifest: 47/47 non-manifest hashes match
- scope and whitespace checks: PASS

No new factual authority, approval, metric, geometry, partner, operation, test, or rights result was added.