### PR TITLE
fix: reject unverified visual metric claims

### DIFF
--- a/docs/formal-submission-guide.md
+++ b/docs/formal-submission-guide.md
@@ -443,6 +443,8 @@ HTML 是必交电子展示页面，用于让评审者快速看懂方案。它不
 
 核心指标必须用 `data-metric` 和 `data-value` 标记，便于 `scripts/visual_review.py` 与 `metrics.json` 对比：
 
+每一个带数值的 `data-metric` 都必须对应 `metrics.json` 中 `status="known"` 且具有数值 `value` 的指标，并且数值必须一致。`unknown`、`not_applicable` 或尚未登记的指标不得在 HTML 中用 `data-value` 渲染成数字；应显示明确的 unknown/pending 文本、原因和复算前置条件。视觉审查会把这类数值声明判为阻断问题，防止单独截屏或摘录后被误读为正式控规或已知事实。
+
 ```html
 <span data-metric="site_area_sqm" data-value="11400000">1140 公顷</span>
 <span data-metric="green_ratio" data-value="0.23">23%</span>

--- a/scripts/visual_review.py
+++ b/scripts/visual_review.py
@@ -91,11 +91,13 @@ def load_metrics(path: Path) -> dict[str, Any]:
 
 
 class VisualMetricParser(HTMLParser):
-    """Collect explicit metric declarations without depending on attribute order."""
+    """Collect numeric metric declarations without depending on attribute order."""
 
     def __init__(self) -> None:
         super().__init__(convert_charrefs=True)
         self.metrics: dict[str, float] = {}
+        self.declarations: list[tuple[str, float]] = []
+        self.nonfinite_metrics: set[str] = set()
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         attributes = {name.lower(): value for name, value in attrs}
@@ -103,13 +105,16 @@ class VisualMetricParser(HTMLParser):
         raw_value = attributes.get("data-value")
         if not isinstance(name, str) or not isinstance(raw_value, str):
             return
+        name = html.unescape(name)
         try:
-            value = float(raw_value)
+            value = float(html.unescape(raw_value))
         except ValueError:
             return
         if not math.isfinite(value):
+            self.nonfinite_metrics.add(name)
             return
-        self.metrics[html.unescape(name)] = value
+        self.declarations.append((name, value))
+        self.metrics[name] = value
 
     def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         self.handle_starttag(tag, attrs)
@@ -150,29 +155,59 @@ def review_visual(submission_dir: Path) -> VisualReport:
                 f"Visualization must visibly include `{marker}`.",
             )
 
-    declared = extract_visual_metrics(text)
+    parser = VisualMetricParser()
+    parser.feed(text)
+    parser.close()
+    declarations = parser.declarations
+    declared = parser.metrics
     report.metrics_seen = declared
     metrics = load_metrics(submission_dir / "metrics.json")
-    for name in REQUIRED_METRICS:
-        if name not in declared:
-            report.add("VISUAL_METRIC_MISSING", "major", display_path, f"Missing data-metric `{name}`.")
-            continue
+    for name in sorted(parser.nonfinite_metrics):
+        report.add(
+            "VISUAL_METRIC_NONFINITE_VALUE",
+            "major",
+            display_path,
+            f"HTML metric `{name}` must use a finite numeric data-value.",
+        )
+    for name, value in declarations:
         metric = metrics.get(name)
-        if not isinstance(metric, dict) or metric.get("status") != "known":
-            report.add("VISUAL_METRIC_SOURCE_MISSING", "major", display_path, f"`metrics.json` has no known metric `{name}`.")
+        if not isinstance(metric, dict):
+            report.add(
+                "VISUAL_METRIC_SOURCE_MISSING",
+                "major",
+                display_path,
+                f"HTML declares unregistered metric `{name}`; add it to metrics.json before displaying a numeric value.",
+            )
+            continue
+        if metric.get("status") != "known":
+            issue_id = "VISUAL_METRIC_SOURCE_MISSING" if name in REQUIRED_METRICS else "VISUAL_METRIC_NON_KNOWN_CLAIM"
+            report.add(
+                issue_id,
+                "major",
+                display_path,
+                f"HTML declares numeric metric `{name}` but metrics.json status is `{metric.get('status')!r}`; unknown or not_applicable metrics must remain explicitly non-numeric.",
+            )
             continue
         expected = metric.get("value")
         if not isinstance(expected, (int, float)):
-            report.add("VISUAL_METRIC_SOURCE_MISSING", "major", display_path, f"`metrics.json` metric `{name}` has no numeric value.")
+            report.add(
+                "VISUAL_METRIC_SOURCE_MISSING",
+                "major",
+                display_path,
+                f"`metrics.json` metric `{name}` has no numeric value.",
+            )
             continue
         tolerance = max(abs(float(expected)) * 1e-6, 1e-6)
-        if abs(declared[name] - float(expected)) > tolerance:
+        if abs(value - float(expected)) > tolerance:
             report.add(
                 "VISUAL_METRIC_MISMATCH",
                 "major",
                 display_path,
-                f"HTML metric `{name}` value {declared[name]} does not match metrics.json value {expected}.",
+                f"HTML metric `{name}` value {value} does not match metrics.json value {expected}.",
             )
+    for name in REQUIRED_METRICS:
+        if name not in declared:
+            report.add("VISUAL_METRIC_MISSING", "major", display_path, f"Missing data-metric `{name}`.")
     return report
 
 

--- a/tests/test_visual_review.py
+++ b/tests/test_visual_review.py
@@ -98,19 +98,78 @@ class VisualReviewTests(unittest.TestCase):
         self.assertTrue(report.ok, [issue.__dict__ for issue in report.issues])
         self.assertEqual(0.2, report.metrics_seen["green_ratio"])
 
-    def test_nonfinite_metric_cannot_bypass_consistency_check(self) -> None:
+    def test_unknown_extra_metric_claim_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             submission = write_valid_visual_package(Path(tmp))
+            metrics_path = submission / "metrics.json"
+            metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+            metrics["metrics"]["floor_area_ratio"] = {
+                "status": "unknown",
+                "value": None,
+                "reason": "Official planning controls are not available.",
+            }
+            metrics_path.write_text(json.dumps(metrics), encoding="utf-8")
             html = VALID_HTML.replace(
-                'data-metric="green_ratio" data-value="0.2"',
-                'data-metric="green_ratio" data-value="NaN"',
+                "</body>",
+                '<span data-metric="floor_area_ratio" data-value="2.0">2.0</span></body>',
             )
             (submission / "visual" / "index.html").write_text(html, encoding="utf-8")
 
             report = review_visual(submission)
 
-        self.assertFalse(report.ok)
-        self.assertIn("VISUAL_METRIC_MISSING", {issue.check_id for issue in report.issues})
+            self.assertFalse(report.ok)
+            self.assertIn("VISUAL_METRIC_NON_KNOWN_CLAIM", {issue.check_id for issue in report.issues})
+
+    def test_unknown_extra_metric_claim_is_order_independent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_valid_visual_package(Path(tmp))
+            metrics_path = submission / "metrics.json"
+            metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+            metrics["metrics"]["floor_area_ratio"] = {
+                "status": "unknown",
+                "value": None,
+                "reason": "Official planning controls are not available.",
+            }
+            metrics_path.write_text(json.dumps(metrics), encoding="utf-8")
+            html = VALID_HTML.replace(
+                "</body>",
+                '<span data-value="2.0" data-metric="floor_area_ratio">2.0</span></body>',
+            )
+            (submission / "visual" / "index.html").write_text(html, encoding="utf-8")
+
+            report = review_visual(submission)
+
+            self.assertFalse(report.ok)
+            self.assertIn("VISUAL_METRIC_NON_KNOWN_CLAIM", {issue.check_id for issue in report.issues})
+
+    def test_unregistered_extra_metric_claim_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_valid_visual_package(Path(tmp))
+            html = VALID_HTML.replace(
+                "</body>",
+                '<span data-metric="unregistered_ratio" data-value="0.4">0.4</span></body>',
+            )
+            (submission / "visual" / "index.html").write_text(html, encoding="utf-8")
+
+            report = review_visual(submission)
+
+            self.assertFalse(report.ok)
+            self.assertIn("VISUAL_METRIC_SOURCE_MISSING", {issue.check_id for issue in report.issues})
+
+    def test_nonfinite_metric_cannot_bypass_consistency_check(self) -> None:
+        for raw_value in ["NaN", "Inf"]:
+            with self.subTest(raw_value=raw_value), tempfile.TemporaryDirectory() as tmp:
+                submission = write_valid_visual_package(Path(tmp))
+                html = VALID_HTML.replace(
+                    'data-metric="green_ratio" data-value="0.2"',
+                    f'data-metric="green_ratio" data-value="{raw_value}"',
+                )
+                (submission / "visual" / "index.html").write_text(html, encoding="utf-8")
+
+                report = review_visual(submission)
+
+            self.assertFalse(report.ok)
+            self.assertIn("VISUAL_METRIC_NONFINITE_VALUE", {issue.check_id for issue in report.issues})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- make `scripts/visual_review.py` inspect every numeric `data-metric` declaration, not only the three required metrics;
- reject numeric claims for metrics that are unregistered, `unknown`, or `not_applicable`;
- keep the existing exact-value consistency check for all declared known metrics;
- document the rule and add regression coverage.

## Why

Issue #215 identified a real presentation risk: `metrics.json` can honestly mark FAR, height, density, or other controls as unknown while an HTML card or copied exhibit can still display a precise number. Before this change, extra `data-metric` declarations were ignored, so the visual gate could pass them silently.

The new check keeps the evidence boundary machine-readable: unknown/pending values must be shown as explicit non-numeric text with a reason and recalculation prerequisite. It does not require the organizer's missing official geometry and does not change the existing provisional-boundary eligibility policy.

## Validation

- `python3 -m pytest -q` — 247 passed
- `python3 -m pytest -q tests/test_visual_review.py` — 7 passed
- `python3 scripts/visual_review.py submissions/147228/jingzhang-open-pulse --json` — PASS on the current main package
- same visual review on exact #766 head `c35f39ae` — PASS
- `python3 -m py_compile scripts/visual_review.py`
- `git diff --check`

This is a code/docs/test PR and does not modify any participant submission or gallery publication data.
