### PR TITLE
Bound taskbook authority

### DIFF
--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -49,7 +49,7 @@
       "path": "sources.json",
       "role": "sources",
       "required": true,
-      "sha256": "c81652dc2676a1004112de49e48458f1cbc622cdac66e74579854b50b508d3e2"
+      "sha256": "3ccf5b140cf007fa6874536ca5211b133e61b3171b403c39aed473e154da39a5"
     },
     {
       "path": "self_check.json",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
@@ -114,7 +114,8 @@
         "scenario requirements"
       ],
       "not_usable_for": [
-        "statutory controls"
+        "statutory controls",
+        "institutional authorization"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- clarify that the agent taskbook defines requirements but not institutional authorization
- refresh the source-registry manifest hash

## Validation
- deterministic validation: PASS
- self-check: `formal-review-ready`
- manifest: 47/47 non-manifest hashes match
- scope and whitespace checks: PASS

No authorization, approval, funding, geometry, metric, partner, operation, test, or rights-clearance result was added.