### PR TITLE
Bound Origin background use

### DIFF
--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -49,7 +49,7 @@
       "path": "sources.json",
       "role": "sources",
       "required": true,
-      "sha256": "c81652dc2676a1004112de49e48458f1cbc622cdac66e74579854b50b508d3e2"
+      "sha256": "15dd90b84247448d40cadae4e08bb288db5fbf9675b21211b6eb06b774a0938c"
     },
     {
       "path": "self_check.json",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
@@ -242,7 +242,8 @@
       "not_usable_for": [
         "project approval",
         "partner commitment",
-        "spatial control"
+        "spatial control",
+        "current operating result"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- clarify that the Origin Community background source does not prove current operating results
- refresh the source-registry manifest hash

## Validation
- deterministic validation: PASS
- self-check: `formal-review-ready`
- manifest: 47/47 non-manifest hashes match
- scope and whitespace checks: PASS

No operating result, approval, partner, metric, geometry, operation, test, or rights-clearance claim was added.