### PR TITLE
fix: remove redundant proposal report title

### DIFF
--- a/scripts/render_proposal_html.py
+++ b/scripts/render_proposal_html.py
@@ -262,6 +262,19 @@ def render_markdown_body(submission_dir: Path, markdown: str) -> str:
     return "\n".join(blocks)
 
 
+def strip_redundant_leading_title(markdown: str, title: str) -> str:
+    """Remove a leading Markdown H1 when the report hero already shows it."""
+    lines = markdown.splitlines(keepends=True)
+    for index, line in enumerate(lines):
+        if not line.strip():
+            continue
+        match = re.fullmatch(r"\s*#\s+(.+?)\s*(?:\n)?", line)
+        if match and match.group(1).strip() == title.strip():
+            del lines[index]
+        break
+    return "".join(lines)
+
+
 def render_html(
     submission_dir: Path,
     proposal_name: str = "proposal.md",
@@ -273,6 +286,7 @@ def render_html(
     summary = metadata.get("summary", "")
     language = metadata.get("language", "zh")
     document_lang = "en" if language == "en" else "zh-CN"
+    body = strip_redundant_leading_title(body, title)
     translation_match = re.search(r"(?m)^# 中文正式译文\s*$", body) if language == "en" else None
     if translation_match:
         english_body = body[: translation_match.start()]

--- a/tests/test_render_proposal_html.py
+++ b/tests/test_render_proposal_html.py
@@ -13,6 +13,20 @@ from render_proposal_html import render_html  # noqa: E402
 
 
 class RenderProposalHtmlTests(unittest.TestCase):
+    def test_render_html_omits_redundant_leading_title(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission_dir = Path(tmp)
+            (submission_dir / "proposal.md").write_text(
+                '---\ntitle: "测试方案"\nsummary: "离线阅读版"\n---\n\n'
+                '# 测试方案\n\n正文。\n',
+                encoding="utf-8",
+            )
+
+            html = render_html(submission_dir)
+
+            self.assertEqual(1, html.count("<h1>测试方案</h1>"))
+            self.assertIn("<p>正文。</p>", html)
+
     def test_render_html_rewrites_local_figure_paths(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             submission_dir = Path(tmp)


### PR DESCRIPTION
## Summary

The report renderer always emits a hero `<h1>` from front matter and also renders a matching leading Markdown `#` heading from the proposal body. Current main therefore has duplicate report titles; a scan of 242 existing packages found the same pattern.

This patch removes only the first body H1 when it exactly matches the front-matter title. Other headings and non-matching body titles remain unchanged.

## Why

This keeps future offline HTML reports readable and prevents regenerated bilingual reports from reintroducing duplicate titles. It is a generator fix, not a retroactive rewrite of the 242 historical packages.

## Validation

- `python3 -m unittest -v tests/test_render_proposal_html.py` — 12 passed
- `python3 -m pytest -q` — 268 passed
- `python3 scripts/generate_submissions_data.py --check` — PASS
- `node --check submissions-data.js` — PASS
- `py_compile` and `git diff --check` — PASS
