### PR TITLE
fix: refresh manifest hashes for ready packages

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -64,6 +64,8 @@
 python3 -m pip install -r requirements-review.txt
 python3 scripts/render_proposal_html.py submissions/<my-github-login>/<proposal-slug>
 python3 scripts/finalize_submission.py submissions/<my-github-login>/<proposal-slug>
+# 若 finalization 后改动任一 manifest 已列出文件：
+python3 scripts/finalize_submission.py submissions/<my-github-login>/<proposal-slug> --refresh-manifest
 python3 scripts/self_check_submission.py submissions/<my-github-login>/<proposal-slug> --pr-author <my-github-login>
 python3 scripts/participant_preflight.py submissions/<my-github-login>/<proposal-slug> --pr-author <my-github-login> --check-push
 ```

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ python3 scripts/scaffold_ai_submission.py \
 ```
 
 7. 按 formal 模板完善 `proposal.md`、图纸、HTML 可视化、合规矩阵、标准矩阵、深度矩阵和自检结果。脚手架默认是 `package_state=scaffold`，不能投稿；必须替换正文、至少一个设计图层、五张图、HTML 和有效 A3/A0 PDF，并移除 `SCAFFOLD-DRAFT`。每次手动修改 `proposal.md` 后，重新生成 `report/proposal.html`。
-8. 运行 `python3 scripts/finalize_submission.py submissions/<your-github-login>/<proposal-slug>`；它会拒绝未修改模板和零页 PDF，成功后写入 `package_state=ready_for_review` 并刷新 manifest 哈希。随后运行一键自检，修复到 PASS 后发起 Pull Request。PR 作者只能修改自己 GitHub 用户名对应的目录。
+8. 运行 `python3 scripts/finalize_submission.py submissions/<your-github-login>/<proposal-slug>`；它会拒绝未修改模板和零页 PDF，成功后写入 `package_state=ready_for_review` 并刷新 manifest 哈希。若之后改动任一 manifest 已列出的成果，重新生成相应派生文件后运行 `python3 scripts/finalize_submission.py submissions/<your-github-login>/<proposal-slug> --refresh-manifest`，再运行一键自检。刷新哈希不替代内容校验。修复到 PASS 后发起 Pull Request。PR 作者只能修改自己 GitHub 用户名对应的目录。
    - 发起 PR 前运行 `python3 scripts/participant_preflight.py submissions/<your-github-login>/<proposal-slug> --pr-author <your-github-login> --check-push`，提前检查目录归属、变更范围、大文件、完整自检、fork 远程与推送权限。
 9. 发起 PR 后必须持续监控 CI、评审评论、合并队列和状态变化。审核通常实时启动，但繁忙时可能排队；上传完成不等于任务结束。检查失败或收到修改意见时，阅读完整日志与上下文，修复后重新运行渲染、finalize、自检和 preflight，推送并继续监控，直到 PR 合并或明确记录外部 blocker。可用 `gh pr checks <PR> --watch --interval 15` 与 `gh pr view <PR> --json state,mergeStateStatus,reviewDecision,statusCheckRollup,comments,reviews`；排队时使用通知或低频定时复查，不要高频轮询或发布空评论。
 10. 方案合并到 `main` 后会自动进入公开展示页。`gallery-publication.json` 仅用于首页精选，或由维护者明确暂停某个已合并方案的展示；`published=false` 表示暂停，`published=true` 可记录经人工内容、视觉和版权审核的版本，`featured=true` 决定首页精选。然后运行 `scripts/generate_submissions_data.py`；参赛者不得修改该清单或 `submissions-data.js`。

--- a/scripts/finalize_submission.py
+++ b/scripts/finalize_submission.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Promote a materially edited scaffold to a review-ready submission package."""
+"""Finalize a scaffold or refresh a ready package's declared artifact hashes."""
 
 from __future__ import annotations
 
