### PR TITLE
feat: flag high-similarity schema structures

### DIFF
--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -114,6 +114,12 @@ python3 scripts/prelaunch_check.py
 
 若输出不是 `Recommendation: **formal-review-ready**`，或 `prelaunch_check.py` 失败，应先修复审核逻辑、展示索引或公开文档，不要发布新的投稿入口。
 
+### Schema 来源复核信号
+
+`submission-validation` 会对本次新增或修改的 `*.schema.json`，与当前受信任主线中**其他投稿**的既有 Schema 做一个窄的结构比较。只有顶层 `required` 字段至少 8 项且同序，并且至少 3 个同名嵌套对象的 `required` 字段是保序的同集/子集，CI 才会输出 provenance warning。
+
+该 warning 不判定抄袭、侵权、作者意图或改编许可，也不自动阻断投稿。维护者应回看提交历史、原始来源、逐资产署名和实际许可；若来源或授权仍不清楚，应要求补证、独立重设计，或在权利结论前暂停公开展示。不要以补一行 attribution 代替权利人确认。
+
 ## 5. 合并后更新公开展示与首页精选
 
 合并到 `main` 的方案会自动进入 `submissions.html`。维护者只在需要首页精选或明确暂停展示时编辑 `gallery-publication.json`：

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -21,6 +21,7 @@ import urllib.request
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+from schema_provenance_review import format_similarity_warning, review_changed_schema_files
 from validate_submission import (
     PARTICIPANT_PROTECTED_GLOBAL_FILES,
     PROTECTED_REVIEW_ARTIFACT_PREFIXES,
@@ -483,6 +484,13 @@ def main() -> int:
                 )
         else:
             validation = validate_submission(worktree, pr_author, validation_files, bypass)
+        trusted_repo_root = Path(__file__).resolve().parents[1]
+        for finding in review_changed_schema_files(
+            worktree,
+            trusted_repo_root,
+            validation_files,
+        ):
+            validation.add_warning(format_similarity_warning(finding))
         validation_markdown = format_report(validation)
 
         if not is_current_pull_request_head(client, pr_number, head_sha):

