### PR TITLE
Bound content-label authority

### DIFF
--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -49,7 +49,7 @@
       "path": "sources.json",
       "role": "sources",
       "required": true,
-      "sha256": "c81652dc2676a1004112de49e48458f1cbc622cdac66e74579854b50b508d3e2"
+      "sha256": "618a9e97cf3b641762b979682a2b9f143b22bfb515049bbd77062cf5f1b50574"
     },
     {
       "path": "self_check.json",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/sources.json
@@ -293,7 +293,8 @@
         "culture content provenance"
       ],
       "not_usable_for": [
-        "substitute for legal review"
+        "substitute for legal review",
+        "complete rights clearance"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- clarify that AI-content labeling rules do not constitute complete rights clearance
- refresh the source-registry manifest hash

## Validation
- deterministic validation: PASS
- self-check: `formal-review-ready`
- manifest: 47/47 non-manifest hashes match
- scope and whitespace checks: PASS

No rights clearance, approval, funding, partner, metric, geometry, operation, or test result was added.