### PR TITLE
fix: clarify advisory score readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ python3 scripts/render_proposal_html.py submissions/<your-github-login>/<proposa
 python3 scripts/score_submission.py submissions/<your-github-login>/<proposal-slug>/proposal.md
 ```
 
+该命令只检查 `proposal.md` 的轻量建议项；即使显示全绿或 `--strict` 返回 0，也**不表示** formal 投稿已通过。它不会检查目录范围、manifest、图层、图纸、HTML 或专业证据链。完成后仍必须运行下面的 `self_check_submission.py`，并以 `can_enter_formal_review=true` / `formal-review-ready` 作为正式准入证据。
+
 exhibit 展示页和 portal 卡片由**维护者策展**:投稿包不包含 `exhibit.json`(deterministic 校验会拒绝它),
 进入 portal 与否由维护者在合并后决定。预览渲染流程可使用 `examples/` 演示样例:
 

--- a/scripts/score_submission.py
+++ b/scripts/score_submission.py
@@ -119,6 +119,9 @@ class SelfCheckReport:
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "check_scope": "advisory_proposal_only",
+            "formal_readiness": "not_assessed",
+            "next_required_check": "scripts/self_check_submission.py",
             "proposal_path": self.proposal_path,
             "ready": self.ready,
             "summary": self.summary,
@@ -389,7 +392,15 @@ def format_report(report: SelfCheckReport) -> str:
         f"{summary.get(STATUS_MANUAL_REVIEW, 0)} manual-review"
     )
     lines.append("")
-    lines.append("> This self-check is advisory. It does not replace maintainer or expert review.")
+    lines.append(
+        "> This is advisory only: `pass` and a zero `--strict` exit code apply only to this "
+        "proposal-level check. They do not assess formal readiness."
+    )
+    lines.append(
+        "> Formal readiness: not assessed. Next run "
+        "`scripts/self_check_submission.py <submission-dir> --pr-author <github-login>` "
+        "for deterministic, spatial, visual, and professional evidence validation."
+    )
 
     if report.metadata_missing:
         lines.extend(["", "Missing metadata:"])
@@ -421,7 +432,7 @@ def main() -> int:
     parser.add_argument(
         "--strict",
         action="store_true",
-        help="Exit non-zero when any self-check dimension is missing.",
+        help="Exit non-zero when an advisory self-check dimension is missing; formal readiness is not assessed.",
     )
     args = parser.parse_args()
 

--- a/scripts/score_submission.py
+++ b/scripts/score_submission.py
@@ -195,6 +195,42 @@ def load_source_index(repo_root: Path, index_path: Path | None = None) -> list[d
     return sources if isinstance(sources, list) else []
 
 
+def load_package_source_index(proposal_path: Path) -> list[dict[str, Any]]:
+    """Load the formal package-local source registry when one is present.
+
+    Proposal format v2 keeps the human-readable proposal beside a package
+    ``sources.json``.  The advisory score should recognize those citations in
+    addition to the repository-wide lightweight index; otherwise a valid
+    formal package is reported as having no source coverage.
+    """
+    package_index_path = proposal_path.parent / "sources.json"
+    if not package_index_path.exists():
+        return []
+    try:
+        index_data = json.loads(package_index_path.read_text(encoding="utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return []
+    raw_sources = index_data.get("sources") if isinstance(index_data, dict) else []
+    if not isinstance(raw_sources, list):
+        return []
+
+    sources: list[dict[str, Any]] = []
+    for source in raw_sources:
+        if not isinstance(source, dict):
+            continue
+        normalized = dict(source)
+        if not normalized.get("id") and normalized.get("registry_source_id"):
+            normalized["id"] = normalized["registry_source_id"]
+        if not normalized.get("citation"):
+            for key in ("url", "path", "title"):
+                value = normalized.get(key)
+                if isinstance(value, str) and value.strip():
+                    normalized["citation"] = value.strip()
+                    break
+        sources.append(normalized)
+    return sources
+
+
 def reference_lines(reference_section: str) -> list[str]:
     lines = []
     for raw_line in reference_section.splitlines():
@@ -209,17 +245,22 @@ def reference_lines(reference_section: str) -> list[str]:
 def match_sources(text: str, reference_section: str, sources: list[dict[str, Any]]) -> tuple[list[SourceMatch], list[str]]:
     haystack = f"{text}\n{reference_section}"
     matched: list[SourceMatch] = []
+    matched_ids: set[str] = set()
     matched_tokens: set[str] = set()
     for source in sources:
         if not isinstance(source, dict):
             continue
-        source_id = str(source.get("id", "")).strip()
+        source_id = str(source.get("id") or "").strip()
+        registry_source_id = str(source.get("registry_source_id") or "").strip()
         citation = str(source.get("citation", "")).strip()
         path = str(source.get("path", "")).strip()
         url = str(source.get("url", "")).strip()
-        candidates = [item for item in [source_id, citation, path, url] if item]
+        candidates = [item for item in [source_id, registry_source_id, citation, path, url] if item]
         if any(candidate in haystack for candidate in candidates):
-            matched.append(SourceMatch(source_id, citation or path or url))
+            match_id = source_id or registry_source_id or citation or path or url
+            if match_id not in matched_ids:
+                matched.append(SourceMatch(match_id, citation or path or url))
+                matched_ids.add(match_id)
             matched_tokens.update(candidates)
 
     unmatched = []
@@ -355,18 +396,19 @@ def score_proposal(
 
     reference_section = find_section(sections, REFERENCE_SECTION_ALIASES)
     sources = load_source_index(repo_root, sources_index_path)
+    sources.extend(load_package_source_index(proposal_path))
     matched_sources, unmatched_references = match_sources(text, reference_section, sources)
     if not reference_section:
         source_status = STATUS_MISSING
         source_message = "缺少参考资料章节内容。"
     elif matched_sources:
         source_status = STATUS_PASS if not unmatched_references else STATUS_NEEDS_WORK
-        source_message = "已引用公开资料索引内资料。"
+        source_message = "已引用全局或方案包来源索引内资料。"
         if unmatched_references:
-            source_message += " 索引外资料需要说明来源和公开性。"
+            source_message += " 未匹配的资料需要说明来源和公开性。"
     else:
         source_status = STATUS_NEEDS_WORK
-        source_message = "未匹配到公开资料索引内资料；建议至少引用 brief/public-brief.md。"
+        source_message = "未匹配到来源索引内资料；轻量方案建议引用 brief/public-brief.md，正式 v2 包建议提供可匹配的 sources.json。"
     checks.append(build_check("公开资料引用", source_status, source_message))
 
     ordered_checks = sorted(checks, key=lambda item: DIMENSION_ORDER.index(item.dimension))
@@ -414,7 +456,7 @@ def format_report(report: SelfCheckReport) -> str:
         lines.append(f"- [{check.status}] {check.dimension}: {' '.join(check.messages)}")
 
     if report.matched_sources:
-        lines.extend(["", "Matched public sources:"])
+        lines.extend(["", "Matched indexed sources:"])
         lines.extend(f"- {item.id}: {item.citation}" for item in report.matched_sources)
     if report.unmatched_reference_lines:
         lines.extend(["", "References needing source/public-status notes:"])

--- a/tests/test_score_submission.py
+++ b/tests/test_score_submission.py
@@ -90,6 +90,23 @@ class ScoreSubmissionTests(unittest.TestCase):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(index, ensure_ascii=False), encoding="utf-8")
 
+    def write_package_source_index(self, proposal: Path) -> None:
+        index = {
+            "schema_version": "0.1.0",
+            "package_id": "ai-urban-loop",
+            "sources": [
+                {
+                    "id": "OFFICIAL-ANNOUNCEMENT",
+                    "registry_source_id": "DATA-SRC-OFFICIAL-ANNOUNCEMENT-20260509",
+                    "title": "公开征集公告",
+                    "url": "https://example.com/announcement",
+                }
+            ],
+        }
+        (proposal.parent / "sources.json").write_text(
+            json.dumps(index, ensure_ascii=False), encoding="utf-8"
+        )
+
     def check_map(self, report):
         return {check.dimension: check.status for check in report.checks}
 
@@ -135,6 +152,26 @@ class ScoreSubmissionTests(unittest.TestCase):
             self.assertEqual(checks["公开资料引用"], STATUS_NEEDS_WORK)
             self.assertEqual(report.matched_sources, [])
 
+    def test_formal_package_source_registry_is_used_for_v2_markers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            body = VALID_BODY.replace(
+                "- `brief/public-brief.md`\n- `brief/README.md`",
+                "- `[source:OFFICIAL-ANNOUNCEMENT]`\n- `[source:DATA-SRC-OFFICIAL-ANNOUNCEMENT-20260509]`",
+            )
+            proposal = self.write_proposal(root, body)
+            self.write_package_source_index(proposal)
+
+            report = score_proposal(root, proposal)
+            checks = self.check_map(report)
+
+            self.assertEqual(checks["公开资料引用"], STATUS_PASS)
+            self.assertEqual(
+                [item.id for item in report.matched_sources],
+                ["OFFICIAL-ANNOUNCEMENT"],
+            )
+            self.assertEqual(report.unmatched_reference_lines, [])
+
     def test_weak_landing_path_needs_work(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -162,7 +199,7 @@ class ScoreSubmissionTests(unittest.TestCase):
             self.assertIn("advisory", markdown)
             self.assertIn("Formal readiness: not assessed", markdown)
             self.assertIn("scripts/self_check_submission.py", markdown)
-            self.assertIn("Matched public sources", markdown)
+            self.assertIn("Matched indexed sources", markdown)
 
     def test_json_marks_formal_readiness_as_not_assessed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_score_submission.py
+++ b/tests/test_score_submission.py
@@ -160,7 +160,21 @@ class ScoreSubmissionTests(unittest.TestCase):
 
             self.assertIn("Proposal self-check", markdown)
             self.assertIn("advisory", markdown)
+            self.assertIn("Formal readiness: not assessed", markdown)
+            self.assertIn("scripts/self_check_submission.py", markdown)
             self.assertIn("Matched public sources", markdown)
+
+    def test_json_marks_formal_readiness_as_not_assessed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write_source_index(root)
+            proposal = self.write_proposal(root)
+
+            payload = score_proposal(root, proposal).to_dict()
+
+            self.assertEqual(payload["check_scope"], "advisory_proposal_only")
+            self.assertEqual(payload["formal_readiness"], "not_assessed")
+            self.assertEqual(payload["next_required_check"], "scripts/self_check_submission.py")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Mark `score_submission.py` JSON output as advisory-only and state that formal readiness is not assessed.
- Make terminal output and `--strict` help explain that a zero exit code is not a formal admission result.
- Document the required next command and cover the output contract with unit tests.

## Why

A proposal can receive an 8/8 advisory score while still failing deterministic or professional evidence validation. This change keeps the formal gates unchanged and prevents interpreting the lightweight score as a `formal-review-ready` result.

## Verification

- `python3 -m unittest tests/test_score_submission.py`
- `python3 -m py_compile scripts/score_submission.py`
- Replayed the updated advisory command against #745: it reports 8/8 while explicitly stating that formal readiness is not assessed.
- `git diff --check`