--- a/scripts/schema_provenance_review.py
+++ b/scripts/schema_provenance_review.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Surface unusually close JSON Schema structures for human provenance review.
+
+This module deliberately does not decide originality, plagiarism, copyright, or
+permission. It identifies a narrow, reproducible structural signal so a
+maintainer can inspect sources, attribution, and licence boundaries before a
+submission is published.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+
+MIN_TOP_LEVEL_REQUIRED_FIELDS = 8
+MIN_NESTED_REQUIRED_MATCHES = 3
+MIN_NESTED_REQUIRED_FIELDS = 3
+MAX_FINDINGS_PER_CANDIDATE = 3
+
+
+@dataclass(frozen=True)
+class SchemaFingerprint:
+    """Required-field vectors at the root and named object-property paths."""
+
+    top_level_required: tuple[str, ...]
+    nested_required: dict[str, tuple[str, ...]]
+
+
+@dataclass(frozen=True)
+class SchemaSimilarityFinding:
+    """A high-confidence structural signal that needs human review."""
+
+    candidate_path: str
+    peer_path: str
+    top_level_required_count: int
+    nested_paths: tuple[str, ...]
+
+
+def _required_vector(value: object) -> tuple[str, ...] | None:
+    if not isinstance(value, dict):
+        return None
+    required = value.get("required")
+    if not isinstance(required, list) or not all(isinstance(item, str) for item in required):
+        return None
+    if len(required) != len(set(required)):
+        return None
+    return tuple(required)
+
+
+def fingerprint_schema(value: object) -> SchemaFingerprint | None:
+    """Return only field structure, never descriptions, examples, or prose."""
+    if not isinstance(value, dict):
+        return None
+
+    top_level_required = _required_vector(value)
+    if top_level_required is None:
+        return None
+
+    nested_required: dict[str, tuple[str, ...]] = {}
+
+    def visit(node: object, path: tuple[str, ...]) -> None:
+        if not isinstance(node, dict):
+            return
+        if path:
+            required = _required_vector(node)
+            if required is not None:
+                nested_required[".".join(path)] = required
+        properties = node.get("properties")
+        if not isinstance(properties, dict):
+            return
+        for name, child in properties.items():
+            if isinstance(name, str):
+                visit(child, (*path, name))
+
+    visit(value, ())
+    return SchemaFingerprint(top_level_required, nested_required)
+
+
+def _ordered_subset(smaller: tuple[str, ...], larger: tuple[str, ...]) -> bool:
+    """Require common fields to retain their relative required-field order."""
+    smaller_fields = set(smaller)
+    if not smaller_fields.issubset(larger):
+        return False
+    return smaller == tuple(item for item in larger if item in smaller_fields)
+
+
+def _nested_required_matches(
+    candidate: SchemaFingerprint,
+    peer: SchemaFingerprint,
+) -> tuple[str, ...]:
+    matches: list[str] = []
+    for path, candidate_fields in candidate.nested_required.items():
+        peer_fields = peer.nested_required.get(path)
+        if peer_fields is None:
+            continue
+        if min(len(candidate_fields), len(peer_fields)) < MIN_NESTED_REQUIRED_FIELDS:
+            continue
+        if _ordered_subset(candidate_fields, peer_fields) or _ordered_subset(peer_fields, candidate_fields):
+            matches.append(path)
+    return tuple(sorted(matches))
+
+
+def find_structural_similarity(
+    candidate_path: str,
+    candidate: SchemaFingerprint,
+    peer_path: str,
+    peer: SchemaFingerprint,
+) -> SchemaSimilarityFinding | None:
+    """Return a finding only for a deliberately high bar of shared structure."""
+    top_level = candidate.top_level_required
+    if len(top_level) < MIN_TOP_LEVEL_REQUIRED_FIELDS or top_level != peer.top_level_required:
+        return None
+    nested_paths = _nested_required_matches(candidate, peer)
+    if len(nested_paths) < MIN_NESTED_REQUIRED_MATCHES:
+        return None
+    return SchemaSimilarityFinding(
+        candidate_path=candidate_path,
+        peer_path=peer_path,
+        top_level_required_count=len(top_level),
+        nested_paths=nested_paths,
+    )
+
+
+def _load_fingerprint(path: Path) -> SchemaFingerprint | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return fingerprint_schema(value)
+
+
+def _proposal_root(path: PurePosixPath) -> tuple[str, str] | None:
+    if len(path.parts) < 4 or path.parts[0] != "submissions":
+        return None
+    return path.parts[1], path.parts[2]
+
+
+def _changed_schema_paths(worktree: Path, changed_files: list[str]) -> list[PurePosixPath]:
+    paths: list[PurePosixPath] = []
+    for raw_path in changed_files:
+        path = PurePosixPath(raw_path)
+        if path.is_absolute() or ".." in path.parts or not path.name.endswith(".schema.json"):
+            continue
+        if _proposal_root(path) is None or not (worktree / path).is_file():
+            continue
+        paths.append(path)
+    return sorted(dict.fromkeys(paths), key=lambda item: item.as_posix())
+
+
+def review_changed_schema_files(
+    worktree: Path,
+    trusted_repo_root: Path,
+    changed_files: list[str],
+) -> list[SchemaSimilarityFinding]:
+    """Compare changed submission schemas with existing peer submission schemas.
+
+    `worktree` contains inert contributor files. `trusted_repo_root` must be the
+    checked-out base branch, so a submission cannot select the peer corpus that
+    produces a warning.
+    """
+    peer_root = trusted_repo_root / "submissions"
+    if not peer_root.is_dir():
+        return []
+
+    peer_fingerprints: list[tuple[PurePosixPath, SchemaFingerprint]] = []
+    for peer_file in sorted(peer_root.rglob("*.schema.json")):
+        if not peer_file.is_file():
+            continue
+        fingerprint = _load_fingerprint(peer_file)
+        if fingerprint is not None:
+            peer_fingerprints.append((peer_file.relative_to(trusted_repo_root), fingerprint))
+
+    findings: list[SchemaSimilarityFinding] = []
+    for candidate_path in _changed_schema_paths(worktree, changed_files):
+        candidate_fingerprint = _load_fingerprint(worktree / candidate_path)
+        candidate_root = _proposal_root(candidate_path)
+        if candidate_fingerprint is None or candidate_root is None:
+            continue
+        candidate_findings: list[SchemaSimilarityFinding] = []
+        for peer_path, peer_fingerprint in peer_fingerprints:
+            if peer_path == candidate_path or _proposal_root(peer_path) == candidate_root:
+                continue
+            finding = find_structural_similarity(
+                candidate_path.as_posix(),
+                candidate_fingerprint,
+                peer_path.as_posix(),
+                peer_fingerprint,
+            )
+            if finding is not None:
+                candidate_findings.append(finding)
+        findings.extend(
+            sorted(
+                candidate_findings,
+                key=lambda item: (-len(item.nested_paths), item.peer_path),
+            )[:MAX_FINDINGS_PER_CANDIDATE]
+        )
+    return findings
+
+
+def format_similarity_warning(finding: SchemaSimilarityFinding) -> str:
+    """Keep the CI signal precise and non-accusatory."""
+    nested_paths = ", ".join(f"`{path}`" for path in finding.nested_paths)
+    return (
+        f"{finding.candidate_path}: has the same ordered top-level `required` fields "
+        f"({finding.top_level_required_count}) as existing peer schema {finding.peer_path}, "
+        f"with ordered equal/subset nested `required` fields at {nested_paths}; "
+        "maintainer provenance, attribution, and licence review required. "
+        "This structural signal is not an automated plagiarism, infringement, or permission conclusion."
+    )

