### PR TITLE
fix: skip stale review queue entries

### DIFF
--- a/docs/github-settings.md
+++ b/docs/github-settings.md
@@ -53,7 +53,7 @@
 required CI 不接入 AI，也不配置模型密钥。它只做确定性的路径、格式、文件类型、文件大小、提交阶段语义、基础 GeoJSON 字段和明显红线预检。
 校验通过后 workflow 自动添加 `review/queued`；失败则添加 `review/ci-failed`，受信任 worker 只消费前者。
 
-可信空间复核和 AI 评审 agent 应作为独立的受信任 worker 运行，不应替代 `submission-validation` 这个硬门禁。worker 只能在 required CI 成功后读取固定 PR head SHA，不执行投稿代码，并在 review 与 merge 前再次核对 SHA 和 CI。当前 intake 政策允许四项 gate 与强制退件检查通过且 Review Agent 得分不低于 60/100 时自动合并；合并后自动进入方案展示，但不等同于首页精选、最终评分或落地实施结论。完整 SOP 见 [maintainer-workflow.md](maintainer-workflow.md)。
+可信空间复核和 AI 评审 agent 应作为独立的受信任 worker 运行，不应替代 `submission-validation` 这个硬门禁。worker 只能在 required CI 成功后读取固定 PR head SHA，不执行投稿代码，并在 review 与 merge 前再次核对 SHA 和 CI；队列还必须跳过已经存在当前 head review marker 的残留 `review/queued` 项，避免旧标签挤占评审批次。当前 intake 政策允许四项 gate 与强制退件检查通过且 Review Agent 得分不低于 60/100 时自动合并；合并后自动进入方案展示，但不等同于首页精选、最终评分或落地实施结论。完整 SOP 见 [maintainer-workflow.md](maintainer-workflow.md)。
 
 ```bash
 python3 -m pip install -r requirements-review.txt

--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -257,7 +257,7 @@ python3 scripts/auto_review_queue.py --limit 10
 python3 scripts/auto_review_queue.py --limit 10 --concurrency 3 --apply --admin-merge
 ```
 
-固定顺序为：required CI → 单一作者目录 → 固定 head SHA worktree → 本地四项 gate →
+固定顺序为：required CI → 单一作者目录 → 当前 head 的既有 Review Agent marker 过滤 → 固定 head SHA worktree → 本地四项 gate →
 强制退件 → 多模态 100 分评审 → 决策前再次检查 head SHA/CI → review 与标签 →
 合并前最后一次检查 head SHA/CI。低于 60 分标记 `review/low-quality`；CI 未成功的
 PR 不调用模型；draft 不进入队列。合并仅表示仓库 intake，展示、精选、正式评分与
@@ -269,6 +269,9 @@ SHA 复核和 merge 使用进程内锁串行执行，避免 Git 引用锁和 bas
 `submission-validation` 成功时会自动清除旧的 CI/修改/低质量标签并添加
 `review/queued`；投稿人推送修订后无需维护者手动重新排队。CI 失败时 workflow
 移除 queued 并添加 `review/ci-failed`，因此不会产生付费模型调用。
+队列 worker 在消耗 batch slot 前会读取当前 head 的 review marker；已对同一
+SHA 完成 intake 的 PR 即使仍残留 `review/queued` 也会被跳过，避免历史标签占满
+前 N 个位置。若 API 无法确认当前 head，worker 应保守跳过该候选，不把旧事件送入评审。
 
 审计材料保存在 `.maintainer-review/queue/pr-<number>/<head-sha>/`，worktree 默认在
 `.pr-worktree/auto-review/` 并在单稿完成后删除。建议用 launchd/systemd timer 每

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import sys
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -39,6 +40,45 @@ class Decision:
     action: str
     score: float | None
     reason: str
