### PR TITLE
fix: separate nonblocking data limitations

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,7 +33,7 @@
 
 - [ ] `geometry/site_boundary.geojson` 使用可信 official boundary，且 `official_boundary=true`
 - [ ] `geometry/key_areas.geojson` 使用三处可信 official key-area polygons，且 `official_boundary=true`
-- [ ] `manifest.validation_claim.known_blockers` 为空
+- [ ] `manifest.validation_claim.known_blockers` 为空（投稿者可修复的阻断项）；组织方资料缺口、临时边界和复算要求记录在可选的 `known_limitations`，不为消除警告而删除
 - [ ] `self_check_submission.py` 输出 `can_enter_formal_review=true`
 - [ ] 没有 blocking self-check、空间复核、视觉复核或专业证据链缺口
 

--- a/brief/site-package/schemas/manifest.schema.json
+++ b/brief/site-package/schemas/manifest.schema.json
@@ -155,6 +155,12 @@
             "type": "string"
           }
         },
+        "known_limitations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "data_confidence": {
           "type": "string",
           "enum": [

--- a/docs/formal-submission-guide.md
+++ b/docs/formal-submission-guide.md
@@ -36,7 +36,7 @@
 
 面向智能体的开源征集任务书已整理为 `brief/site-package/agent_taskbook.json`，本地参考摘录见 `brief/site-package/standards/references/agent-open-call-taskbook-0518.md`。它补充了十条智能体共创原则、持续参与与协作循环、三大定位、五大功能、三区两翼、六项智能体任务、统一评审维度和统一边界条款。agent 必须把这些要求写入 `proposal.md`、`compliance_matrix.json`、`standard_matrix.json`、HTML 和图纸，不得只在 JSON 中形式覆盖；任务书、资料或社区反馈更新后，应重新同步、复核并迭代方案。
 
-公开资料登记表位于 `data/source_registry.json`，处理规则见 `docs/data-workflow.md`。agent 必须区分 `usable_for_formal="yes"`、`background_only` 和 `provisional_only`：formal 权威结论只能来自已批准的 formal 可用资料；背景资料不能支撑空间控制结论；provisional 资料只能支撑临时生成、可视化和讨论，不能冒充官方或精确依据，但该数据缺口本身不阻断内容评分。
+公开资料登记表位于 `data/source_registry.json`，处理规则见 `docs/data-workflow.md`。agent 必须区分 `usable_for_formal="yes"`、`background_only` 和 `provisional_only`：formal 权威结论只能来自已批准的 formal 可用资料；背景资料不能支撑空间控制结论；provisional 资料只能支撑临时生成、可视化和讨论，不能冒充官方或精确依据，但该数据缺口本身不阻断内容评分。将投稿者能修复的缺件、来源/授权不足等事项写入 `manifest.validation_claim.known_blockers`；将组织方资料缺口、临时边界和精度复算要求写入可选的 `known_limitations`。不要为了获得更高 readiness 删除真实限制。
 
 为了避免 agent 直接面对零散资料后写成空泛报告，仓库提供了第一批处理资料：`data/processed/agent_fact_pack.md`、`project_scope_summary.csv`、`agent_task_requirements.csv`、`source_use_matrix.csv` 和 `missing_data_checklist.csv`。参赛者应先用这些文件建立任务清单、范围结构、资料用途和缺口清单，再在 `proposal.md` 中把它们翻译成可读的设计论证。处理资料不能替代原始来源；正文只回引直接支撑当前判断的 `source_id`，完整来源覆盖由 `sources.json` 负责。
 

--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -53,7 +53,7 @@ python3 scripts/maintainer_review.py \
 - `formal-review-ready`：可进入正式专业评分。
 - `reject`：触发强制拒绝条件，关闭或拒绝 PR。
 
-`package_type` 描述提交物种类，`review_status` 描述审核决定。组织方缺少 official boundary/key areas 只能形成精度与复算警示，不得阻断内容评分或导致扣分。
+`package_type` 描述提交物种类，`review_status` 描述审核决定。组织方缺少 official boundary/key areas 只能形成精度与复算警示，不得阻断内容评分或导致扣分。`known_blockers` 只记录投稿者可修复、应在正式评分前处理的事项；`known_limitations` 记录组织方资料缺口、临时边界与复算要求，必须保留给评审但不应被当作自动阻断。
 
 ### Intake 最低质量门槛
 

--- a/docs/simulations/fact-pack-provisional-intake-rehearsal.md
+++ b/docs/simulations/fact-pack-provisional-intake-rehearsal.md
@@ -53,7 +53,7 @@ Expected warnings:
 - `geometry/site_boundary.geojson` uses provisional boundary.
 - `geometry/key_areas.geojson` contains three provisional key areas.
 
-These warnings do not block intake, but they do block formal professional scoring.
+The transcript above records the former boundary-gated result. Under the current rule, these warnings do not block intake or content scoring; they must stay visible until official geometry is supplied and precision-sensitive metrics are recalculated.
 
 ## Maintainer Review Summary
 
@@ -66,7 +66,7 @@ python3 scripts/maintainer_review.py \
   --comment
 ```
 
-Result:
+Historical result:
 
 ```text
 Recommendation: intake-provisional
@@ -77,9 +77,18 @@ visual_review: PASS
 professional_review: PASS
 ```
 
+Current expected result for the same participant-controlled checks is:
+
+```text
+Recommendation: formal-review-ready
+Can enter formal professional scoring: YES
+```
+
+The change does not treat provisional geometry as authoritative. It separates the organizer-owned data limitation from participant-controlled readiness defects.
+
 ## Gallery Integration
 
-After maintainer-style index generation:
+Historical gallery result after maintainer-style index generation:
 
 ```bash
 python3 scripts/generate_submissions_data.py
@@ -96,9 +105,11 @@ visualUrl: submissions/codex-final/jingzhang-ai-symbiotic-rail/visual/index.html
 proposalUrl: submissions/codex-final/jingzhang-ai-symbiotic-rail/report/proposal.html
 ```
 
+Under the current rule, the corresponding current status is `formal_review_ready`; the retained limitation is shown to reviewers without downgrading the gallery status.
+
 ## Remaining Issues
 
-The flow is now walkable for intake. The project still needs official or cleared data before formal scoring:
+The flow is now walkable for content scoring, while the project still needs official or cleared data for authoritative geometry and precision-sensitive recalculation:
 
 - Official overall design area polygon.
 - Official coordinated research area polygon.

--- a/docs/simulations/provisional-formal-intake-review.md
+++ b/docs/simulations/provisional-formal-intake-review.md
@@ -23,7 +23,7 @@ This document records the former boundary-gated behavior. Current review eligibi
 - Spatial review: PASS with minor warnings for provisional key areas.
 - Visual packaging check: PASS.
 - Professional evidence review: PASS.
-- `can_enter_formal_review`: false.
+- Historical `can_enter_formal_review`: false.
 
 ## What Is Now Walkable
 
@@ -43,7 +43,7 @@ This document records the former boundary-gated behavior. Current review eligibi
 
 ## Reviewer Interpretation
 
-This is an intake-passable provisional formal submission, not an approval-ready professional scoring package. The system now separates two questions:
+The text below records the former boundary-gated interpretation. Under the current policy, it is a formal-review-ready submission when all participant-controlled checks pass; provisional geometry remains a visible data and precision limitation, not an official redline or a basis for precise-area claims. The system separates two questions:
 
 - Can the AI agent produce a readable, structured, topology-clean, self-checked proposal? Yes.
-- Can it enter official professional scoring without official polygons and control data? No.
+- Can it enter professional content scoring while awaiting organizer-supplied polygons and control data? Yes, with the limitation retained and affected metrics recalculated later.

--- a/scripts/export_review_packet.py
+++ b/scripts/export_review_packet.py
@@ -319,6 +319,12 @@ def known_blockers(packet: SubmissionPacket) -> list[str]:
     return [text(item) for item in as_list(blockers) if text(item).strip()]
 
 
+def known_limitations(packet: SubmissionPacket) -> list[str]:
+    validation_claim = as_dict(packet.manifest.get("validation_claim"))
+    limitations = validation_claim.get("known_limitations")
+    return [text(item) for item in as_list(limitations) if text(item).strip()]
+
+
 def metric_rows(packet: SubmissionPacket) -> list[list[Any]]:
     rows = []
     for key, value in sorted(packet.metrics.items()):
@@ -425,6 +431,11 @@ def append_packet_markdown(lines: list[str], packet: SubmissionPacket, index: in
     if blockers:
         lines.extend(["", "### 已知阻断项", ""])
         lines.extend(f"- {item}" for item in blockers)
+
+    limitations = known_limitations(packet)
+    if limitations:
+        lines.extend(["", "### 已知限制与资料边界", ""])
+        lines.extend(f"- {item}" for item in limitations)
 
     lines.extend(["", "### 风险与待补条件", ""])
     if packet.risk_dimensions:
@@ -603,6 +614,12 @@ def render_packet_html_section(packet: SubmissionPacket, output_dir: Path, index
         blocker_html = "<h3>已知阻断项</h3><ul>" + "".join(
             f"<li>{html.escape(item)}</li>" for item in blockers
         ) + "</ul>"
+    limitations = known_limitations(packet)
+    limitation_html = ""
+    if limitations:
+        limitation_html = "<h3>已知限制与资料边界</h3><ul>" + "".join(
+            f"<li>{html.escape(item)}</li>" for item in limitations
+        ) + "</ul>"
     summary_html = f"<p class=\"summary\">{html.escape(packet.summary)}</p>" if packet.summary else ""
     return f"""
 <article class="proposal">
@@ -617,6 +634,7 @@ def render_packet_html_section(packet: SubmissionPacket, output_dir: Path, index
     <div><span>版本 / 迭代</span><strong>{html.escape(packet.version or '未声明')} / {html.escape(packet.iteration or '未声明')}</strong></div>
   </section>
   {blocker_html}
+  {limitation_html}
   <h3>风险与待补条件</h3>
   {html_table(["风险维度", "等级", "说明", "缓解方式"], risk_rows(packet)) if packet.risk_dimensions else '<p class="empty">未提供 risk.json。</p>'}
   <h4>假设与资料缺口</h4>

--- a/scripts/generate_submissions_data.py
+++ b/scripts/generate_submissions_data.py
@@ -225,13 +225,19 @@ def classify_submission(submission_dir: Path, manifest: Any) -> str:
         return "legacy_fixture"
     if not package_complete(submission_dir):
         return "needs_revision"
+    # A stored self-check can be stale after the manifest changes. Current
+    # participant-controlled blockers must therefore outrank any historical
+    # `can_enter_formal_review=true` result. Organizer-owned limitations belong
+    # in `known_limitations` and do not enter this branch.
+    if known_blockers(manifest):
+        return "needs_revision"
     if stored_formal_readiness(submission_dir) is True:
         return "formal_review_ready"
     if stored_formal_readiness(submission_dir) is False:
         # Stored results created under the former organizer-data gate are not
         # authoritative. Only participant-controlled validation failures block.
         return "formal_review_ready" if not has_blocking_self_check(submission_dir) else "needs_revision"
-    if known_blockers(manifest) or has_blocking_self_check(submission_dir):
+    if has_blocking_self_check(submission_dir):
         return "needs_revision"
     return "formal_review_ready"
 

--- a/scripts/review_submission.py
+++ b/scripts/review_submission.py
@@ -208,7 +208,7 @@ def build_prompt(review_input: dict) -> str:
             "- Data gaps and repair actions",
             "- `pr_comment_markdown`: concise Markdown for a PR comment",
             "",
-            "Important: deterministic validation and spatial review results are evidence. Treat blocking self-checks, known blockers, and missing official geometry as serious readiness limits.",
+            "Important: deterministic validation and spatial review results are evidence. Treat participant-controlled blocking self-checks and known_blockers as serious readiness limits. Treat known_limitations (including organizer-owned missing official geometry, provisional boundaries, and precision-sensitive recalculation) as visible data boundaries: preserve them in the review, but do not let them by themselves block formal content scoring or reduce rubric scores. Keep this distinction explicit.",
             "Treat background_only, provisional_only, and needs_review registry entries as non-formal evidence unless the submitted package separately provides reviewed official/cleared evidence.",
             "Version 2 bilingual deliverables are mandatory. A missing, incomplete, malformed, or incorrectly mapped Chinese/English counterpart is a blocking package-readiness failure. Historical version 1 packages remain compatible; review their available language without inventing missing content. Human reviewers must still compare translated claims, metrics, evidence, and figure positions for substantive equivalence.",
             "If pre-submit self-check, spatial review, machine visual-packaging checks, or professional evidence review is FAIL, the package cannot enter formal professional scoring.",

--- a/scripts/scaffold_ai_submission.py
+++ b/scripts/scaffold_ai_submission.py
@@ -772,9 +772,9 @@ def make_visual_html(title: str, metrics: dict[str, Any], boundary_mode: str, ke
     readiness_text = (
         "official geometry ready for formal professional scoring"
         if boundary_mode == "official" and key_area_mode == "official"
-        else "provisional geometry: PASS intake only, replace with official polygons before formal professional scoring"
+        else "provisional geometry: content scoring remains eligible with a precision warning; recalculate when official polygons are supplied"
     )
-    readiness_label = "正式评分就绪" if boundary_mode == "official" and key_area_mode == "official" else "临时边界 intake"
+    readiness_label = "正式评分就绪" if boundary_mode == "official" and key_area_mode == "official" else "临时边界与复算"
     return f"""<!doctype html>
 <html lang="zh-CN">
 <head>
@@ -787,7 +787,7 @@ def make_visual_html(title: str, metrics: dict[str, Any], boundary_mode: str, ke
 </style>
 </head>
 <body>
-<header><div class="wrap hero"><div><div class="eyebrow">方案可视化总览 / Centennial Jing-Zhang AI Innovation Belt</div><h1>{title}</h1><p class="hero-copy">离线电子展示成果。权威数据仍以 GeoJSON、metrics.json、矩阵和自检结果为准；本页把总览地图、三层范围、重点区域、用地分区、交通慢行、蓝绿公共空间、建筑更新项目、AI 场景、核心指标、任务覆盖、自检状态、来源与假设转成人类可读的视觉说明。</p><div class="pill-row"><span class="pill">三层范围</span><span class="pill">重点区域</span><span class="pill">AI 场景</span><span class="pill">任务覆盖</span><span class="pill">自检状态</span></div></div><aside class="status-box"><strong>{readiness_label}</strong><p>{readiness_text}</p><p>使用 provisional 边界时，本页仅支持 intake 展示、讨论和返修，不作为正式专业评分图纸。</p></aside></div></header>
+<header><div class="wrap hero"><div><div class="eyebrow">方案可视化总览 / Centennial Jing-Zhang AI Innovation Belt</div><h1>{title}</h1><p class="hero-copy">离线电子展示成果。权威数据仍以 GeoJSON、metrics.json、矩阵和自检结果为准；本页把总览地图、三层范围、重点区域、用地分区、交通慢行、蓝绿公共空间、建筑更新项目、AI 场景、核心指标、任务覆盖、自检状态、来源与假设转成人类可读的视觉说明。</p><div class="pill-row"><span class="pill">三层范围</span><span class="pill">重点区域</span><span class="pill">AI 场景</span><span class="pill">任务覆盖</span><span class="pill">自检状态</span></div></div><aside class="status-box"><strong>{readiness_label}</strong><p>{readiness_text}</p><p>使用 provisional 边界时，须保留资料精度边界，并在官方多边形提供后复算；该组织方数据缺口本身不阻断内容评分。</p></aside></div></header>
 <main class="wrap">
 <section class="sheet"><div class="sheet-head"><div><h2>总览地图</h2><p>总览地图将用地分区、交通慢行、蓝绿公共空间、建筑与更新项目、AI 场景节点放在同一张证据图中，便于评审快速理解空间主线。</p></div><span class="tag">geometry + metrics</span></div><div class="map-grid"><div><div class="map-frame" aria-label="总览地图、三层范围、重点区域、用地分区、交通慢行、蓝绿公共空间、建筑与更新项目">
 <svg viewBox="0 0 1120 680" role="img" aria-label="专业城市设计总览地图">

--- a/scripts/self_check_submission.py
+++ b/scripts/self_check_submission.py
@@ -115,7 +115,13 @@ def next_actions(report: dict[str, Any]) -> list[str]:
         for error in stdout.get("errors", []) or []:
             actions.append(f"Fix deterministic validation error: {error}")
         for warning in stdout.get("warnings", []) or []:
-            if "cannot enter formal" in warning or "non-official" in warning:
+            if "known_blockers present" in warning:
+                actions.append(f"Resolve formal-readiness warning: {warning}")
+            elif "known_limitations present" in warning:
+                actions.append(
+                    f"Preserve nonblocking data/precision limitation for maintainer review: {warning}"
+                )
+            elif "cannot enter formal" in warning or "non-official" in warning:
                 actions.append(f"Resolve formal-readiness warning: {warning}")
             elif any(
                 marker in warning

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1075,7 +1075,13 @@ def validate_manifest_file(report: ValidationReport, repo_root: Path, proposal_d
         known_blockers = validation_claim.get("known_blockers")
         if isinstance(known_blockers, list) and known_blockers:
             report.add_warning(
-                f"{proposal_dir}/manifest.json: known_blockers present; submission may pass intake but cannot enter formal professional scoring until resolved"
+                f"{proposal_dir}/manifest.json: known_blockers present; resolve participant-controlled blockers before formal professional scoring"
+            )
+        known_limitations = validation_claim.get("known_limitations")
+        if isinstance(known_limitations, list) and known_limitations:
+            report.add_warning(
+                f"{proposal_dir}/manifest.json: known_limitations present; preserve the stated data/precision boundary for review. "
+                "Organizer-owned data gaps alone do not block content scoring"
             )
     return data, stage
 

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -533,6 +533,10 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
             props = site["features"][0]["properties"]
             self.assertEqual(props["geometry_role"], "provisional_constraint")
             self.assertFalse(props["official_boundary"])
+            visual = (submission_dir / "visual" / "index.html").read_text(encoding="utf-8")
+            self.assertIn("content scoring remains eligible", visual)
+            self.assertIn("该组织方数据缺口本身不阻断内容评分", visual)
+            self.assertNotIn("PASS intake only", visual)
 
     def test_formal_scaffold_fails_without_any_boundary_fixture(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_export_review_packet.py
+++ b/tests/test_export_review_packet.py
@@ -171,6 +171,25 @@ class ExportReviewPacketTests(unittest.TestCase):
             self.assertIn("## 2. 方案 B", markdown)
             self.assertIn("| 2 | 方案 B | bob |", markdown)
 
+    def test_export_distinguishes_known_limitations_from_blockers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            submission_dir = make_submission(repo_root, "alice", "proposal-a", "方案 A")
+            manifest_path = submission_dir / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["validation_claim"]["known_limitations"] = [
+                "Official boundary is not yet published; recalculate precision-sensitive metrics later."
+            ]
+            write_json(manifest_path, manifest)
+
+            files = export_review_packet(repo_root, [submission_dir], repo_root / "packet", "测试评审包")
+
+            markdown = Path(files["markdown"]).read_text(encoding="utf-8")
+            html = Path(files["html"]).read_text(encoding="utf-8")
+        self.assertIn("### 已知限制与资料边界", markdown)
+        self.assertNotIn("### 已知阻断项", markdown)
+        self.assertIn("已知限制与资料边界", html)
+
     def test_pdf_export_reports_missing_engine(self) -> None:
         original_exists = Path.exists
 

--- a/tests/test_review_submission.py
+++ b/tests/test_review_submission.py
@@ -84,6 +84,9 @@ summary: "围绕百年京张 AI 创新带提出可审查方案。"
             self.assertIn("pr_comment_markdown", prompt)
             self.assertIn("submissions-data.js", prompt)
             self.assertIn("Version 2 bilingual deliverables are mandatory", prompt)
+            self.assertIn("known_limitations", prompt)
+            self.assertIn("do not let them by themselves block formal content scoring", prompt)
+            self.assertNotIn("missing official geometry as serious readiness limits", prompt)
             self.assertTrue((out_dir / "advisory-review.md").exists())
 
     def test_advisory_review_schema_defines_pr_comment_contract(self) -> None:

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -37,6 +37,7 @@ from github_pr_validation import (  # noqa: E402
     validation_paths_for,
 )
 from validate_local_submission import discover_submission_files  # noqa: E402
+from self_check_submission import next_actions  # noqa: E402
 
 
 class _Response:
@@ -1623,6 +1624,35 @@ class SubmissionWorkflowTests(unittest.TestCase):
             path.write_text(readable, encoding="utf-8")
             report = validate_submission(root, "alice", [f"{base}/manifest.json"])
             self.assertTrue(report.ok, report.errors)
+
+    def test_known_limitations_are_nonblocking_and_preserved_for_review(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            self.update_json(
+                root,
+                f"{base}/manifest.json",
+                lambda data: data["validation_claim"].update(
+                    {
+                        "known_limitations": [
+                            "Provisional boundary; recalculate when organizer publishes official polygons."
+                        ]
+                    }
+                ),
+            )
+
+            report = validate_submission(root, "alice", changed)
+
+        self.assertTrue(report.ok, report.errors)
+        warnings = "\n".join(report.warnings)
+        self.assertIn("known_limitations present", warnings)
+        self.assertIn("Organizer-owned data gaps alone do not block", warnings)
+        actions = next_actions(
+            {"deterministic_validation": {"stdout": {"warnings": report.warnings}}}
+        )
+        self.assertTrue(any("Preserve nonblocking" in action for action in actions))
+        self.assertFalse(any("Resolve formal-readiness" in action for action in actions))
 
     def test_bilingual_contract_manifest_only_update_rechecks_full_package(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_submissions_gallery.py
+++ b/tests/test_submissions_gallery.py
@@ -16,6 +16,8 @@ from generate_submissions_data import (  # noqa: E402
     discover_submissions,
     load_publication_registry,
     package_sha256,
+    classify_submission,
+    REQUIRED_PACKAGE_FILES,
 )
 DATA_FILE = ROOT / "submissions-data.js"
 INDEX_FILE = ROOT / "index.html"
@@ -104,6 +106,28 @@ class TestSubmissionsGallery(unittest.TestCase):
                 encoding="utf-8",
             )
             self.assertEqual([], build_data(root))
+
+    def test_current_blockers_override_stale_formal_readiness(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission = root / "submissions" / "alice" / "example"
+            for rel in REQUIRED_PACKAGE_FILES:
+                path = submission / rel
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(b"placeholder")
+            (submission / "self_check.json").write_text(
+                json.dumps({"ok": True, "can_enter_formal_review": True}),
+                encoding="utf-8",
+            )
+            manifest = {
+                "submission_stage": "formal",
+                "validation_claim": {
+                    "self_checked": True,
+                    "known_blockers": ["Unresolved participant-controlled licence issue"],
+                },
+            }
+
+            self.assertEqual("needs_revision", classify_submission(submission, manifest))
 
     def test_publication_registry_rejects_missing_selection_metadata(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## What changed

- Add optional `validation_claim.known_limitations` for organizer-owned data gaps, provisional geometry, and later recalculation requirements.
- Keep `known_blockers` for contributor-remediable formal-readiness defects.
- Surface the two categories separately in validation, self-check actions, review-packet Markdown/HTML, templates, and guidance.
- Correct the new-submission scaffold and historical simulations so provisional geometry is a precision boundary, not an automatic scoring block.

## Why

PR #634 exposed a contradictory path: a submission described an organizer-owned provisional boundary, while generic `known_blockers` wording said any listed item stopped formal scoring. Project policy already says missing organizer geometry must not block content scoring or cause a deduction.

## Impact

Contributors retain real data limitations instead of deleting them to chase readiness. Maintainers can still require fixes for missing artifacts, provenance, or rights evidence, while seeing organizer data limits without automatically downgrading an otherwise valid package.

## Validation

- `python3 -m unittest tests.test_submission_workflow tests.test_export_review_packet tests.test_agent_scaffold_and_self_check -q` — 112 passed
- `python3 -m pytest -q` — 269 passed
- `python3 -m py_compile scripts/validate_submission.py scripts/self_check_submission.py scripts/export_review_packet.py scripts/scaffold_ai_submission.py`
- `git diff --check`