### PR TITLE
feat: persist passing submission self-checks

### DIFF
--- a/docs/formal-submission-guide.md
+++ b/docs/formal-submission-guide.md
@@ -465,7 +465,8 @@ HTML 展示值与 `metrics.json` 不一致会失败。
 python3 -m pip install -r requirements-review.txt
 python3 scripts/render_proposal_html.py submissions/<github-login>/<proposal-slug>
 python3 scripts/finalize_submission.py submissions/<github-login>/<proposal-slug>
-python3 scripts/self_check_submission.py submissions/<github-login>/<proposal-slug> --pr-author <github-login>
+python3 scripts/self_check_submission.py submissions/<github-login>/<proposal-slug> --pr-author <github-login> --record-pass --json
+python3 scripts/self_check_submission.py submissions/<github-login>/<proposal-slug> --pr-author <github-login> --json
 ```
 
 这个命令会依次运行：
@@ -476,6 +477,8 @@ python3 scripts/self_check_submission.py submissions/<github-login>/<proposal-sl
 - professional evidence review
 
 全部 PASS 只说明 package 具备进入机器检查和内容评审的基础条件。provisional boundary 会保留精度警示和复算要求，但不会因组织方数据缺口阻断评分。PASS 不代表方案优秀或获得官方批准。
+
+第一次命令使用可信本地检查结果更新 `self_check.json` 的 `ok`、`can_enter_formal_review`、`review_status` 和检查时间，同时将 `manifest.json` 的 `validation_claim.self_checked` 置为 `true`，并刷新 `self_check.json` 的 sha256。`manifest.json` 本身不纳入自身哈希。第二次不带 `--record-pass` 的命令用于回读；检查失败时不会写入通过状态。
 
 维护者审核 PR 时会运行 `scripts/maintainer_review.py --comment`，并在本地忽略目录 `.maintainer-review/<proposal-slug>/` 生成 `maintainer-comment.md`、`review-summary.json`、`review-input.json`、`review-prompt.md` 和 `advisory-review.md`。维护者只把命令输出复制到 PR comment；maintainer review 结果不提交到仓库，也不进入公开展示页。方案合并到 `main` 后自动进入全部方案页；维护者通过 `gallery-publication.json` 明确暂停展示或决定首页精选，再运行 `scripts/generate_submissions_data.py`。参赛者只提交自己的投稿目录，不修改发布清单或 `submissions-data.js`。
 

--- a/scripts/self_check_submission.py
+++ b/scripts/self_check_submission.py
@@ -4,10 +4,12 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib.util
 import json
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -255,6 +257,59 @@ def build_self_check(repo_root: Path, submission_dir: Path, pr_author: str) -> d
     return report
 
 
+def record_pass(submission_dir: Path, pr_author: str, report: dict[str, Any]) -> None:
+    """Persist a successful local self-check without hashing manifest.json itself."""
+    if not report.get("ok") or not report.get("can_enter_formal_review"):
+        raise ValueError("only a passing package that can enter formal review may be recorded")
+
+    manifest_path = submission_dir / "manifest.json"
+    self_check_path = submission_dir / "self_check.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        self_check = json.loads(self_check_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot load manifest.json/self_check.json: {exc}") from exc
+    if not isinstance(manifest, dict) or not isinstance(self_check, dict):
+        raise ValueError("manifest.json and self_check.json must contain JSON objects")
+    if not isinstance(self_check.get("checks"), list):
+        raise ValueError("self_check.json must contain a checks array")
+    claim = manifest.get("validation_claim")
+    if not isinstance(claim, dict):
+        raise ValueError("manifest.json must contain a validation_claim object")
+    files = manifest.get("files")
+    if not isinstance(files, list):
+        raise ValueError("manifest.json must contain a files array")
+    self_check_entry = next(
+        (item for item in files if isinstance(item, dict) and item.get("path") == "self_check.json"),
+        None,
+    )
+    if self_check_entry is None:
+        raise ValueError("manifest.json must list self_check.json")
+
+    checked_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    self_check.update(
+        {
+            "ok": True,
+            "can_enter_formal_review": True,
+            "review_status": "formal-review-ready",
+            "checked_at": checked_at,
+            "checked_by": pr_author,
+            "validator": "scripts/self_check_submission.py",
+        }
+    )
+    self_check_path.write_text(
+        json.dumps(self_check, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    claim["self_checked"] = True
+    self_check_entry["sha256"] = hashlib.sha256(self_check_path.read_bytes()).hexdigest()
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
 def format_markdown(report: dict[str, Any]) -> str:
     lines = ["# Submission self-check", ""]
     lines.append(f"Result: {'PASS' if report.get('ok') else 'FAIL'}")
@@ -269,6 +324,8 @@ def format_markdown(report: dict[str, Any]) -> str:
     lines.append(f"Spatial review: {'PASS' if spatial.get('ok') else 'FAIL'}")
     lines.append(f"Visual packaging check: {'PASS' if visual.get('ok') else 'FAIL'}")
     lines.append(f"Professional evidence review: {'PASS' if professional.get('ok') else 'FAIL'}")
+    if report.get("recorded"):
+        lines.append("Recorded pass: YES")
     if report.get("missing_review_dependencies"):
         lines.extend(["", "Missing review dependencies:"])
         lines.extend(f"- `{item}`" for item in report["missing_review_dependencies"])
@@ -291,6 +348,11 @@ def main() -> int:
     parser.add_argument("--pr-author", required=True)
     parser.add_argument("--repo-root", default=".")
     parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--record-pass",
+        action="store_true",
+        help="Persist a passing self-check to self_check.json and manifest.json.",
+    )
     args = parser.parse_args()
 
     repo_root = Path(args.repo_root)
@@ -299,6 +361,19 @@ def main() -> int:
         submission_dir = repo_root / submission_dir
 
     report = build_self_check(repo_root, submission_dir, args.pr_author)
+    if args.record_pass:
+        try:
+            record_pass(submission_dir, args.pr_author, report)
+        except ValueError as exc:
+            report["recorded"] = False
+            report["record_error"] = str(exc)
+            if args.json:
+                print(json.dumps(report, ensure_ascii=False, indent=2))
+            else:
+                print(format_markdown(report))
+                print(f"\nCannot record pass: {exc}", file=sys.stderr)
+            return 2
+        report["recorded"] = True
     if args.json:
         print(json.dumps(report, ensure_ascii=False, indent=2))
     else:

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -576,6 +576,99 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
             self.assertEqual([], report["professional_issue_ids"])
             self.assertEqual([], report["visual_issue_ids"])
 
+    def test_record_pass_persists_self_check_summary_and_manifest_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_provisional_site_package(root)
+            submission_dir = root / "submissions" / "alice" / "recorded-pass"
+            scaffold = run_scaffold(submission_dir, cwd=root)
+            self.assertEqual(scaffold.returncode, 0, scaffold.stdout + scaffold.stderr)
+            finalized = complete_scaffold(submission_dir)
+            self.assertEqual(finalized.returncode, 0, finalized.stdout + finalized.stderr)
+
+            recorded = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "self_check_submission.py"),
+                    str(submission_dir),
+                    "--repo-root",
+                    str(root),
+                    "--pr-author",
+                    "alice",
+                    "--record-pass",
+                    "--json",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(0, recorded.returncode, recorded.stdout + recorded.stderr)
+            self.assertTrue(json.loads(recorded.stdout)["recorded"])
+
+            self_check = json.loads((submission_dir / "self_check.json").read_text(encoding="utf-8"))
+            self.assertTrue(self_check["ok"])
+            self.assertTrue(self_check["can_enter_formal_review"])
+            self.assertEqual("formal-review-ready", self_check["review_status"])
+            self.assertEqual("alice", self_check["checked_by"])
+            self.assertIsInstance(self_check["checked_at"], str)
+
+            manifest = json.loads((submission_dir / "manifest.json").read_text(encoding="utf-8"))
+            self.assertTrue(manifest["validation_claim"]["self_checked"])
+            self_check_item = next(item for item in manifest["files"] if item["path"] == "self_check.json")
+            self.assertEqual(
+                hashlib.sha256((submission_dir / "self_check.json").read_bytes()).hexdigest(),
+                self_check_item["sha256"],
+            )
+
+            reread = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "self_check_submission.py"),
+                    str(submission_dir),
+                    "--repo-root",
+                    str(root),
+                    "--pr-author",
+                    "alice",
+                    "--json",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(0, reread.returncode, reread.stdout + reread.stderr)
+            self.assertNotIn("recorded", json.loads(reread.stdout))
+
+    def test_record_pass_refuses_failed_package_without_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_provisional_site_package(root)
+            submission_dir = root / "submissions" / "alice" / "scaffold-only"
+            scaffold = run_scaffold(submission_dir, cwd=root)
+            self.assertEqual(scaffold.returncode, 0, scaffold.stdout + scaffold.stderr)
+            manifest_before = (submission_dir / "manifest.json").read_bytes()
+            self_check_before = (submission_dir / "self_check.json").read_bytes()
+
+            recorded = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "self_check_submission.py"),
+                    str(submission_dir),
+                    "--repo-root",
+                    str(root),
+                    "--pr-author",
+                    "alice",
+                    "--record-pass",
+                    "--json",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(2, recorded.returncode)
+            self.assertFalse(json.loads(recorded.stdout)["recorded"])
+            self.assertEqual(manifest_before, (submission_dir / "manifest.json").read_bytes())
+            self.assertEqual(self_check_before, (submission_dir / "self_check.json").read_bytes())
+
     def test_missing_review_dependencies_are_reported(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## What changed

- Add `--record-pass` to `scripts/self_check_submission.py`.
- Persist a passing self-check summary in `self_check.json` while preserving its existing `checks` array.
- Set `manifest.validation_claim.self_checked=true` and refresh only the `self_check.json` manifest hash; `manifest.json` is not self-hashed.
- Document the record-then-readback workflow and add success/failure regression coverage.

## Why

PR #763 exposed that the contributor guidance needed a way to persist a successful trusted self-check, but the referenced `--record-pass` option did not exist in `main`. This made the suggested remediation command fail and left package status evidence stale even after all checks passed.

The new flag refuses to write on a failed package and validates the manifest/self-check structure before writing, so a failed or malformed package cannot be marked as passed.

## Verification

- `20 passed` — `tests/test_agent_scaffold_and_self_check.py`
- `109 passed` — `tests/test_agent_scaffold_and_self_check.py tests/test_submission_workflow.py`
- `4 passed` — trusted review script tests
- `py_compile` and `git diff --check` pass
- Real PR #763 package replay: record pass, manifest hash audit, and second readback all pass
