### PR TITLE
Support alternate preflight push remotes

### DIFF
--- a/scripts/participant_preflight.py
+++ b/scripts/participant_preflight.py
@@ -77,11 +77,12 @@ def file_inventory(submission_dir: Path) -> tuple[list[dict[str, Any]], int]:
     return files, total
 
 
-def check_push(repo_root: Path, branch: str) -> dict[str, Any]:
-    completed = run(["git", "push", "--dry-run", "origin", f"HEAD:refs/heads/{branch}"], repo_root)
+def check_push(repo_root: Path, branch: str, remote: str = "origin") -> dict[str, Any]:
+    command = ["git", "push", "--dry-run", remote, f"HEAD:refs/heads/{branch}"]
+    completed = run(command, repo_root)
     return {
         "ok": completed.returncode == 0,
-        "command": f"git push --dry-run origin HEAD:refs/heads/{branch}",
+        "command": " ".join(command),
         "stdout": completed.stdout.strip(),
         "stderr": completed.stderr.strip(),
     }
@@ -141,12 +142,21 @@ def inspect(args: argparse.Namespace) -> dict[str, Any]:
 
     origin_url = git_output(repo_root, "remote", "get-url", "origin", allow_failure=True)
     upstream_url = git_output(repo_root, "remote", "get-url", "upstream", allow_failure=True)
-    if not origin_url:
+    push_remote_url = git_output(
+        repo_root,
+        "remote",
+        "get-url",
+        args.push_remote,
+        allow_failure=True,
+    )
+    if not origin_url and args.push_remote == "origin":
         blockers.append("origin remote is missing")
-    elif "open-city-ai/haidian" in origin_url and not args.allow_canonical_origin:
+    if not push_remote_url:
+        blockers.append(f"push remote '{args.push_remote}' is missing")
+    elif "open-city-ai/haidian" in push_remote_url and not args.allow_canonical_origin:
         warnings.append(
-            "origin points to the canonical repository; contributors without write access "
-            "should clone their fork as origin"
+            f"{args.push_remote} points to the canonical repository; contributors without "
+            "write access should select their writable fork remote"
         )
     if origin_url and "open-city-ai/haidian" not in origin_url and not upstream_url:
         warnings.append("fork workspace has no upstream remote for syncing open-city-ai/haidian")
@@ -205,10 +215,13 @@ def inspect(args: argparse.Namespace) -> dict[str, Any]:
             blockers.append("submission self-check failed; repair the reported issues before pushing")
 
     push_check: dict[str, Any] | None = None
-    if args.check_push and branch and origin_url:
-        push_check = check_push(repo_root, branch)
+    if args.check_push and branch and push_remote_url:
+        push_check = check_push(repo_root, branch, args.push_remote)
         if not push_check["ok"]:
