### PR TITLE
Bound provisional boundary use

### DIFF
--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -49,7 +49,7 @@
       "path": "sources.json",
       "role": "sources",
       "required": true,
-      "sha256": "c81652dc2676a1004112de49e48458f1cbc622cdac66e74579854b50b508d3e2"
+      "sha256": "124c5e17bfa3fe0f26997c7d2fb72fbe7f255802d35fc7d7066122f80b53e6b5"
     },
     {
       "path": "self_check.json",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
@@ -65,7 +65,8 @@
       "not_usable_for": [
         "official redline",
         "approval",
-        "precise area"
+        "precise area",
+        "engineering linework"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- explicitly exclude engineering linework from the provisional boundary source
- refresh the source-registry manifest hash

## Validation
- deterministic validation: PASS
- self-check: `formal-review-ready`
- manifest: 47/47 non-manifest hashes match
- scope and whitespace checks: PASS

No official boundary, engineering, approval, metric, partner, operation, test, or rights-clearance claim was added.