### PR TITLE
fix: keep rendered reports reproducible

### DIFF
--- a/docs/formal-submission-guide.md
+++ b/docs/formal-submission-guide.md
@@ -347,6 +347,8 @@ agent.6 一带全球AI创新活动体系与长期运营设计
 
 `report/proposal.html` 是从 `proposal.md` 自动渲染出的离线阅读版，用于解决不同 Markdown 预览器对图片路径、中文排版和证据标签显示不一致的问题。它不是第二套主体文本，也不能替代 `proposal.md`、GeoJSON、metrics 或图纸。
 
+当 PR 修改 `proposal.md`、`proposal.zh.md` / `proposal.en.md` 或对应的 `report/proposal*.html` 时，GitHub 的确定性校验会在内存中用仓库可信渲染器重新生成并比对报告。不要手工维护报告；先运行渲染命令，再刷新 manifest hash 与 self-check。历史包不会因渲染器演进被自动重写，普通全包 self-check 也不会因此阻断；需要在本地预演该 PR gate 时，可在 `validate_local_submission.py` 后加 `--check-generated-reports`。
+
 提交者每次手动修改 `proposal.md` 后都应运行：
 
 ```bash
@@ -361,6 +363,12 @@ python3 scripts/finalize_submission.py submissions/<github-login>/<proposal-slug
 - 图片引用必须指向本地派生图，例如 `../assets/figures/site-overview.png`。
 - 不得加载远程图片、外部脚本、iframe、表单、API 请求或跟踪代码。
 - HTML 阅读版应让评审者直接看到正文、图片、图注和 `[source:...]`、`[standard:...]`、`[depth:...]`、`[data:...]`、`[metric:...]` 证据标签。
+
+已修改报告或任何清单内文件时，可用下列命令只刷新 `manifest.json` 已登记文件的 sha256；脚本不会新增清单项，并会拒绝路径穿越：
+
+```bash
+python3 scripts/refresh_manifest_hashes.py submissions/<github-login>/<proposal-slug>
+```
 
 ## 8. A3 文册与 A0 展板
 

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -418,7 +418,13 @@ def main() -> int:
                     "participant deletion-only PR; removed files were not content-validated"
                 )
         else:
-            validation = validate_submission(worktree, pr_author, validation_files, bypass)
+            validation = validate_submission(
+                worktree,
+                pr_author,
+                validation_files,
+                bypass,
+                check_generated_reports=True,
+            )
         validation_markdown = format_report(validation)
 
         comment = (

--- a/scripts/refresh_manifest_hashes.py
+++ b/scripts/refresh_manifest_hashes.py
@@ -17,6 +17,12 @@ def manifest_file_path(root: Path, raw_path: object) -> tuple[str, Path]:
     if pure_path.is_absolute() or ".." in pure_path.parts:
         raise ValueError(f"manifest path must stay inside the package: {relative}")
     path = root / pure_path.as_posix()
+    try:
+        resolved_root = root.resolve()
+        resolved_path = path.resolve()
+        resolved_path.relative_to(resolved_root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ValueError(f"manifest path must stay inside the package: {relative}") from exc
     if path.is_symlink() or not path.is_file():
         raise ValueError(f"manifest file is missing or not a regular file: {relative}")
     return pure_path.as_posix(), path

--- a/scripts/refresh_manifest_hashes.py
+++ b/scripts/refresh_manifest_hashes.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Refresh sha256 values for files already listed in a submission manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+
+
+def manifest_file_path(root: Path, raw_path: object) -> tuple[str, Path]:
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        raise ValueError("manifest file path must be a non-empty string")
+    relative = raw_path.strip()
+    pure_path = PurePosixPath(relative)
+    if pure_path.is_absolute() or ".." in pure_path.parts:
+        raise ValueError(f"manifest path must stay inside the package: {relative}")
+    path = root / pure_path.as_posix()
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"manifest file is missing or not a regular file: {relative}")
+    return pure_path.as_posix(), path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("submission_dir")
+    args = parser.parse_args()
+
+    root = Path(args.submission_dir).resolve()
+    manifest_path = root / "manifest.json"
+    if not manifest_path.is_file():
+        parser.error(f"manifest.json not found under {root}")
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        parser.error(f"manifest.json must be valid UTF-8 JSON: {exc}")
+
+    files = manifest.get("files") if isinstance(manifest, dict) else None
+    if not isinstance(files, list):
+        parser.error("manifest.json must contain a files array")
+
+    errors: list[str] = []
+    resolved_files: list[tuple[dict, str, Path]] = []
+    for index, item in enumerate(files):
+        if not isinstance(item, dict):
+            errors.append(f"files[{index}] must be an object")
+            continue
+        try:
+            relative, path = manifest_file_path(root, item.get("path"))
+        except ValueError as exc:
+            errors.append(f"files[{index}]: {exc}")
+            continue
+        if relative == "manifest.json":
+            continue
+        resolved_files.append((item, relative, path))
+
+    if errors:
+        print("Manifest hashes were not updated:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    for item, _, path in resolved_files:
+        item["sha256"] = hashlib.sha256(path.read_bytes()).hexdigest()
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    print(f"Updated {len(resolved_files)} manifest hashes: {manifest_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/refresh_manifest_hashes.py
+++ b/scripts/refresh_manifest_hashes.py
@@ -28,15 +28,29 @@ def manifest_file_path(root: Path, raw_path: object) -> tuple[str, Path]:
     return pure_path.as_posix(), path
 
 
+def package_manifest_path(root: Path) -> Path:
+    """Return only a regular manifest file physically contained by the package."""
+    manifest_path = root / "manifest.json"
+    try:
+        resolved_path = manifest_path.resolve(strict=True)
+        resolved_path.relative_to(root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ValueError("manifest.json must stay inside the package") from exc
+    if manifest_path.is_symlink() or not manifest_path.is_file():
+        raise ValueError("manifest.json must be a regular file inside the package")
+    return manifest_path
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("submission_dir")
     args = parser.parse_args()
 
     root = Path(args.submission_dir).resolve()
-    manifest_path = root / "manifest.json"
-    if not manifest_path.is_file():
-        parser.error(f"manifest.json not found under {root}")
+    try:
+        manifest_path = package_manifest_path(root)
+    except ValueError as exc:
+        parser.error(str(exc))
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:

--- a/scripts/render_proposal_html.py
+++ b/scripts/render_proposal_html.py
@@ -24,6 +24,7 @@ REFERENCE_LABELS = {
 
 
 def parse_front_matter(text: str) -> tuple[dict[str, str], str]:
+    text = text.lstrip("\ufeff\n")
     if not text.startswith("---\n"):
         return {}, text
     end = text.find("\n---\n", 4)
@@ -37,6 +38,21 @@ def parse_front_matter(text: str) -> tuple[dict[str, str], str]:
         key, value = line.split(":", 1)
         metadata[key.strip()] = value.strip().strip('"').strip("'")
     return metadata, text[end + 5 :]
+
+
+def strip_redundant_leading_title(markdown: str, title: str) -> str:
+    """Keep one title in the hero when Markdown repeats the front-matter title."""
+    if not title.strip():
+        return markdown
+    lines = markdown.splitlines(keepends=True)
+    for index, line in enumerate(lines):
+        if not line.strip():
+            continue
+        heading = re.fullmatch(r"\s*#\s+(.+?)\s*(?:\n)?", line)
+        if heading and heading.group(1).strip() == title.strip():
+            del lines[index]
+        break
+    return "".join(lines)
 
 
 def normalize_image_src(submission_dir: Path, raw_src: str) -> str:
@@ -272,6 +288,7 @@ def render_html(
     title = metadata.get("title") or submission_dir.name
     summary = metadata.get("summary", "")
     language = metadata.get("language", "zh")
+    body = strip_redundant_leading_title(body, title)
     document_lang = "en" if language == "en" else "zh-CN"
     translation_match = re.search(r"(?m)^# 中文正式译文\s*$", body) if language == "en" else None
     if translation_match:

--- a/scripts/validate_local_submission.py
+++ b/scripts/validate_local_submission.py
@@ -65,6 +65,11 @@ def main() -> int:
     parser.add_argument("--pr-author", required=True)
     parser.add_argument("--repo-root", default=".")
     parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--check-generated-reports",
+        action="store_true",
+        help="require report/proposal*.html to match the current trusted renderer",
+    )
     args = parser.parse_args()
 
     repo_root = Path(args.repo_root)
@@ -73,7 +78,12 @@ def main() -> int:
         submission_dir = repo_root / submission_dir
 
     changed_files = discover_submission_files(submission_dir, repo_root)
-    report = validate_submission(repo_root, args.pr_author, changed_files)
+    report = validate_submission(
+        repo_root,
+        args.pr_author,
+        changed_files,
+        check_generated_reports=args.check_generated_reports,
+    )
     if args.json:
         print(json.dumps(report.to_dict(), ensure_ascii=False, indent=2))
     else:

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Iterable
 
+from render_proposal_html import render_html
+
 
 POLICY_ROOT = Path(__file__).resolve().parents[1]
 
@@ -1425,6 +1427,71 @@ def validate_proposal_html_file(
             report.add_error(message)
 
 
+def validate_generated_report_freshness(
+    report: ValidationReport, proposal_dir: str, base: Path
+) -> None:
+    """Require changed rendered reports to match the trusted Markdown renderer.
+
+    This is intentionally a forward-only rule: historic reports may have been
+    produced by earlier renderer versions, but a PR that changes a proposal
+    source or its corresponding report must leave that report reproducible.
+    """
+    changed_rel = {
+        relative_to_proposal(path, proposal_dir)
+        for path in report.changed_files
+        if path.startswith(proposal_dir.rstrip("/") + "/")
+    }
+    primary_path = base / "proposal.md"
+    if not primary_path.is_file():
+        return
+    try:
+        metadata, _ = parse_front_matter(primary_path.read_text(encoding="utf-8"))
+    except UnicodeDecodeError:
+        return
+
+    translation_name = metadata.get("translation_file", "")
+    translation_report = None
+    if translation_name in {"proposal.zh.md", "proposal.en.md"} and (
+        base / translation_name
+    ).is_file():
+        language = "zh" if translation_name == "proposal.zh.md" else "en"
+        translation_report = f"report/proposal.{language}.html"
+
+    candidates = [
+        (
+            "proposal.md",
+            "report/proposal.html",
+            f"proposal.{translation_name.split('.')[1]}.html"
+            if translation_report
+            else None,
+        )
+    ]
+    if translation_report:
+        candidates.append((translation_name, translation_report, "proposal.html"))
+
+    for source_name, report_name, translation_href in candidates:
+        if {source_name, report_name}.isdisjoint(changed_rel):
+            continue
+        source_path = base / source_name
+        report_path = base / report_name
+        if not source_path.is_file() or not report_path.is_file():
+            continue
+        display_path = f"{proposal_dir}/{report_name}"
+        try:
+            expected = render_html(base, source_name, translation_href=translation_href)
+            actual = report_path.read_text(encoding="utf-8")
+        except Exception as exc:
+            report.add_error(
+                f"{display_path}: trusted renderer could not reproduce the report: {exc}"
+            )
+            continue
+        if actual != expected:
+            report.add_error(
+                f"{display_path}: does not match the trusted renderer output; rerun "
+                f"`python3 scripts/render_proposal_html.py {proposal_dir}` and refresh manifest hashes"
+            )
+
+
 def validate_visual_html_safety(
     report: ValidationReport,
     path: Path,
@@ -1673,7 +1740,12 @@ def validate_bilingual_display(
                 )
 
 
-def validate_ai_package_dir(report: ValidationReport, repo_root: Path, proposal_dir: str) -> None:
+def validate_ai_package_dir(
+    report: ValidationReport,
+    repo_root: Path,
+    proposal_dir: str,
+    check_generated_reports: bool = False,
+) -> None:
     base = repo_root / proposal_dir
     for required in sorted(REQUIRED_AI_PACKAGE_FILES):
         if not (base / required).exists():
@@ -1731,6 +1803,9 @@ def validate_ai_package_dir(report: ValidationReport, repo_root: Path, proposal_
                 require_primary_figures=False,
                 translation_advisory=not strict_bilingual,
             )
+
+    if check_generated_reports:
+        validate_generated_report_freshness(report, proposal_dir, base)
 
     for visual_name in ["index.html", "index.zh.html", "index.en.html"]:
         visual_path = base / "visual" / visual_name
@@ -2090,6 +2165,8 @@ def validate_submission(
     pr_author: str,
     changed_files: Iterable[str],
     maintainer_bypass_logins: Iterable[str] = (),
+    *,
+    check_generated_reports: bool = False,
 ) -> ValidationReport:
     report = ValidationReport()
     repo_root = repo_root.resolve()
@@ -2316,7 +2393,12 @@ def validate_submission(
     for proposal_dir in sorted(ai_package_dirs):
         if proposal_dir in unsafe_submission_dirs:
             continue
-        validate_ai_package_dir(report, repo_root, proposal_dir)
+        validate_ai_package_dir(
+            report,
+            repo_root,
+            proposal_dir,
+            check_generated_reports=check_generated_reports,
+        )
 
     for changelog_path in sorted(changelog_files):
         if str(PurePosixPath(changelog_path).parent) in unsafe_submission_dirs:
@@ -2373,12 +2455,19 @@ def main() -> int:
     parser.add_argument("--changed-file", action="append")
     parser.add_argument("--changed-files-list")
     parser.add_argument("--maintainer-bypass-logins", default=os.getenv("MAINTAINER_BYPASS_LOGINS", ""))
+    parser.add_argument("--check-generated-reports", action="store_true")
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args()
 
     changed_files = load_changed_files(args)
     bypass_logins = [item for item in args.maintainer_bypass_logins.split(",") if item.strip()]
-    report = validate_submission(Path(args.repo_root), args.pr_author, changed_files, bypass_logins)
+    report = validate_submission(
+        Path(args.repo_root),
+        args.pr_author,
+        changed_files,
+        bypass_logins,
+        check_generated_reports=args.check_generated_reports,
+    )
 
     if args.json:
         print(json.dumps(report.to_dict(), ensure_ascii=False, indent=2))

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -119,6 +119,18 @@ def complete_scaffold(output_dir: Path) -> subprocess.CompletedProcess:
         target = source.with_name(f"{source.stem}.en{source.suffix}")
         if not target.exists():
             target.write_bytes(source.read_bytes())
+    rendered = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "render_proposal_html.py"),
+            str(output_dir),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if rendered.returncode:
+        return rendered
     return subprocess.run(
         [sys.executable, str(REPO_ROOT / "scripts" / "finalize_submission.py"), str(output_dir)],
         capture_output=True,

--- a/tests/test_refresh_manifest_hashes.py
+++ b/tests/test_refresh_manifest_hashes.py
@@ -68,3 +68,20 @@ class RefreshManifestHashesTests(unittest.TestCase):
 
             self.assertNotEqual(0, completed.returncode)
             self.assertIn("must stay inside the package", completed.stdout)
+
+    def test_rejects_symlinked_manifest_without_modifying_its_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            package = Path(tmp) / "package"
+            outside = Path(tmp) / "outside-manifest.json"
+            package.mkdir()
+            outside.write_text('{"files": []}', encoding="utf-8")
+            if not hasattr(os, "symlink"):
+                self.skipTest("symlink support is unavailable")
+            os.symlink(outside, package / "manifest.json")
+            original = outside.read_bytes()
+
+            completed = self.run_refresh(package)
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn("manifest.json must stay inside the package", completed.stderr)
+            self.assertEqual(original, outside.read_bytes())

--- a/tests/test_refresh_manifest_hashes.py
+++ b/tests/test_refresh_manifest_hashes.py
@@ -1,0 +1,52 @@
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "refresh_manifest_hashes.py"
+
+
+class RefreshManifestHashesTests(unittest.TestCase):
+    def write_manifest(self, package: Path, files: list[dict]) -> None:
+        (package / "manifest.json").write_text(
+            json.dumps({"files": files}, ensure_ascii=False), encoding="utf-8"
+        )
+
+    def run_refresh(self, package: Path) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), str(package)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_refreshes_only_manifest_listed_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            package = Path(tmp)
+            proposal = package / "proposal.md"
+            proposal.write_text("proposal body\n", encoding="utf-8")
+            self.write_manifest(package, [{"path": "proposal.md", "sha256": "old"}])
+
+            completed = self.run_refresh(package)
+
+            self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+            manifest = json.loads((package / "manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(
+                hashlib.sha256(proposal.read_bytes()).hexdigest(),
+                manifest["files"][0]["sha256"],
+            )
+
+    def test_rejects_paths_outside_the_package(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            package = Path(tmp)
+            self.write_manifest(package, [{"path": "../outside.txt"}])
+
+            completed = self.run_refresh(package)
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn("must stay inside the package", completed.stdout)

--- a/tests/test_refresh_manifest_hashes.py
+++ b/tests/test_refresh_manifest_hashes.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -45,6 +46,23 @@ class RefreshManifestHashesTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             package = Path(tmp)
             self.write_manifest(package, [{"path": "../outside.txt"}])
+
+            completed = self.run_refresh(package)
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn("must stay inside the package", completed.stdout)
+
+    def test_rejects_symlinked_parent_escaping_package(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            package = Path(tmp) / "package"
+            outside = Path(tmp) / "outside"
+            package.mkdir()
+            outside.mkdir()
+            (outside / "secret.txt").write_text("outside package\n", encoding="utf-8")
+            if not hasattr(os, "symlink"):
+                self.skipTest("symlink support is unavailable")
+            os.symlink(outside, package / "assets")
+            self.write_manifest(package, [{"path": "assets/secret.txt"}])
 
             completed = self.run_refresh(package)
 

--- a/tests/test_render_proposal_html.py
+++ b/tests/test_render_proposal_html.py
@@ -53,6 +53,31 @@ summary: "离线阅读版"
             self.assertIn('data-evidence-value="SITE-PACKAGE"', html)
             self.assertIn('>来源</sup>', html)
 
+    def test_render_html_accepts_a_leading_blank_line_before_front_matter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission_dir = Path(tmp)
+            (submission_dir / "proposal.md").write_text(
+                '\n---\ntitle: "测试方案"\nsummary: "离线阅读版"\n---\n\n# 测试方案\n',
+                encoding="utf-8",
+            )
+
+            html = render_html(submission_dir)
+
+            self.assertIn("<h1>测试方案</h1>", html)
+            self.assertNotIn("<p>---", html)
+
+    def test_render_html_does_not_repeat_a_leading_title_in_the_body(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission_dir = Path(tmp)
+            (submission_dir / "proposal.md").write_text(
+                '---\ntitle: "测试方案"\nsummary: "离线阅读版"\n---\n\n# 测试方案\n\n正文。\n',
+                encoding="utf-8",
+            )
+
+            html = render_html(submission_dir)
+
+            self.assertEqual(1, html.count("<h1>测试方案</h1>"))
+
     def test_render_html_renders_markdown_tables(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             submission_dir = Path(tmp)

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -37,6 +37,7 @@ from github_pr_validation import (  # noqa: E402
     validation_paths_for,
 )
 from validate_local_submission import discover_submission_files  # noqa: E402
+from render_proposal_html import parse_front_matter, render_html  # noqa: E402
 
 
 class _Response:
@@ -580,6 +581,50 @@ class SubmissionWorkflowTests(unittest.TestCase):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(content)
 
+    def render_reports(self, root: Path, base: str) -> None:
+        package = root / base
+        metadata, _ = parse_front_matter(
+            (package / "proposal.md").read_text(encoding="utf-8")
+        )
+        translation_name = metadata.get("translation_file", "")
+        translation_report = None
+        if translation_name in {"proposal.zh.md", "proposal.en.md"} and (
+            package / translation_name
+        ).is_file():
+            language = "zh" if translation_name == "proposal.zh.md" else "en"
+            translation_report = f"report/proposal.{language}.html"
+
+        self.write(
+            root,
+            f"{base}/report/proposal.html",
+            render_html(
+                package,
+                translation_href=(
+                    f"proposal.{translation_name.split('.')[1]}.html"
+                    if translation_report
+                    else None
+                ),
+            ),
+        )
+        if translation_report:
+            self.write(
+                root,
+                f"{base}/{translation_report}",
+                render_html(package, translation_name, translation_href="proposal.html"),
+            )
+
+        manifest_path = package / "manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        for item in manifest.get("files", []):
+            if not isinstance(item, dict) or "sha256" not in item:
+                continue
+            path = package / str(item.get("path", ""))
+            if path.is_file():
+                item["sha256"] = hashlib.sha256(path.read_bytes()).hexdigest()
+        manifest_path.write_text(
+            json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+        )
+
     def write_minimal_ai_package(self, root: Path, base: str) -> list[str]:
         proposal = f"{base}/proposal.md"
         self.write(root, proposal)
@@ -896,23 +941,13 @@ class SubmissionWorkflowTests(unittest.TestCase):
 <span data-metric="public_space_ratio" data-value="0.1">0.1</span>
 </body></html>""",
         )
-        self.write(
-            root,
-            f"{base}/report/proposal.html",
-            """<!doctype html><html lang="zh-CN"><head><meta charset="utf-8"><title>Proposal</title></head><body><main>
-<figure><img src="../assets/figures/site-overview.png" alt="资料证据链与提交包关系图"></figure>
-<figure><img src="../assets/figures/land-use-structure.png" alt="三层范围与空间工作框架图"></figure>
-<figure><img src="../assets/figures/key-areas.png" alt="三处重点区域索引与设计任务图"></figure>
-<figure><img src="../assets/figures/mobility-bluegreen.png" alt="交通慢行与蓝绿公共空间复合系统图"></figure>
-<figure><img src="../assets/figures/metrics-evidence.png" alt="核心指标复算与证据链图"></figure>
-</main></body></html>""",
-        )
         for figure in figure_assets:
             self.write(
                 root,
                 f"{base}/{figure}",
                 '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><title>Figure</title><rect width="10" height="10"/></svg>',
             )
+        self.render_reports(root, base)
         return [proposal] + [f"{base}/{item}" for item in required]
 
     def add_bilingual_v2_display(self, root: Path, base: str, changed: list[str]) -> None:
@@ -1327,6 +1362,39 @@ class SubmissionWorkflowTests(unittest.TestCase):
             report = validate_submission(root, "alice", changed)
             self.assertTrue(report.ok, report.errors)
 
+    def test_changed_report_must_match_trusted_renderer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            report_path = root / base / "report/proposal.html"
+            report_path.write_text(
+                report_path.read_text(encoding="utf-8") + "\n<!-- stale -->\n",
+                encoding="utf-8",
+            )
+
+            report = validate_submission(
+                root, "alice", changed, check_generated_reports=True
+            )
+
+            self.assertFalse(report.ok)
+            self.assertIn("does not match the trusted renderer output", "\n".join(report.errors))
+
+    def test_local_full_package_check_keeps_legacy_report_compatibility(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            report_path = root / base / "report/proposal.html"
+            report_path.write_text(
+                report_path.read_text(encoding="utf-8") + "\n<!-- legacy report -->\n",
+                encoding="utf-8",
+            )
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertTrue(report.ok, report.errors)
+
     def test_changelog_submission_passes_hard_validation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -1340,6 +1408,7 @@ class SubmissionWorkflowTests(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
+            self.render_reports(root, base)
             changelog = f"{base}/changelog.md"
             self.write(root, changelog, VALID_CHANGELOG)
             changed.append(changelog)
@@ -1485,6 +1554,7 @@ class SubmissionWorkflowTests(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
+            self.render_reports(root, base)
 
             report = validate_submission(root, "alice", changed)
 
@@ -1504,6 +1574,7 @@ class SubmissionWorkflowTests(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
+            self.render_reports(root, base)
 
             report = validate_submission(root, "alice", changed)
 
@@ -1560,6 +1631,7 @@ class SubmissionWorkflowTests(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
+            self.render_reports(root, base)
 
             report = validate_submission(root, "alice", changed)
 
@@ -1605,6 +1677,7 @@ class SubmissionWorkflowTests(unittest.TestCase):
             changed = self.write_minimal_ai_package(root, base)
             path = root / base / "proposal.md"
             path.write_text(english_primary(path.read_text(encoding="utf-8")), encoding="utf-8")
+            self.render_reports(root, base)
             self.promote_package_to_formal(root, base)
             report = validate_submission(root, "alice", changed)
             self.assertTrue(report.ok, report.errors)
@@ -1783,6 +1856,7 @@ class SubmissionWorkflowTests(unittest.TestCase):
                 })
             manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
             changed.extend(f"{base}/{path}" for path in companion_paths)
+            self.render_reports(root, base)
             report = validate_submission(root, "alice", changed)
             self.assertTrue(report.ok, report.errors)
             bilingual_warnings = [
@@ -2065,6 +2139,7 @@ class SubmissionWorkflowTests(unittest.TestCase):
                 )
             proposal_path.write_text(text, encoding="utf-8")
             self.add_bilingual_v2_display(root, base, changed)
+            self.render_reports(root, base)
             report = validate_submission(root, "alice", changed)
             self.assertTrue(report.ok, "\n".join(report.errors))
             self.assertNotIn("missing known metric reference", "\n".join(report.errors))


### PR DESCRIPTION
## What changed

- Make the proposal renderer remove a leading H1 when it exactly repeats the front-matter title, so the hero title is not duplicated in generated reports.
- Add a forward-only deterministic GitHub PR check: when a PR changes `proposal.md`, a localized proposal, or its matching rendered report, the report must exactly match the trusted renderer output. Full-package local self-check stays compatible with historical reports; `--check-generated-reports` opts into the same check locally.
- Align renderer front-matter parsing with the validator for files that begin with a BOM or blank line.
- Add a manifest hash refresh command that updates only listed regular files and rejects package-escaping paths.

## Why

PR #775 exposes a generator behavior where a repeated leading H1 becomes a duplicate report title. Existing static HTML checks accept it because they do not verify that a changed artifact matches the trusted renderer. The new PR-only check rejects that mismatch without retroactively requiring historical packages to be rewritten or blocking ordinary full-package self-checks.

This overlaps the title-only generator correction in #779 and extends it with the reproducibility gate, actionable hash-refresh command, and end-to-end self-check coverage.

## Contributor impact

After changing a proposal or rendered report, run:

```bash
python3 scripts/render_proposal_html.py submissions/<github-login>/<proposal-slug>
python3 scripts/refresh_manifest_hashes.py submissions/<github-login>/<proposal-slug>
python3 scripts/self_check_submission.py submissions/<github-login>/<proposal-slug> --pr-author <github-login>
```

## Validation

- `python3 -m pytest -q` — 273 passed
- Replayed the exact #775 head (`0295f44b6c38d8f415b53cb2b3439f01e18fca53`): ordinary full-package validation passes; the explicit PR-freshness mode rejects the two changed reports.