-            blockers.append("origin push dry-run failed; authenticate or use a writable fork before uploading")
+            blockers.append(
+                f"{args.push_remote} push dry-run failed; authenticate or select a writable "
+                "fork remote before uploading"
+            )
 
     return {
         "ok": not blockers,
@@ -218,6 +231,8 @@ def inspect(args: argparse.Namespace) -> dict[str, Any]:
         "branch": branch,
         "origin_url": origin_url,
         "upstream_url": upstream_url,
+        "push_remote": args.push_remote,
+        "push_remote_url": push_remote_url,
         "workspace": {
             "partial_clone_filter": partial_filter or None,
             "sparse_checkout": sparse,
@@ -235,7 +250,7 @@ def inspect(args: argparse.Namespace) -> dict[str, Any]:
         "next_commands": [
             f"git add {submission_rel}",
             f'git commit -m "Submit {parts[-1] if parts else "proposal"}"',
-            "git push -u origin HEAD",
+            f"git push -u {args.push_remote} HEAD",
             "gh pr create --repo open-city-ai/haidian --base main",
         ],
     }
@@ -269,7 +284,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--pr-author", required=True)
     parser.add_argument("--repo-root", default=".")
     parser.add_argument("--skip-self-check", action="store_true")
-    parser.add_argument("--check-push", action="store_true", help="Authenticate with origin using git push --dry-run")
+    parser.add_argument(
+        "--check-push",
+        action="store_true",
+        help="Authenticate with the selected push remote using git push --dry-run",
+    )
+    parser.add_argument(
+        "--push-remote",
+        default="origin",
+        help="Remote used by --check-push and the suggested upload command (default: origin)",
+    )
     parser.add_argument(
         "--allow-canonical-origin",
         action="store_true",

--- a/scripts/participant_preflight.py
+++ b/scripts/participant_preflight.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -15,6 +16,16 @@ from typing import Any
 GITHUB_HARD_FILE_LIMIT = 100 * 1024 * 1024
 LARGE_FILE_WARNING = 25 * 1024 * 1024
 LARGE_PACKAGE_WARNING = 200 * 1024 * 1024
+SAFE_REMOTE_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9._/-]*")
+
+
+def validate_remote_name(remote: str) -> str:
+    if not SAFE_REMOTE_NAME.fullmatch(remote):
+        raise RuntimeError(
+            "push remote must start with an ASCII letter or digit and contain only "
+            "ASCII letters, digits, '.', '_', '/', or '-'"
+        )
+    return remote
 
 
 def run(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -78,6 +89,7 @@ def file_inventory(submission_dir: Path) -> tuple[list[dict[str, Any]], int]:
 
 
 def check_push(repo_root: Path, branch: str, remote: str = "origin") -> dict[str, Any]:
+    remote = validate_remote_name(remote)
     command = ["git", "push", "--dry-run", remote, f"HEAD:refs/heads/{branch}"]
     completed = run(command, repo_root)
     return {
@@ -113,6 +125,7 @@ def run_self_check(repo_root: Path, submission_rel: str, pr_author: str) -> dict
 
 
 def inspect(args: argparse.Namespace) -> dict[str, Any]:
+    push_remote = validate_remote_name(args.push_remote)
     requested_root = Path(args.repo_root).expanduser().resolve()
     root_text = git_output(requested_root, "rev-parse", "--show-toplevel")
     repo_root = Path(root_text).resolve()
@@ -146,16 +159,16 @@ def inspect(args: argparse.Namespace) -> dict[str, Any]:
         repo_root,
         "remote",
         "get-url",
-        args.push_remote,
+        push_remote,
         allow_failure=True,
     )
-    if not origin_url and args.push_remote == "origin":
+    if not origin_url and push_remote == "origin":
         blockers.append("origin remote is missing")
     if not push_remote_url:
-        blockers.append(f"push remote '{args.push_remote}' is missing")
+        blockers.append(f"push remote '{push_remote}' is missing")
     elif "open-city-ai/haidian" in push_remote_url and not args.allow_canonical_origin:
         warnings.append(
-            f"{args.push_remote} points to the canonical repository; contributors without "
+            f"{push_remote} points to the canonical repository; contributors without "
             "write access should select their writable fork remote"
         )
     if origin_url and "open-city-ai/haidian" not in origin_url and not upstream_url:
@@ -216,10 +229,10 @@ def inspect(args: argparse.Namespace) -> dict[str, Any]:
 
     push_check: dict[str, Any] | None = None
     if args.check_push and branch and push_remote_url:
-        push_check = check_push(repo_root, branch, args.push_remote)
+        push_check = check_push(repo_root, branch, push_remote)
         if not push_check["ok"]:
             blockers.append(
-                f"{args.push_remote} push dry-run failed; authenticate or select a writable "
+                f"{push_remote} push dry-run failed; authenticate or select a writable "
                 "fork remote before uploading"
             )
 
@@ -231,7 +244,7 @@ def inspect(args: argparse.Namespace) -> dict[str, Any]:
         "branch": branch,
         "origin_url": origin_url,
         "upstream_url": upstream_url,
-        "push_remote": args.push_remote,
+        "push_remote": push_remote,
         "push_remote_url": push_remote_url,
         "workspace": {
             "partial_clone_filter": partial_filter or None,
@@ -250,7 +263,7 @@ def inspect(args: argparse.Namespace) -> dict[str, Any]:
         "next_commands": [
             f"git add {submission_rel}",
             f'git commit -m "Submit {parts[-1] if parts else "proposal"}"',
-            f"git push -u {args.push_remote} HEAD",
+            f"git push -u {push_remote} HEAD",
             "gh pr create --repo open-city-ai/haidian --base main",
         ],
     }

--- a/skills/urban-design-ai-submission/references/lightweight-workspace.md
+++ b/skills/urban-design-ai-submission/references/lightweight-workspace.md
@@ -120,4 +120,20 @@ python3 scripts/participant_preflight.py \
   --check-push
 ```
 
+Legacy checkouts may name the canonical repository `origin` and the writable
+participant fork `fork`. Keep that layout if other tooling depends on it and
+select the upload target explicitly:
+
+```bash
+python3 scripts/participant_preflight.py \
+  submissions/<github-login>/<proposal-slug> \
+  --pr-author <github-login> \
+  --check-push \
+  --push-remote fork
+```
+
+`--push-remote` controls both the dry-run authentication check and the upload
+command printed after a successful preflight. It defaults to `origin` for
+workspaces created by the current bootstrap helper.
+
 The preflight checks the branch, proposal ownership, PR file scope, GitHub's 100 MiB per-file limit, package size, partial/sparse workspace configuration, fork/upstream remotes, contributor self-check, and optional push authentication. Repair every blocker before uploading.

--- a/skills/urban-design-ai-submission/references/lightweight-workspace.md
+++ b/skills/urban-design-ai-submission/references/lightweight-workspace.md
@@ -134,6 +134,9 @@ python3 scripts/participant_preflight.py \
 
 `--push-remote` controls both the dry-run authentication check and the upload
 command printed after a successful preflight. It defaults to `origin` for
-workspaces created by the current bootstrap helper.
+workspaces created by the current bootstrap helper. Remote names must start
+with an ASCII letter or digit and contain only ASCII letters, digits, `.`, `_`,
+`/`, or `-`. Option-like names, whitespace, shell metacharacters, and control
+characters are rejected before Git runs.
 
 The preflight checks the branch, proposal ownership, PR file scope, GitHub's 100 MiB per-file limit, package size, partial/sparse workspace configuration, fork/upstream remotes, contributor self-check, and optional push authentication. Repair every blocker before uploading.

--- a/tests/test_participant_preflight.py
+++ b/tests/test_participant_preflight.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import os
 import subprocess
 import sys
@@ -75,6 +76,59 @@ class ParticipantPreflightEncodingTests(unittest.TestCase):
         self.assertEqual("1", kwargs["env"]["PYTHONUTF8"])
         self.assertEqual("utf-8", kwargs["env"]["PYTHONIOENCODING"])
         self.assertEqual(completed.stdout, "海淀规划\n")
+
+
+class ParticipantPreflightPushRemoteTests(unittest.TestCase):
+    def test_check_push_uses_selected_remote(self) -> None:
+        completed = subprocess.CompletedProcess(
+            ["git", "push"],
+            0,
+            stdout="Everything up-to-date\n",
+            stderr="",
+        )
+        with patch.object(participant_preflight, "run", return_value=completed) as mocked:
+            report = participant_preflight.check_push(
+                REPO_ROOT,
+                "submission/alice/example",
+                "fork",
+            )
+
+        mocked.assert_called_once_with(
+            [
+                "git",
+                "push",
+                "--dry-run",
+                "fork",
+                "HEAD:refs/heads/submission/alice/example",
+            ],
+            REPO_ROOT,
+        )
+        self.assertTrue(report["ok"])
+        self.assertEqual(
+            report["command"],
+            "git push --dry-run fork HEAD:refs/heads/submission/alice/example",
+        )
+
+    def test_cli_accepts_push_remote(self) -> None:
+        report = {"ok": True, "blockers": [], "warnings": []}
+        with (
+            patch.object(participant_preflight, "inspect", return_value=report) as mocked,
+            patch("sys.stdout", new_callable=io.StringIO),
+        ):
+            returncode = participant_preflight.main(
+                [
+                    "submissions/alice/example",
+                    "--pr-author",
+                    "alice",
+                    "--check-push",
+                    "--push-remote",
+                    "fork",
+                    "--json",
+                ]
+            )
+
+        self.assertEqual(returncode, 0)
+        self.assertEqual(mocked.call_args.args[0].push_remote, "fork")
 
 
 if __name__ == "__main__":

--- a/tests/test_participant_preflight.py
+++ b/tests/test_participant_preflight.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import json
 import os
 import subprocess
 import sys
@@ -129,6 +130,34 @@ class ParticipantPreflightPushRemoteTests(unittest.TestCase):
 
         self.assertEqual(returncode, 0)
         self.assertEqual(mocked.call_args.args[0].push_remote, "fork")
+
+    def test_cli_rejects_unsafe_push_remote_before_git_call(self) -> None:
+        unsafe_remotes = (
+            "--upload-pack=touch-pwned",
+            "fork;echo-unsafe",
+            "fork\nunsafe",
+        )
+
+        for remote in unsafe_remotes:
+            with (
+                self.subTest(remote=remote),
+                patch.object(participant_preflight, "git_output") as mocked_git,
+                patch("sys.stdout", new_callable=io.StringIO) as stdout,
+            ):
+                returncode = participant_preflight.main(
+                    [
+                        "submissions/alice/example",
+                        "--pr-author",
+                        "alice",
+                        f"--push-remote={remote}",
+                        "--json",
+                    ]
+                )
+
+                mocked_git.assert_not_called()
+                self.assertEqual(returncode, 1)
+                report = json.loads(stdout.getvalue())
+                self.assertIn("push remote must start", report["blockers"][0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add `--push-remote` to `participant_preflight.py`, defaulting to `origin`
- use the selected remote for both `git push --dry-run` and the suggested upload command
- validate that the selected remote exists and report its URL in JSON output
- document the legacy `origin=canonical` / `fork=writable` workspace layout
- add focused CLI and command-construction regression tests

## Why

The current preflight hard-codes `origin` for its push-access check. Existing participant workspaces may legitimately keep the canonical repository as `origin` and the writable participant fork as `fork`. Those workspaces pass every package check but receive a false upload blocker until the user renames remotes.

An explicit remote is deterministic and avoids probing or guessing which configured remote should receive the branch. The default remains `origin`, so workspaces created by the current bootstrap helper are unchanged.

## Validation

- `python3 -m unittest tests.test_participant_preflight` — 6 passed
- `python3 -m unittest tests.test_participant_preflight tests.test_lightweight_participant_flow tests.test_site_package_contract` — 21 passed
- real `git push --dry-run` through a temporary alternate remote — PASS; no remote branch created
- `python3 -m unittest discover -s tests` — 236/241 passed
- the five failures are generated-gallery freshness/count checks and reproduce unchanged in a clean `upstream/main` worktree
- `python3 -m py_compile scripts/participant_preflight.py tests/test_participant_preflight.py` — PASS
- `git diff --check` — PASS

## Scope

This changes only the participant preflight, its focused tests, and the lightweight-workspace documentation. It does not modify any submission package or generated gallery data.
