### PR TITLE
fix: consolidate pilgrimage source bounds

### DIFF
--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -49,7 +49,7 @@
       "path": "sources.json",
       "role": "sources",
       "required": true,
-      "sha256": "c81652dc2676a1004112de49e48458f1cbc622cdac66e74579854b50b508d3e2"
+      "sha256": "9d66b3d4110861d5aa1ea0f9ba0fb7adcbf462b9ee6a511b7e4828494a9a335e"
     },
     {
       "path": "self_check.json",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -49,7 +49,7 @@
       "path": "sources.json",
       "role": "sources",
       "required": true,
-      "sha256": "9d66b3d4110861d5aa1ea0f9ba0fb7adcbf462b9ee6a511b7e4828494a9a335e"
+      "sha256": "cd649a960df1d3b128051c9488d5b6fa38e655f8e86f84b24f164d390e6baf1d"
     },
     {
       "path": "self_check.json",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -49,7 +49,7 @@
       "path": "sources.json",
       "role": "sources",
       "required": true,
-      "sha256": "cd649a960df1d3b128051c9488d5b6fa38e655f8e86f84b24f164d390e6baf1d"
+      "sha256": "d0e769dc4c4e49819a0f5480c6a882dc5b471dcb33542ea1a634f27bd8b6ae4b"
     },
     {
       "path": "self_check.json",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -49,7 +49,7 @@
       "path": "sources.json",
       "role": "sources",
       "required": true,
-      "sha256": "d0e769dc4c4e49819a0f5480c6a882dc5b471dcb33542ea1a634f27bd8b6ae4b"
+      "sha256": "f6dfc86a2f7ad99b6c465d24d4d6bceec95737c467622b0afc770491114b74b4"
     },
     {
       "path": "self_check.json",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -110,13 +110,13 @@
       "path": "report/narrative.md",
       "role": "narrative",
       "required": false,
-      "sha256": "54b9e3efb524420dd73296a345e1594e905dfd68c5dbd79de899bc271478a2b4"
+      "sha256": "b9582517306a63c7aa0c7de523499f261c20aa7d8cde1d25309c2494b1f6f9e5"
     },
     {
       "path": "report/copyright_statement.md",
       "role": "copyright_statement",
       "required": true,
-      "sha256": "8eae533db9619e8f4b628fce75299538cbd91d67f6eb8afaf007da097383d0f9"
+      "sha256": "1a2c919b15b7775c107add55be1c2168a46835181f2cca4961272bb53258c81d"
     },
     {
       "path": "drawings/a3-booklet.pdf",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/report/copyright_statement.md
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/report/copyright_statement.md
@@ -13,6 +13,8 @@
 
 本台账可以支持仓库评审中的事实披露，但不构成法律意见、所有权证明或公共发布许可。对外展示、专业深化或其他再利用前，必须完成台账中 `RIGHTS-OPEN-01`—`RIGHTS-OPEN-05` 里适用的事项，并由维护者或权利专业人员确认。
 
+建议按“来源与许可证 → 字体与生成工具 → 地图衍生与署名 → Logo/地标 → 可编辑源与再利用范围”的顺序复核；任一环节未确认时，整体状态继续保持 `not_fully_cleared`，不得用部分完成替代发布许可。
+
 ## English
 
 This package no longer claims that rights clearance is complete. `visual/assets/rights-clearance-ledger.json` groups every one of the 48 manifest paths and records its origin basis, current rights status, limits, and release gate. The number of completed independent file-level clearance audits is **0**, and the overall status is `not_fully_cleared`.
@@ -25,3 +27,5 @@ This package no longer claims that rights clearance is complete. `visual/assets/
 - The JZ geometric logo and landmark names are conceptual proposals pending trademark and production-brand review; they imply no corporate or government authorization.
 
 The ledger supports transparent repository review, but it is not legal advice, proof of ownership, or a public-release license. Before external display, professional deepening, or other reuse, the applicable `RIGHTS-OPEN-01`—`RIGHTS-OPEN-05` items must be completed and confirmed by maintainers or qualified rights professionals.
+
+Review in this order: sources and licenses → fonts and generation tools → map derivatives and attribution → logo and landmarks → editable sources and reuse scope. If any step is unconfirmed, the overall status remains `not_fully_cleared`; partial completion must not be treated as a release license.

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/report/narrative.md
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/report/narrative.md
@@ -127,7 +127,7 @@ The record above validates only exact head `e71ff206…` and its raw manifest Gi
 ```powershell
 $pkg = 'submissions/xyh202131/jingzhang-ai-pilgrimage-belt'
 python scripts/score_submission.py "$pkg/proposal.md" --strict --json
-python scripts/spatial_review.py $pkg --json
+python scripts/spatial_review.py $pkg --stage formal --json
 python scripts/visual_review.py $pkg --json
 python scripts/professional_review.py $pkg --json
 python scripts/self_check_submission.py $pkg --pr-author xyh202131 --json

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
@@ -256,7 +256,8 @@
       "not_usable_for": [
         "project approval",
         "partner commitment",
-        "spatial control"
+        "spatial control",
+        "current operating result"
       ]
     },
     {
@@ -274,7 +275,8 @@
       "not_usable_for": [
         "partnership commitment",
         "funding promise",
-        "local controls"
+        "local controls",
+        "specific project authorization"
       ]
     },
     {
@@ -291,7 +293,8 @@
       ],
       "not_usable_for": [
         "site system approval",
-        "capacity commitment"
+        "capacity commitment",
+        "site-specific capacity standard"
       ]
     },
     {

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
@@ -120,7 +120,8 @@
         "scenario requirements"
       ],
       "not_usable_for": [
-        "statutory controls"
+        "statutory controls",
+        "institutional authorization"
       ]
     },
     {
@@ -155,7 +156,8 @@
         "background case study"
       ],
       "not_usable_for": [
-        "local controls"
+        "local controls",
+        "local implementation evidence"
       ]
     },
     {
@@ -170,7 +172,8 @@
         "background case study"
       ],
       "not_usable_for": [
-        "local controls"
+        "local controls",
+        "local implementation evidence"
       ]
     },
     {
@@ -185,7 +188,8 @@
         "background case study"
       ],
       "not_usable_for": [
-        "local controls"
+        "local controls",
+        "local implementation evidence"
       ]
     },
     {
@@ -200,7 +204,8 @@
         "background case study"
       ],
       "not_usable_for": [
-        "local controls"
+        "local controls",
+        "local implementation evidence"
       ]
     },
     {
@@ -215,7 +220,8 @@
         "background case study"
       ],
       "not_usable_for": [
-        "local controls"
+        "local controls",
+        "local implementation evidence"
       ]
     },
     {
@@ -230,7 +236,8 @@
         "background case study"
       ],
       "not_usable_for": [
-        "local controls"
+        "local controls",
+        "local implementation evidence"
       ]
     },
     {

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
@@ -16,7 +16,8 @@
         "provisional intake"
       ],
       "not_usable_for": [
-        "statutory approval"
+        "statutory approval",
+        "construction authorization"
       ]
     },
     {
@@ -31,7 +32,8 @@
         "source status"
       ],
       "not_usable_for": [
-        "creating new authority"
+        "creating new authority",
+        "legal rights clearance"
       ]
     },
     {
@@ -46,7 +48,8 @@
         "navigation"
       ],
       "not_usable_for": [
-        "new factual authority"
+        "new factual authority",
+        "original-document verification"
       ]
     },
     {
@@ -65,7 +68,8 @@
       "not_usable_for": [
         "official redline",
         "approval",
-        "precise area"
+        "precise area",
+        "engineering linework"
       ]
     },
     {
@@ -81,7 +85,8 @@
         "display"
       ],
       "not_usable_for": [
-        "official key-area polygons"
+        "official key-area polygons",
+        "precise area"
       ]
     },
     {
@@ -98,7 +103,8 @@
         "deliverables"
       ],
       "not_usable_for": [
-        "precise GIS boundary"
+        "precise GIS boundary",
+        "project-specific approval"
       ]
     },
     {
@@ -127,13 +133,14 @@
       "authority_level": "open_background",
       "license": "ODbL",
       "usable_for": [
-        "background orientation"
+        "background orientation only"
       ],
       "not_usable_for": [
         "road redlines",
         "rail protection zones",
         "water blue lines",
-        "official boundary"
+        "official boundary",
+        "engineering design"
       ]
     },
     {

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
@@ -310,7 +310,8 @@
         "culture content provenance"
       ],
       "not_usable_for": [
-        "substitute for legal review"
+        "substitute for legal review",
+        "complete rights clearance"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Consolidate the compatible package-boundary and evidence-readability updates for `submissions/xyh202131/jingzhang-ai-pilgrimage-belt` into one verifiable PR:

- source-use boundaries from #725, #727, #728, #729, #731, #732, #733, #734, #735, #737, #738, #739, #740, #741, #742, #743, #744, and #746;
- rights-review ordering from #722;
- formal spatial-review command pin from #724;
- verified evidence-density/readability repair from #717;
- one final `sources.json`, synchronized proposal/report/HTML files, and matching manifest hashes.

The package remains explicit that public sources do not authorize construction, project-specific approval, legal rights clearance, original-document verification, precise boundary/area work, engineering design, local implementation evidence, current operating results, or complete rights clearance.

No new factual, approval, metric, rights-clearance, partner, or operating claim is introduced.

## Verification

- current exact head: `d5948f30`;
- `self_check_submission.py`: `formal-review-ready`;
- `participant_preflight.py`: PASS;
- changed-file deterministic validation: PASS;
- spatial / visual / professional review: PASS, with existing provisional-boundary warning only;
- readability repair preserves source/standard/metric/depth markers in Chinese and English Markdown and offline HTML;
- final file SHA-256 values match `manifest.json`; JSON parsing and `git diff --check`: PASS.

The original single-purpose PRs should be closed after this consolidated PR is accepted, otherwise they will continue to compete over the same manifest hash.
