### PR TITLE
Bound announcement authority

### DIFF
--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -49,7 +49,7 @@
       "path": "sources.json",
       "role": "sources",
       "required": true,
-      "sha256": "c81652dc2676a1004112de49e48458f1cbc622cdac66e74579854b50b508d3e2"
+      "sha256": "e45bbc31f8c24ec617b18dd902ea0e13273db67fd6ed10aad2ca4b910e557168"
     },
     {
       "path": "self_check.json",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
@@ -98,7 +98,8 @@
         "deliverables"
       ],
       "not_usable_for": [
-        "precise GIS boundary"
+        "precise GIS boundary",
+        "project-specific approval"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- clarify that the official call supports scope and deliverables, not project-specific approval
- refresh the source-registry manifest hash

## Validation
- deterministic validation: PASS
- self-check: `formal-review-ready`
- manifest: 47/47 non-manifest hashes match
- scope and whitespace checks: PASS

No approval, funding, geometry, metric, partner, operation, test, or rights-clearance result was added.