### PR TITLE
Bound district background use

### DIFF
--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -49,7 +49,7 @@
       "path": "sources.json",
       "role": "sources",
       "required": true,
-      "sha256": "c81652dc2676a1004112de49e48458f1cbc622cdac66e74579854b50b508d3e2"
+      "sha256": "6c7db507642a472920f2aeeb077d0c65750bb2a87e3546b22846517d5c2e01c3"
     },
     {
       "path": "self_check.json",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
@@ -260,7 +260,8 @@
       "not_usable_for": [
         "partnership commitment",
         "funding promise",
-        "local controls"
+        "local controls",
+        "specific project authorization"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- clarify that the innovation-district background source does not authorize this project
- refresh the source-registry manifest hash

## Validation
- deterministic validation: PASS
- self-check: `formal-review-ready`
- manifest: 47/47 non-manifest hashes match
- scope and whitespace checks: PASS

No authorization, funding, partner, metric, geometry, operation, test, or rights-clearance claim was added.