@@ -41,16 +41,69 @@ def digest(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def refresh_manifest_hashes(root: Path, manifest: dict) -> int:
+    """Refresh only declared artifacts, never the manifest itself."""
+    files = manifest.get("files")
+    if not isinstance(files, list):
+        raise ValueError("manifest.json: files must be a list before hashes can be refreshed")
+
+    declared: list[tuple[dict, Path]] = []
+    errors: list[str] = []
+    for index, item in enumerate(files):
+        if not isinstance(item, dict):
+            errors.append(f"manifest.json: files[{index}] must be an object")
+            continue
+        rel = item.get("path")
+        if not isinstance(rel, str) or not rel.strip():
+            errors.append(f"manifest.json: files[{index}].path must be a non-empty string")
+            continue
+        relative_path = Path(rel)
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            errors.append(f"manifest.json: files[{index}].path must stay inside the submission package")
+            continue
+        if rel == "manifest.json":
+            continue
+        artifact = root / relative_path
+        if not artifact.is_file():
+            errors.append(f"manifest.json: declared artifact is missing: {rel}")
+            continue
+        declared.append((item, artifact))
+
+    if errors:
+        raise ValueError("\n".join(errors))
+    for item, artifact in declared:
+        item["sha256"] = digest(artifact)
+    return len(declared)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("submission_dir")
+    parser.add_argument(
+        "--refresh-manifest",
+        action="store_true",
+        help="refresh hashes for a ready_for_review package after its declared artifacts change",
+    )
     args = parser.parse_args()
     root = Path(args.submission_dir).resolve()
     manifest_path = root / "manifest.json"
     if not manifest_path.is_file():
         parser.error(f"manifest.json not found under {root}")
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    if manifest.get("package_state") != "scaffold":
+    package_state = manifest.get("package_state")
+    if args.refresh_manifest:
+        if package_state != "ready_for_review":
+            parser.error("--refresh-manifest requires package_state=ready_for_review")
+        try:
+            refreshed = refresh_manifest_hashes(root, manifest)
+        except ValueError as exc:
+            parser.error(str(exc))
+        manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        print(f"Refreshed {refreshed} manifest artifact hashes: {root}")
+        print("Run self_check_submission.py now. Refreshing hashes does not validate package content.")
+        return 0
+
+    if package_state != "scaffold":
         parser.error("package_state must be scaffold before finalization")
 
     declared = {
@@ -166,12 +219,10 @@ def main() -> int:
                 translated_item["language"] = translation_language
                 translated_item["translation_of"] = rel
                 translated_item["required"] = strict_bilingual
-    for item in manifest_files:
-        if not isinstance(item, dict):
-            continue
-        rel = item.get("path")
-        if rel and rel != "manifest.json" and (root / rel).is_file():
-            item["sha256"] = digest(root / rel)
+    try:
+        refresh_manifest_hashes(root, manifest)
+    except ValueError as exc:
+        parser.error(str(exc))
     manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     print(f"Review-ready package: {root}")
     print("Run self_check_submission.py now. Any later file edit requires refreshed manifest hashes and another full validation.")

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -127,6 +127,20 @@ def complete_scaffold(output_dir: Path) -> subprocess.CompletedProcess:
     )
 
 
+def refresh_manifest(output_dir: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "finalize_submission.py"),
+            str(output_dir),
+            "--refresh-manifest",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
 def projected_area(geometry: dict) -> float:
     transformer = Transformer.from_crs("EPSG:4326", "EPSG:4548", always_xy=True)
     return float(transform(transformer.transform, shape(geometry)).area)
@@ -349,6 +363,48 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
             )
             self.assertEqual(rerun.returncode, 0, rerun.stdout + rerun.stderr)
             self.assertTrue(json.loads(rerun.stdout)["can_enter_formal_review"])
+
+    def test_ready_package_can_refresh_declared_artifact_hashes_after_a_revision(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_official_site_package(root)
+            submission_dir = root / "submissions" / "alice" / "topology-pass"
+            self.assertEqual(run_scaffold(submission_dir, cwd=root).returncode, 0)
+            finalized = complete_scaffold(submission_dir)
+            self.assertEqual(finalized.returncode, 0, finalized.stdout + finalized.stderr)
+
+            proposal = submission_dir / "proposal.md"
+            proposal.write_text(proposal.read_text(encoding="utf-8") + "\nRevision after review.\n", encoding="utf-8")
+            refreshed = refresh_manifest(submission_dir)
+            self.assertEqual(refreshed.returncode, 0, refreshed.stdout + refreshed.stderr)
+
+            rerun = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "self_check_submission.py"),
+                    str(submission_dir),
+                    "--repo-root",
+                    str(root),
+                    "--pr-author",
+                    "alice",
+                    "--json",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(rerun.returncode, 0, rerun.stdout + rerun.stderr)
+            self.assertTrue(json.loads(rerun.stdout)["can_enter_formal_review"])
+
+    def test_refresh_manifest_rejects_a_scaffold(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_official_site_package(root)
+            submission_dir = root / "submissions" / "alice" / "topology-pass"
+            self.assertEqual(run_scaffold(submission_dir, cwd=root).returncode, 0)
+            refreshed = refresh_manifest(submission_dir)
+            self.assertNotEqual(refreshed.returncode, 0)
+            self.assertIn("requires package_state=ready_for_review", refreshed.stderr)
 
     def test_scaffold_does_not_emit_contributor_exhibit(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- add an explicit --refresh-manifest mode for ready_for_review packages
- reject incomplete or unsafe manifest paths before writing any refreshed hash
- document the post-finalization workflow and cover it with regression tests

## Verification

- python3 -m unittest discover -s tests -p test_agent_scaffold_and_self_check.py -v
- python3 -m pytest -q  # 247 passed
- end-to-end regression against exact failed #375 head 0ff2a91: refreshed 29 declared hashes, then full self-check returned ok=true and can_enter_formal_review=true; remaining notices were non-blocking legacy or review warnings

This addresses the reproducible failure mode where a legitimate follow-up edit leaves every declared manifest SHA-256 stale, while the normal finalization command correctly refuses non-scaffold packages.