### PR TITLE
fix: reject materially underfilled PDF boards in visual review

### DIFF
--- a/requirements-review.txt
+++ b/requirements-review.txt
@@ -1,4 +1,5 @@
 jsonschema>=4.0
 Pillow>=10.0
+PyMuPDF>=1.24
 pyproj>=3.0
 shapely>=2.0

--- a/scripts/self_check_submission.py
+++ b/scripts/self_check_submission.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 
-REVIEW_DEPENDENCIES = ("shapely", "pyproj", "jsonschema")
+REVIEW_DEPENDENCIES = ("shapely", "pyproj", "jsonschema", "fitz")
 INSTALL_HINT = "python3 -m pip install -r requirements-review.txt"
 SCRIPT_DIR = Path(__file__).resolve().parent
 

--- a/scripts/visual_review.py
+++ b/scripts/visual_review.py
@@ -16,6 +16,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+try:
+    import fitz
+except ImportError:  # pragma: no cover - exercised through the dependency report
+    fitz = None
+
 
 REQUIRED_TEXT_MARKERS = [
     "总览地图",
@@ -34,6 +39,10 @@ REQUIRED_TEXT_MARKERS = [
     "假设",
 ]
 REQUIRED_METRICS = ["site_area_sqm", "green_ratio", "public_space_ratio"]
+DRAWING_COVERAGE_THRESHOLDS = {
+    "a0-boards.pdf": 0.05,
+    "a3-booklet.pdf": 0.03,
+}
 FORBIDDEN_PATTERNS = [
     (re.compile(r"<iframe\b", re.I), "HTML must not contain iframe embeds"),
     (re.compile(r"<form\b", re.I), "HTML must not contain form submission UI"),
@@ -102,6 +111,74 @@ def extract_visual_metrics(text: str) -> dict[str, float]:
     return metrics
 
 
+def page_nonwhite_ratio(page: Any, scale: float = 0.2) -> float:
+    """Estimate how much of a PDF page contains visible ink or artwork.
+
+    This is intentionally a coarse screening signal, not a legibility score.
+    Rendering at a small scale keeps the check bounded while still catching a
+    valid PDF whose board is effectively blank.
+    """
+    pixmap = page.get_pixmap(matrix=fitz.Matrix(scale, scale), alpha=False)
+    samples = pixmap.samples
+    channels = pixmap.n
+    visible = 0
+    for offset in range(0, len(samples), channels):
+        if min(samples[offset : offset + channels]) < 245:
+            visible += 1
+    total = pixmap.width * pixmap.height
+    return visible / total if total else 0.0
+
+
+def review_drawing_coverage(submission_dir: Path, report: VisualReport) -> None:
+    """Reject only clearly under-filled drawing pages, leaving fine legibility to human review."""
+    drawing_dir = submission_dir / "drawings"
+    drawing_paths = sorted(drawing_dir.glob("*.pdf"))
+    if not drawing_paths:
+        return
+    if fitz is None:
+        report.add(
+            "VISUAL_PDF_COVERAGE_UNAVAILABLE",
+            "advisory",
+            "drawings",
+            "Install PyMuPDF from requirements-review.txt to run the coarse PDF page-coverage check.",
+        )
+        return
+
+    for path in drawing_paths:
+        threshold = next(
+            (
+                value
+                for name, value in DRAWING_COVERAGE_THRESHOLDS.items()
+                if path.name.endswith(name)
+            ),
+            None,
+        )
+        if threshold is None:
+            continue
+        try:
+            document = fitz.open(path)
+        except Exception as exc:  # pragma: no cover - malformed-PDF handling varies by fitz version
+            report.add(
+                "VISUAL_PDF_READ_ERROR",
+                "major",
+                path.relative_to(submission_dir).as_posix(),
+                f"Unable to render PDF for page-coverage review: {exc}",
+            )
+            continue
+        try:
+            for index, page in enumerate(document, start=1):
+                ratio = page_nonwhite_ratio(page)
+                if ratio < threshold:
+                    report.add(
+                        "VISUAL_DRAWING_PAGE_COVERAGE",
+                        "major",
+                        path.relative_to(submission_dir).as_posix(),
+                        f"Page {index} has only {ratio:.1%} visible coverage; expand the board's maps, diagrams, and explanatory modules before review (minimum coarse threshold {threshold:.1%}).",
+                    )
+        finally:
+            document.close()
+
+
 def review_visual(submission_dir: Path) -> VisualReport:
     report = VisualReport()
     index_path = submission_dir / "visual" / "index.html"
@@ -153,6 +230,7 @@ def review_visual(submission_dir: Path) -> VisualReport:
                 display_path,
                 f"HTML metric `{name}` value {declared[name]} does not match metrics.json value {expected}.",
             )
+    review_drawing_coverage(submission_dir, report)
     return report
 
 

--- a/tests/test_visual_review.py
+++ b/tests/test_visual_review.py
@@ -1,4 +1,5 @@
 import json
+import importlib.util
 import sys
 import tempfile
 import unittest
@@ -9,6 +10,11 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from visual_review import review_visual  # noqa: E402
+
+
+HAS_FITZ = importlib.util.find_spec("fitz") is not None
+if HAS_FITZ:
+    import fitz  # noqa: E402
 
 
 VALID_HTML = """<!doctype html>
@@ -83,6 +89,23 @@ class VisualReviewTests(unittest.TestCase):
             report = review_visual(submission)
             self.assertFalse(report.ok)
             self.assertIn("VISUAL_METRIC_MISMATCH", {issue.check_id for issue in report.issues})
+
+    @unittest.skipUnless(HAS_FITZ, "PyMuPDF is required for PDF coverage checks")
+    def test_sparse_a0_board_fails_coarse_coverage_check(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_valid_visual_package(Path(tmp))
+            drawings = submission / "drawings"
+            drawings.mkdir()
+            document = fitz.open()
+            page = document.new_page(width=2384, height=3370)
+            page.draw_rect(fitz.Rect(40, 40, 120, 120), color=(0, 0, 0), fill=(0, 0, 0))
+            document.save(drawings / "a0-boards.pdf")
+            document.close()
+
+            report = review_visual(submission)
+
+            self.assertFalse(report.ok)
+            self.assertIn("VISUAL_DRAWING_PAGE_COVERAGE", {issue.check_id for issue in report.issues})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

Current PR #749 has a valid two-page A0 PDF, but page 1 contains only about 3.7% visible ink/artwork and is effectively unreadable at board scale. The existing visual review checked HTML safety and metric consistency, but never inspected the drawing PDFs.

## What changed

- Add an optional PyMuPDF review dependency.
- Render primary `a0-boards.pdf` and `a3-booklet.pdf` pages at low resolution and calculate coarse non-white coverage.
- Fail clearly underfilled pages with `VISUAL_DRAWING_PAGE_COVERAGE`; malformed PDFs fail with a separate read error.
- Keep the check bounded and explicitly coarse: it is a page-occupancy screen, not a substitute for human legibility review.
- Surface the dependency in contributor self-check installation guidance.

## Evidence

- Exact local reproduction against #749 head: `a0-boards.pdf`, page 1 = 3.7% coverage, threshold = 5.0%, deterministic failure.
- Focused tests: `107 passed`.
- `py_compile` and `git diff --check` pass.
- Full suite: `235 passed, 5 failed`; the five failures are the current upstream stale generated-gallery data checks (`submissions-data.js` / gallery count), unrelated to this patch.

The trusted PR workflow remains unchanged; this is a maintainer/contributor visual-review gate and does not claim to replace manual review.