### PR TITLE
fix: skip already reviewed heads in auto-review queue

### DIFF
--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -71,6 +71,21 @@ def ci_state(meta: dict[str, Any]) -> str:
     return "pending"
 
 
+def has_current_head_review_marker(meta: dict[str, Any]) -> bool:
+    head_sha = str(meta.get("headRefOid") or "")
+    if not head_sha:
+        return False
+    marker = REVIEW_MARKER.format(head_sha=head_sha)
+    reviews = meta.get("reviews")
+    if not isinstance(reviews, list):
+        return False
+    return any(
+        marker in str(review.get("body") or "")
+        for review in reviews
+        if isinstance(review, dict)
+    )
+
+
 def submission_dir_from_files(paths: list[str], author: str) -> str:
     roots: set[str] = set()
     prefix = f"submissions/{author.casefold()}/"
@@ -109,7 +124,13 @@ def decide(review: dict[str, Any], decision: dict[str, Any], threshold: float) -
 def pr_meta(repo: str, number: int, cwd: Path) -> dict[str, Any]:
     return gh_json(
         repo,
-        ["pr", "view", str(number), "--json", "number,author,headRefOid,state,isDraft,statusCheckRollup,labels"],
+        [
+            "pr",
+            "view",
+            str(number),
+            "--json",
+            "number,author,headRefOid,state,isDraft,statusCheckRollup,labels,reviews",
+        ],
         cwd=cwd,
     )
 
@@ -184,6 +205,8 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
     state = ci_state(meta)
     if meta.get("isDraft"):
         return {"number": number, "result": "skipped-draft"}
+    if has_current_head_review_marker(meta):
+        return {"number": number, "head_sha": head_sha, "result": "skipped-current-head-reviewed"}
     if state != "success":
         return {"number": number, "head_sha": head_sha, "result": f"skipped-ci-{state}"}
 
@@ -312,10 +335,11 @@ def main() -> int:
             "--limit",
             "1000",
             "--json",
-            "number,author,headRefOid,state,isDraft,statusCheckRollup,labels",
+            "number,author,headRefOid,state,isDraft,statusCheckRollup,labels,reviews",
         ],
         cwd=repo_root,
     )
+    candidates = [item for item in candidates if not has_current_head_review_marker(item)]
     selected = sorted(candidates, key=lambda item: int(item["number"]))[: args.limit]
     results = []
     with ThreadPoolExecutor(max_workers=args.concurrency) as executor:

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -6,7 +6,14 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
-from auto_review_queue import WorkerError, ci_state, decide, submission_dir_from_files  # noqa: E402
+from auto_review_queue import (  # noqa: E402
+    REVIEW_MARKER,
+    WorkerError,
+    ci_state,
+    decide,
+    has_current_head_review_marker,
+    submission_dir_from_files,
+)
 
 
 class AutoReviewQueueTests(unittest.TestCase):
@@ -96,6 +103,35 @@ class AutoReviewQueueTests(unittest.TestCase):
                     ]
                 }
             ),
+        )
+
+    def test_current_head_review_marker_is_detected(self) -> None:
+        head_sha = "a" * 40
+        self.assertTrue(
+            has_current_head_review_marker(
+                {
+                    "headRefOid": head_sha,
+                    "reviews": [{"body": f"{REVIEW_MARKER.format(head_sha=head_sha)}\nscore: 91"}],
+                }
+            )
+        )
+
+    def test_stale_head_review_marker_is_not_detected(self) -> None:
+        head_sha = "a" * 40
+        old_sha = "b" * 40
+        self.assertFalse(
+            has_current_head_review_marker(
+                {
+                    "headRefOid": head_sha,
+                    "reviews": [{"body": REVIEW_MARKER.format(head_sha=old_sha)}],
+                }
+            )
+        )
+
+    def test_missing_reviews_are_not_treated_as_reviewed(self) -> None:
+        self.assertFalse(has_current_head_review_marker({"headRefOid": "a" * 40}))
+        self.assertFalse(
+            has_current_head_review_marker({"headRefOid": "a" * 40, "reviews": None})
         )
 
 


### PR DESCRIPTION
## Problem
The trusted auto-review worker selects queued PRs by number before checking whether the current head already has an auto-review marker. Repeated review markers on older queued PRs therefore consume the limited worker slots and can starve newer submissions such as #761.

## Fix
- request reviews in queue metadata
- filter current-head-reviewed PRs before selecting the FIFO batch
- keep a second guard in process_pr
- do not skip stale markers from a different head

## Verification
- python3 -m pytest -q: 270 passed
- python3 -m py_compile scripts/auto_review_queue.py
- git diff --check

This preserves the existing review marker and label state; it only prevents already-reviewed current heads from occupying new queue slots.