--- a/tests/test_schema_provenance_review.py
+++ b/tests/test_schema_provenance_review.py
@@ -1,0 +1,122 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from schema_provenance_review import (  # noqa: E402
+    format_similarity_warning,
+    review_changed_schema_files,
+)
+
+
+def receipt_schema(drop_fields: bool = False) -> dict:
+    required = [
+        "schema_version",
+        "receipt_id",
+        "scenario_id",
+        "status",
+        "problem",
+        "place",
+        "data",
+        "system",
+        "human_gate",
+        "rights",
+        "operations",
+        "evaluation",
+        "handoff",
+        "disclaimer",
+    ]
+    properties = {
+        "problem": {"type": "object", "required": ["statement", "public_interest", "proposer_role", "evidence_refs"]},
+        "place": {"type": "object", "required": ["geometry_ref", "geometry_status", "space_mode", "non_ai_path"]},
+        "data": {"type": "object", "required": ["purpose", "minimum_fields", "personal_data", "retention", "deletion_verification"]},
+        "system": {"type": "object", "required": ["deployment_status", "model_or_ruleset", "version", "artifact_hash", "tool_permissions", "forbidden_actions", "abstention_conditions"]},
+        "human_gate": {"type": "object", "required": ["accountable_role", "reviewer_roles", "decision", "signed_at", "decision_diff"]},
+        "rights": {"type": "object", "required": ["notice", "opt_out", "appeal", "accessibility", "deletion"]},
+        "operations": {"type": "object", "required": ["service_window", "on_call_role", "fallback", "maintenance_owner", "cost_status", "exit_asset_plan"]},
+        "evaluation": {"type": "object", "required": ["baseline_status", "candidate_metrics", "performance_results", "stop_conditions", "review_cycle"]},
+        "handoff": {"type": "object", "required": ["from_role", "to_role", "output_object", "next_gate"]},
+    }
+    if drop_fields:
+        for name, removed in {
+            "problem": "proposer_role",
+            "place": "space_mode",
+            "data": "deletion_verification",
+            "system": "model_or_ruleset",
+            "human_gate": "decision_diff",
+            "operations": "cost_status",
+            "evaluation": "review_cycle",
+        }.items():
+            properties[name]["required"].remove(removed)
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": required,
+        "properties": properties,
+    }
+
+
+class SchemaProvenanceReviewTests(unittest.TestCase):
+    def write_schema(self, root: Path, relative: str, schema: dict) -> None:
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(schema, ensure_ascii=False), encoding="utf-8")
+
+    def test_flags_issue_style_ordered_top_level_and_nested_subsets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            trusted = Path(tmp) / "trusted"
+            worktree = Path(tmp) / "worktree"
+            peer = "submissions/Mentat-Uran/civic/visual/assets/relay-receipt.schema.json"
+            candidate = "submissions/147228/open-pulse/visual/assets/open-pulse-relay-receipt.schema.json"
+            self.write_schema(trusted, peer, receipt_schema())
+            self.write_schema(worktree, candidate, receipt_schema(drop_fields=True))
+
+            findings = review_changed_schema_files(worktree, trusted, [candidate])
+
+        self.assertEqual(1, len(findings))
+        self.assertEqual(candidate, findings[0].candidate_path)
+        self.assertEqual(peer, findings[0].peer_path)
+        self.assertEqual(14, findings[0].top_level_required_count)
+        self.assertGreaterEqual(len(findings[0].nested_paths), 3)
+        warning = format_similarity_warning(findings[0])
+        self.assertIn("not an automated plagiarism", warning)
+        self.assertIn("licence review required", warning)
+
+    def test_does_not_flag_a_partial_generic_overlap(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            trusted = Path(tmp) / "trusted"
+            worktree = Path(tmp) / "worktree"
+            peer = "submissions/peer/design/visual/assets/contract.schema.json"
+            candidate = "submissions/alice/design/visual/assets/receipt.schema.json"
+            self.write_schema(
+                trusted,
+                peer,
+                {"type": "object", "required": ["id", "status", "data"], "properties": {}},
+            )
+            self.write_schema(worktree, candidate, receipt_schema(drop_fields=True))
+
+            findings = review_changed_schema_files(worktree, trusted, [candidate])
+
+        self.assertEqual([], findings)
+
+    def test_does_not_compare_schemas_within_the_same_submission(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            trusted = Path(tmp) / "trusted"
+            worktree = Path(tmp) / "worktree"
+            peer = "submissions/alice/design/visual/assets/old.schema.json"
+            candidate = "submissions/alice/design/visual/assets/new.schema.json"
+            self.write_schema(trusted, peer, receipt_schema())
+            self.write_schema(worktree, candidate, receipt_schema(drop_fields=True))
+
+            findings = review_changed_schema_files(worktree, trusted, [candidate])
+
+        self.assertEqual([], findings)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -41,6 +41,7 @@ from github_pr_validation import (  # noqa: E402
     validation_paths_for,
 )
 from validate_local_submission import discover_submission_files  # noqa: E402
+from schema_provenance_review import SchemaSimilarityFinding  # noqa: E402
 
 
 class _Response:
@@ -490,6 +491,90 @@ class ManifestHydrationTests(unittest.TestCase):
         client.fetch_content.assert_not_called()
         comment = client.upsert_comment.call_args.args[1]
         self.assertIn("non-submission code/docs/test PR", comment)
+
+    def test_provenance_signal_is_reported_without_deciding_rights(self) -> None:
+        candidate = "submissions/alice/design/visual/assets/receipt.schema.json"
+        event = {
+            "pull_request": {
+                "number": 648,
+                "user": {"login": "alice"},
+                "head": {"repo": {"full_name": "alice/haidian"}, "sha": "head-sha"},
+            }
+        }
+        files = [{"filename": candidate, "status": "added"}]
+        finding = SchemaSimilarityFinding(
+            candidate_path=candidate,
+            peer_path="submissions/peer/design/visual/assets/receipt.schema.json",
+            top_level_required_count=14,
+            nested_paths=("rights", "handoff", "evaluation"),
+        )
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
+            json.dump(event, event_file)
+            event_file.flush()
+            client = MagicMock()
+            client.repository = "open-city-ai/haidian"
+            client.request.return_value = ({"head": {"sha": "head-sha"}}, {})
+            client.paginate.return_value = files
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "token",
+                    "GITHUB_REPOSITORY": "open-city-ai/haidian",
+                    "GITHUB_EVENT_PATH": event_file.name,
+                },
+                clear=False,
+            ), patch("github_pr_validation.GitHubClient", return_value=client), patch(
+                "github_pr_validation.review_changed_schema_files", return_value=[finding]
+            ):
+                self.assertEqual(1, main())
+        comment = client.upsert_comment.call_args.args[1]
+        self.assertIn("maintainer provenance, attribution, and licence review required", comment)
+        self.assertIn("not an automated plagiarism", comment)
+
+    def test_maintainer_submission_schema_still_receives_provenance_signal(self) -> None:
+        candidate = "submissions/maintainer/design/visual/assets/receipt.schema.json"
+        event = {
+            "pull_request": {
+                "number": 649,
+                "user": {"login": "maintainer"},
+                "head": {"repo": {"full_name": "maintainer/haidian"}, "sha": "head-sha"},
+            }
+        }
+        files = [{"filename": candidate, "status": "added"}]
+
+        def download_content(_repo, path, _sha, destination, *_args):
+            if path == candidate:
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_text('{"type":"object","required":[]}', encoding="utf-8")
+
+        finding = SchemaSimilarityFinding(
+            candidate_path=candidate,
+            peer_path="submissions/peer/design/visual/assets/receipt.schema.json",
+            top_level_required_count=14,
+            nested_paths=("rights", "handoff", "evaluation"),
+        )
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
+            json.dump(event, event_file)
+            event_file.flush()
+            client = MagicMock()
+            client.paginate.return_value = files
+            client.download_content.side_effect = download_content
+            client.fetch_content.return_value = False
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "token",
+                    "GITHUB_REPOSITORY": "open-city-ai/haidian",
+                    "GITHUB_EVENT_PATH": event_file.name,
+                    "MAINTAINER_BYPASS_LOGINS": "maintainer",
+                },
+                clear=False,
+            ), patch("github_pr_validation.GitHubClient", return_value=client), patch(
+                "github_pr_validation.review_changed_schema_files", return_value=[finding]
+            ):
+                self.assertEqual(1, main())
+        comment = client.upsert_comment.call_args.args[1]
+        self.assertIn("maintainer provenance, attribution, and licence review required", comment)
 
     def test_review_queue_candidate_is_one_author_owned_submission(self) -> None:
         self.assertTrue(

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -502,6 +502,12 @@ class ManifestHydrationTests(unittest.TestCase):
             }
         }
         files = [{"filename": candidate, "status": "added"}]
