### PR TITLE
Bound Kendall case use

### DIFF
--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -49,7 +49,7 @@
       "path": "sources.json",
       "role": "sources",
       "required": true,
-      "sha256": "c81652dc2676a1004112de49e48458f1cbc622cdac66e74579854b50b508d3e2"
+      "sha256": "b8e12076b56c89eb9af51648b569ef3122fc668127c5c0c5c1840097e52b60c4"
     },
     {
       "path": "self_check.json",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
@@ -148,7 +148,8 @@
         "background case study"
       ],
       "not_usable_for": [
-        "local controls"
+        "local controls",
+        "local implementation evidence"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- clarify that the Kendall case is background context, not local implementation evidence
- refresh the source-registry manifest hash

## Validation
- deterministic validation: PASS
- self-check: `formal-review-ready`
- manifest: 47/47 non-manifest hashes match
- scope and whitespace checks: PASS

No local control, approval, partner, metric, geometry, operation, test, or rights-clearance claim was added.