### PR TITLE
fix: score v2 package sources by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,10 @@ python3 scripts/render_proposal_html.py submissions/<your-github-login>/<proposa
 python3 scripts/score_submission.py submissions/<your-github-login>/<proposal-slug>/proposal.md
 ```
 
+对 `proposal_format_version: "2"` 的投稿，脚本会自动读取同一投稿目录的
+`sources.json`；可通过 `--sources-index <path>` 显式覆盖。旧格式继续使用
+仓库的公开资料索引。
+
 exhibit 展示页和 portal 卡片由**维护者策展**:投稿包不包含 `exhibit.json`(deterministic 校验会拒绝它),
 进入 portal 与否由维护者在合并后决定。预览渲染流程可使用 `examples/` 演示样例:
 

--- a/scripts/score_submission.py
+++ b/scripts/score_submission.py
@@ -15,7 +15,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from validate_submission import PLACEHOLDERS, extract_headings, parse_front_matter
+from validate_submission import (
+    PLACEHOLDERS,
+    PROPOSAL_FORMAT_VERSION,
+    extract_headings,
+    parse_front_matter,
+)
 
 
 STATUS_PASS = "pass"
@@ -67,6 +72,7 @@ METRIC_TERMS = ["指标", "评估", "满意度", "数量", "比例", "时长", "
 PUBLIC_TERMS = ["居民", "青年", "学生", "企业", "高校", "游客", "无障碍", "包容", "公共", "弱势"]
 RISK_TERMS = ["公开", "非公开", "隐私", "版权", "授权", "复核", "风险", "合规", "涉密", "边界"]
 MANUAL_REVIEW_TERMS = ["内部资料", "内部数据", "非公开空间数据", "未公开图件", "无需审批", "保证落地", "一定实施"]
+DEFAULT_SOURCES_INDEX = Path("sources/public-sources.json")
 
 
 @dataclass
@@ -179,7 +185,7 @@ def status_from_term_count(count: int, pass_at: int = 3, needs_at: int = 1) -> s
 
 
 def load_source_index(repo_root: Path, index_path: Path | None = None) -> list[dict[str, Any]]:
-    index_path = index_path or repo_root / "sources" / "public-sources.json"
+    index_path = index_path or repo_root / DEFAULT_SOURCES_INDEX
     if not index_path.is_absolute():
         index_path = repo_root / index_path
     if not index_path.exists():
@@ -190,6 +196,29 @@ def load_source_index(repo_root: Path, index_path: Path | None = None) -> list[d
         return []
     sources = index_data.get("sources") if isinstance(index_data, dict) else []
     return sources if isinstance(sources, list) else []
+
+
+def resolve_source_index_path(
+    repo_root: Path,
+    proposal_path: Path,
+    metadata: dict[str, str],
+    index_path: Path | None = None,
+) -> Path:
+    """Select the canonical source index without overriding an explicit choice.
+
+    Proposal format v2 stores its complete machine-readable source inventory in
+    the submission package. Earlier formats retain the repository-wide public
+    source index for advisory checks.
+    """
+    if index_path is not None:
+        return index_path
+
+    if metadata.get("proposal_format_version") == PROPOSAL_FORMAT_VERSION:
+        package_index = proposal_path.parent / "sources.json"
+        if package_index.is_file():
+            return package_index
+
+    return repo_root / DEFAULT_SOURCES_INDEX
 
 
 def reference_lines(reference_section: str) -> list[str]:
@@ -351,7 +380,10 @@ def score_proposal(
     checks.append(build_check("表达完整度", completeness_status, completeness_message))
 
     reference_section = find_section(sections, REFERENCE_SECTION_ALIASES)
-    sources = load_source_index(repo_root, sources_index_path)
+    sources = load_source_index(
+        repo_root,
+        resolve_source_index_path(repo_root, proposal_path, metadata, sources_index_path),
+    )
     matched_sources, unmatched_references = match_sources(text, reference_section, sources)
     if not reference_section:
         source_status = STATUS_MISSING
@@ -416,7 +448,10 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("proposal", help="Path to proposal.md")
     parser.add_argument("--repo-root", default=".")
-    parser.add_argument("--sources-index", default="sources/public-sources.json")
+    parser.add_argument(
+        "--sources-index",
+        help="Override the automatically selected source index.",
+    )
     parser.add_argument("--json", action="store_true")
     parser.add_argument(
         "--strict",
@@ -425,7 +460,8 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    report = score_proposal(Path(args.repo_root), Path(args.proposal), Path(args.sources_index))
+    sources_index = Path(args.sources_index) if args.sources_index else None
+    report = score_proposal(Path(args.repo_root), Path(args.proposal), sources_index)
     if args.json:
         print(json.dumps(report.to_dict(), ensure_ascii=False, indent=2))
     else:

--- a/tests/test_score_submission.py
+++ b/tests/test_score_submission.py
@@ -90,6 +90,24 @@ class ScoreSubmissionTests(unittest.TestCase):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(index, ensure_ascii=False), encoding="utf-8")
 
+    def write_sources_index(self, path: Path, source_id: str) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "sources": [
+                        {
+                            "id": source_id,
+                            "citation": f"https://example.org/{source_id.lower()}",
+                        }
+                    ]
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        return path
+
     def check_map(self, report):
         return {check.dimension: check.status for check in report.checks}
 
@@ -134,6 +152,49 @@ class ScoreSubmissionTests(unittest.TestCase):
 
             self.assertEqual(checks["公开资料引用"], STATUS_NEEDS_WORK)
             self.assertEqual(report.matched_sources, [])
+
+    def test_v2_uses_package_source_index_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write_source_index(root)
+            body = VALID_BODY.replace(
+                'license: "CC-BY-4.0"',
+                'license: "CC-BY-4.0"\nproposal_format_version: "2"',
+            ).replace(
+                "- `brief/public-brief.md`\n- `brief/README.md`",
+                "- [source:PACKAGE-PRIMARY]",
+            )
+            proposal = self.write_proposal(root, body)
+            self.write_sources_index(proposal.parent / "sources.json", "PACKAGE-PRIMARY")
+
+            report = score_proposal(root, proposal)
+            checks = self.check_map(report)
+
+            self.assertEqual(checks["公开资料引用"], STATUS_PASS)
+            self.assertEqual({item.id for item in report.matched_sources}, {"PACKAGE-PRIMARY"})
+
+    def test_explicit_source_index_overrides_v2_package_index(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write_source_index(root)
+            body = VALID_BODY.replace(
+                'license: "CC-BY-4.0"',
+                'license: "CC-BY-4.0"\nproposal_format_version: "2"',
+            ).replace(
+                "- `brief/public-brief.md`\n- `brief/README.md`",
+                "- [source:EXPLICIT-PRIMARY]",
+            )
+            proposal = self.write_proposal(root, body)
+            self.write_sources_index(proposal.parent / "sources.json", "PACKAGE-PRIMARY")
+            explicit_index = self.write_sources_index(
+                root / "custom-sources.json", "EXPLICIT-PRIMARY"
+            )
+
+            report = score_proposal(root, proposal, explicit_index)
+            checks = self.check_map(report)
+
+            self.assertEqual(checks["公开资料引用"], STATUS_PASS)
+            self.assertEqual({item.id for item in report.matched_sources}, {"EXPLICIT-PRIMARY"})
 
     def test_weak_landing_path_needs_work(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## What changed

- Automatically use a v2 submission's package-local `sources.json` when no index is specified.
- Preserve the repository-wide public-source index for legacy submissions.
- Preserve `--sources-index` as an explicit override.

## Why

The documented default score command previously read only the legacy global index. A valid v2 submission can keep its complete machine-audit source inventory in its own package, so its `[source:...]` references were reported as unmatched even when the package source checks passed.

## Validation

- `python3 -m unittest tests/test_score_submission.py tests/test_submission_workflow.py` (92 tests)
- `git diff --check`
- Exact-head metadata check against #750 `c197778d40df3e32edafb48aa57aeb152013cd66` selects its package `sources.json`.