+
+        def download_content(_repo, path, _sha, destination, *_args):
+            if path == candidate:
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_text('{"type":"object","required":[]}', encoding="utf-8")
+
         finding = SchemaSimilarityFinding(
             candidate_path=candidate,
             peer_path="submissions/peer/design/visual/assets/receipt.schema.json",
@@ -515,6 +521,8 @@ class ManifestHydrationTests(unittest.TestCase):
             client.repository = "open-city-ai/haidian"
             client.request.return_value = ({"head": {"sha": "head-sha"}}, {})
             client.paginate.return_value = files
+            client.download_content.side_effect = download_content
+            client.fetch_content.return_value = False
             with patch.dict(
                 os.environ,
                 {
@@ -557,6 +565,8 @@ class ManifestHydrationTests(unittest.TestCase):
             json.dump(event, event_file)
             event_file.flush()
             client = MagicMock()
+            client.repository = "open-city-ai/haidian"
+            client.request.return_value = ({"head": {"sha": "head-sha"}}, {})
             client.paginate.return_value = files
             client.download_content.side_effect = download_content
             client.fetch_content.return_value = False


### PR DESCRIPTION
## What changed

- Adds a deterministic, non-blocking review of changed submission `*.schema.json` files against peer schemas on the trusted base branch.
- Emits a provenance warning only when the ordered top-level `required` vector has at least eight identical fields and at least three same-path nested `required` vectors are ordered equal/subset relations.
- Keeps the signal explicitly non-accusatory: it does not determine plagiarism, infringement, author intent, or permission.
- Documents the required maintainer follow-up: inspect history, attribution, source and actual licence; do not treat attribution alone as adaptation permission.

## Why

The #706 review showed that a strong, reproducible structural signal can be missed until after publication. This adds an early human-review cue without turning a deterministic CI check into an automated legal or originality verdict.

## Validation

- `python3 -m pytest -q` — 272 passed
- Historical replay finds the #706 relay-receipt pair (14 ordered top-level fields and 9 nested required-field relations).
- Negative tests cover generic partial overlap and schemas from the same submission.
- `git diff --check` and `py_compile` pass.
