### PR TITLE
Bound data-policy authority

### DIFF
--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -49,7 +49,7 @@
       "path": "sources.json",
       "role": "sources",
       "required": true,
-      "sha256": "c81652dc2676a1004112de49e48458f1cbc622cdac66e74579854b50b508d3e2"
+      "sha256": "d84a1f207d29df30b61af49a7d4fa2364b9551609f1c590ad2db843d4f265782"
     },
     {
       "path": "self_check.json",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
@@ -277,7 +277,8 @@
       ],
       "not_usable_for": [
         "site system approval",
-        "capacity commitment"
+        "capacity commitment",
+        "site-specific capacity standard"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- clarify that national data principles do not define this site's capacity standard
- refresh the source-registry manifest hash

## Validation
- deterministic validation: PASS
- self-check: `formal-review-ready`
- manifest: 47/47 non-manifest hashes match
- scope and whitespace checks: PASS

No site capacity, approval, funding, metric, geometry, partner, operation, test, or rights-clearance claim was added.