+
+
+def has_current_review_marker(reviews: Any, head_sha: str) -> bool:
+    """Return whether this exact PR head already has an auto-review decision."""
+    if not isinstance(reviews, list) or not head_sha:
+        return False
+    marker = REVIEW_MARKER.format(head_sha=head_sha)
+    return any(
+        isinstance(review, dict) and marker in str(review.get("body") or "")
+        for review in reviews
+    )
+
+
+def select_queue_candidates(
+    candidates: list[dict[str, Any]],
+    limit: int,
+    review_loader: Callable[[int], dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Fill the worker batch with unreviewed current heads.
+
+    ``review/queued`` is a durable label, so a completed review can leave a
+    stale queue entry behind.  Selection must inspect the marker for the
+    current head before spending one of the finite batch slots.  A changed or
+    missing head is skipped conservatively rather than risking a decision for
+    a stale event.
+    """
+    selected: list[dict[str, Any]] = []
+    for candidate in sorted(candidates, key=lambda item: int(item["number"])):
+        if len(selected) >= limit:
+            break
+        number = int(candidate["number"])
+        head_sha = str(candidate.get("headRefOid") or "")
+        review = review_loader(number)
+        if review.get("headRefOid") != head_sha:
+            continue
+        if has_current_review_marker(review.get("reviews"), head_sha):
+            continue
+        selected.append(candidate)
+    return selected
 
 
 def run(command: list[str], *, cwd: Path, capture: bool = True) -> subprocess.CompletedProcess[str]:
@@ -129,7 +169,7 @@ def pr_meta(repo: str, number: int, cwd: Path) -> dict[str, Any]:
             "view",
             str(number),
             "--json",
-            "number,author,headRefOid,state,isDraft,mergeable,statusCheckRollup,labels",
+            "number,author,headRefOid,state,isDraft,mergeable,statusCheckRollup,labels,reviews",
         ],
         cwd=cwd,
     )
@@ -433,6 +473,16 @@ def main() -> int:
                     "number": number,
                     "head_sha": live.get("headRefOid"),
                     "result": "changes-requested-conflict" if args.apply else "skipped-conflicting",
+                }
+            )
+            continue
+        head_sha = str(live.get("headRefOid") or "")
+        if has_current_review_marker(live.get("reviews"), head_sha):
+            results.append(
+                {
+                    "number": number,
+                    "head_sha": head_sha,
+                    "result": "skipped-reviewed-head",
                 }
             )
             continue

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -72,7 +72,12 @@ def select_queue_candidates(
             break
         number = int(candidate["number"])
         head_sha = str(candidate.get("headRefOid") or "")
-        review = review_loader(number)
+        try:
+            review = review_loader(number)
+        except Exception:
+            # A live-head lookup that cannot be completed is not safe to review.
+            # Skip this candidate and keep filling the batch from later entries.
+            continue
         if review.get("headRefOid") != head_sha:
             continue
         if has_current_review_marker(review.get("reviews"), head_sha):

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -12,7 +12,9 @@ from auto_review_queue import (  # noqa: E402
     WorkerError,
     ci_state,
     decide,
+    has_current_review_marker,
     load_cached_review,
+    select_queue_candidates,
     submission_dir_from_files,
 )
 from generate_submissions_data import package_sha256  # noqa: E402
@@ -70,6 +72,59 @@ class AutoReviewQueueTests(unittest.TestCase):
         self.assertEqual("submissions/Alice/plan", submission_dir_from_files(paths, "alice"))
         with self.assertRaises(WorkerError):
             submission_dir_from_files(paths + ["README.md"], "alice")
+
+    def test_current_head_review_marker_is_detected(self) -> None:
+        head = "a" * 40
+        self.assertTrue(
+            has_current_review_marker(
+                [{"body": f"<!-- haidian-auto-review:{head} -->\\nMaintainer intake decision"}],
+                head,
+            )
+        )
+
+    def test_stale_head_review_marker_does_not_block_current_head(self) -> None:
+        current = "b" * 40
+        old = "a" * 40
+        self.assertFalse(
+            has_current_review_marker(
+                [{"body": f"<!-- haidian-auto-review:{old} -->\\nMaintainer intake decision"}],
+                current,
+            )
+        )
+
+    def test_queue_selection_skips_reviewed_heads_and_fills_batch(self) -> None:
+        reviewed = "a" * 40
+        stale_marker = "b" * 40
+        pending = "c" * 40
+        candidates = [
+            {"number": 727, "headRefOid": reviewed},
+            {"number": 728, "headRefOid": stale_marker},
+            {"number": 729, "headRefOid": pending},
+        ]
+        states = {
+            727: {
+                "headRefOid": reviewed,
+                "reviews": [{"body": f"<!-- haidian-auto-review:{reviewed} -->"}],
+            },
+            728: {
+                "headRefOid": stale_marker,
+                "reviews": [{"body": f"<!-- haidian-auto-review:{reviewed} -->"}],
+            },
+            729: {"headRefOid": pending, "reviews": []},
+        }
+        selected = select_queue_candidates(candidates, 2, states.__getitem__)
+        self.assertEqual([728, 729], [item["number"] for item in selected])
+
+    def test_queue_selection_skips_changed_head(self) -> None:
+        old = "a" * 40
+        current = "b" * 40
+        candidates = [{"number": 727, "headRefOid": old}]
+        selected = select_queue_candidates(
+            candidates,
+            1,
+            lambda number: {"headRefOid": current, "reviews": []},
+        )
+        self.assertEqual([], selected)
 
     def test_ci_state(self) -> None:
         self.assertEqual(

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -126,6 +126,20 @@ class AutoReviewQueueTests(unittest.TestCase):
         )
         self.assertEqual([], selected)
 
+    def test_queue_selection_skips_unavailable_head_and_fills_batch(self) -> None:
+        candidates = [
+            {"number": 727, "headRefOid": "a" * 40},
+            {"number": 728, "headRefOid": "b" * 40},
+        ]
+
+        def load_review(number: int) -> dict:
+            if number == 727:
+                raise WorkerError("GitHub API rate limit")
+            return {"headRefOid": "b" * 40, "reviews": []}
+
+        selected = select_queue_candidates(candidates, 1, load_review)
+        self.assertEqual([728], [item["number"] for item in selected])
+
     def test_ci_state(self) -> None:
         self.assertEqual(
             "success",


### PR DESCRIPTION
## Summary

The maintainer review worker selects the lowest-numbered PRs carrying `review/queued` before checking whether the current head already has an `haidian-auto-review:<sha>` decision marker. Completed reviews can therefore leave durable queued labels that consume the finite batch and starve newer PRs.

This patch:

- filters queue candidates against the live `headRefOid` before spending a batch slot;
- skips an exact current-head review marker while allowing an old-head marker to be reviewed again;
- skips a candidate when the live head has changed or cannot be confirmed;
- documents the fail-closed queue behavior;
- adds regression coverage for stale labels, changed heads, and batch filling.

## Evidence

The live queue currently contains reviewed current heads such as #734-#740 with `review/queued` still attached. The pre-fix first 15 queued entries included six current-head decisions; the new selector skips them and fills the batch with unreviewed candidates.

## Validation

- `python3 -m pytest -q` — 271 passed
- `python3 scripts/generate_submissions_data.py --check` — PASS
- `node --check submissions-data.js` — PASS
- `python3 -m py_compile scripts/auto_review_queue.py` — PASS
- `git diff --check` — PASS
