### PR TITLE
Bound key-area precision

### DIFF
--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -49,7 +49,7 @@
       "path": "sources.json",
       "role": "sources",
       "required": true,
-      "sha256": "c81652dc2676a1004112de49e48458f1cbc622cdac66e74579854b50b508d3e2"
+      "sha256": "6050fb4ba51499b40d41a20eff74f7bd49ecdb058379aeda2ea24ac01d5618f9"
     },
     {
       "path": "self_check.json",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
@@ -81,7 +81,8 @@
         "display"
       ],
       "not_usable_for": [
-        "official key-area polygons"
+        "official key-area polygons",
+        "precise area"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- explicitly exclude precise area from the provisional key-area source
- refresh the source-registry manifest hash

## Validation
- deterministic validation: PASS
- self-check: `formal-review-ready`
- manifest: 47/47 non-manifest hashes match
- scope and whitespace checks: PASS

No official geometry, approval, metric, partner, operation, test, or rights-clearance claim was added.