### PR TITLE
fix: mark drawing PDFs as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# PDF streams can be valid ASCII85 text. Keep them out of textual diffs and
+# whitespace checks so contributors receive feedback about source files only.
+*.pdf binary


### PR DESCRIPTION
## What changed

- Add `.gitattributes` with `*.pdf binary`.

## Why

Valid drawing PDFs can contain ASCII85 streams, which Git otherwise treats as text. As a result, `git diff --check` reports hundreds of false trailing-whitespace findings from binary PDF bytes, obscuring real source-file errors for participants and reviewers.

## Validation

- `git check-attr -a -- drawings/a0-boards.pdf` confirms `binary: set`, `diff: unset`, `merge: unset`, and `text: unset`.
- Replayed the complete PDF-heavy diff from PR #754: `git diff --check upstream/main...upstream/pr-754` now returns zero output and exit 0.
- `git diff --cached --check` passes.

This only changes Git attributes; it does not alter submitted PDFs or review policy.