### PR TITLE
Bound Station F case use

### DIFF
--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -49,7 +49,7 @@
       "path": "sources.json",
       "role": "sources",
       "required": true,
-      "sha256": "c81652dc2676a1004112de49e48458f1cbc622cdac66e74579854b50b508d3e2"
+      "sha256": "49a8a6e6f936d5fc07a0b97939f6d95a2da742256c35317f7351254899d29832"
     },
     {
       "path": "self_check.json",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
@@ -208,7 +208,8 @@
         "background case study"
       ],
       "not_usable_for": [
-        "local controls"
+        "local controls",
+        "local implementation evidence"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- clarify that the Station F case is background context, not local implementation evidence
- refresh the source-registry manifest hash

## Validation
- deterministic validation: PASS
- self-check: `formal-review-ready`
- manifest: 47/47 non-manifest hashes match
- scope and whitespace checks: PASS

No local control, approval, partner, metric, geometry, operation, test, or rights-clearance claim was added.