### PR TITLE
fix: quote participant preflight push commands

### DIFF
--- a/scripts/participant_preflight.py
+++ b/scripts/participant_preflight.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -77,11 +78,29 @@ def file_inventory(submission_dir: Path) -> tuple[list[dict[str, Any]], int]:
     return files, total
 
 
-def check_push(repo_root: Path, branch: str) -> dict[str, Any]:
-    completed = run(["git", "push", "--dry-run", "origin", f"HEAD:refs/heads/{branch}"], repo_root)
+def shell_push_command(
+    remote: str,
+    target: str,
+    *,
+    dry_run: bool = False,
+    set_upstream: bool = False,
+) -> str:
+    command = ["git", "push"]
+    if dry_run:
+        command.append("--dry-run")
+    if set_upstream:
+        command.append("-u")
+    command.extend([remote, target])
+    return shlex.join(command)
+
+
+def check_push(repo_root: Path, branch: str, remote: str = "origin") -> dict[str, Any]:
+    target = f"HEAD:refs/heads/{branch}"
+    command = ["git", "push", "--dry-run", remote, target]
+    completed = run(command, repo_root)
     return {
         "ok": completed.returncode == 0,
-        "command": f"git push --dry-run origin HEAD:refs/heads/{branch}",
+        "command": shell_push_command(remote, target, dry_run=True),
         "stdout": completed.stdout.strip(),
         "stderr": completed.stderr.strip(),
     }
@@ -141,12 +160,21 @@ def inspect(args: argparse.Namespace) -> dict[str, Any]:
 
     origin_url = git_output(repo_root, "remote", "get-url", "origin", allow_failure=True)
     upstream_url = git_output(repo_root, "remote", "get-url", "upstream", allow_failure=True)
-    if not origin_url:
+    push_remote_url = git_output(
+        repo_root,
+        "remote",
+        "get-url",
+        args.push_remote,
+        allow_failure=True,
+    )
+    if not origin_url and args.push_remote == "origin":
         blockers.append("origin remote is missing")
-    elif "open-city-ai/haidian" in origin_url and not args.allow_canonical_origin:
+    if not push_remote_url:
+        blockers.append(f"push remote '{args.push_remote}' is missing")
+    elif "open-city-ai/haidian" in push_remote_url and not args.allow_canonical_origin:
         warnings.append(
-            "origin points to the canonical repository; contributors without write access "
-            "should clone their fork as origin"
+            f"{args.push_remote} points to the canonical repository; contributors without "
+            "write access should select their writable fork remote"
         )
     if origin_url and "open-city-ai/haidian" not in origin_url and not upstream_url:
         warnings.append("fork workspace has no upstream remote for syncing open-city-ai/haidian")
@@ -205,10 +233,13 @@ def inspect(args: argparse.Namespace) -> dict[str, Any]:
             blockers.append("submission self-check failed; repair the reported issues before pushing")
 
     push_check: dict[str, Any] | None = None
-    if args.check_push and branch and origin_url:
-        push_check = check_push(repo_root, branch)
+    if args.check_push and branch and push_remote_url:
+        push_check = check_push(repo_root, branch, args.push_remote)
         if not push_check["ok"]:
-            blockers.append("origin push dry-run failed; authenticate or use a writable fork before uploading")
+            blockers.append(
+                f"{args.push_remote} push dry-run failed; authenticate or select a writable "
+                "fork remote before uploading"
+            )
 
     return {
         "ok": not blockers,
@@ -218,6 +249,8 @@ def inspect(args: argparse.Namespace) -> dict[str, Any]:
         "branch": branch,
         "origin_url": origin_url,
         "upstream_url": upstream_url,
+        "push_remote": args.push_remote,
+        "push_remote_url": push_remote_url,
         "workspace": {
             "partial_clone_filter": partial_filter or None,
             "sparse_checkout": sparse,
@@ -235,7 +268,7 @@ def inspect(args: argparse.Namespace) -> dict[str, Any]:
         "next_commands": [
             f"git add {submission_rel}",
             f'git commit -m "Submit {parts[-1] if parts else "proposal"}"',
-            "git push -u origin HEAD",
+            shell_push_command(args.push_remote, "HEAD", set_upstream=True),
             "gh pr create --repo open-city-ai/haidian --base main",
         ],
     }
@@ -269,7 +302,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--pr-author", required=True)
     parser.add_argument("--repo-root", default=".")
     parser.add_argument("--skip-self-check", action="store_true")
-    parser.add_argument("--check-push", action="store_true", help="Authenticate with origin using git push --dry-run")
+    parser.add_argument(
+        "--check-push",
+        action="store_true",
+        help="Authenticate with the selected push remote using git push --dry-run",
+    )
+    parser.add_argument(
+        "--push-remote",
+        default="origin",
+        help="Remote used by --check-push and the suggested upload command (default: origin)",
+    )
     parser.add_argument(
         "--allow-canonical-origin",
         action="store_true",

--- a/skills/urban-design-ai-submission/references/lightweight-workspace.md
+++ b/skills/urban-design-ai-submission/references/lightweight-workspace.md
@@ -120,6 +120,24 @@ python3 scripts/participant_preflight.py \
   --check-push
 ```
 
+Legacy checkouts may name the canonical repository `origin` and the writable
+participant fork `fork`. Keep that layout if other tooling depends on it and
+select the upload target explicitly:
+
+```bash
+python3 scripts/participant_preflight.py \
+  submissions/<github-login>/<proposal-slug> \
+  --pr-author <github-login> \
+  --check-push \
+  --push-remote fork
+```
+
+`--push-remote` controls both the dry-run authentication check and the upload
+command printed after a successful preflight. It defaults to `origin` for
+workspaces created by the current bootstrap helper. Commands are shell-quoted
+before display so a remote or branch name with shell punctuation remains one
+literal argument when copied.
+
 The preflight checks the branch, proposal ownership, PR file scope, GitHub's 100 MiB per-file limit, package size, partial/sparse workspace configuration, fork/upstream remotes, contributor self-check, and optional push authentication. Repair every blocker before uploading.
 
 ## Monitor the Pull Request Until It Resolves

--- a/tests/test_participant_preflight.py
+++ b/tests/test_participant_preflight.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import os
 import subprocess
 import sys
@@ -75,6 +76,69 @@ class ParticipantPreflightEncodingTests(unittest.TestCase):
         self.assertEqual("1", kwargs["env"]["PYTHONUTF8"])
         self.assertEqual("utf-8", kwargs["env"]["PYTHONIOENCODING"])
         self.assertEqual(completed.stdout, "海淀规划\n")
+
+
+class ParticipantPreflightPushRemoteTests(unittest.TestCase):
+    def test_check_push_uses_selected_remote_and_quotes_display_command(self) -> None:
+        completed = subprocess.CompletedProcess(
+            ["git", "push"],
+            0,
+            stdout="Everything up-to-date\n",
+            stderr="",
+        )
+        with patch.object(participant_preflight, "run", return_value=completed) as mocked:
+            report = participant_preflight.check_push(
+                REPO_ROOT,
+                "submission/alice/example",
+                "fork;echo-unsafe",
+            )
+
+        mocked.assert_called_once_with(
+            [
+                "git",
+                "push",
+                "--dry-run",
+                "fork;echo-unsafe",
+                "HEAD:refs/heads/submission/alice/example",
+            ],
+            REPO_ROOT,
+        )
+        self.assertTrue(report["ok"])
+        self.assertEqual(
+            report["command"],
+            "git push --dry-run 'fork;echo-unsafe' HEAD:refs/heads/submission/alice/example",
+        )
+
+    def test_upload_command_quotes_selected_remote(self) -> None:
+        self.assertEqual(
+            participant_preflight.shell_push_command(
+                "fork;echo-unsafe",
+                "HEAD",
+                set_upstream=True,
+            ),
+            "git push -u 'fork;echo-unsafe' HEAD",
+        )
+
+    def test_cli_accepts_push_remote(self) -> None:
+        report = {"ok": True, "blockers": [], "warnings": []}
+        with (
+            patch.object(participant_preflight, "inspect", return_value=report) as mocked,
+            patch("sys.stdout", new_callable=io.StringIO),
+        ):
+            returncode = participant_preflight.main(
+                [
+                    "submissions/alice/example",
+                    "--pr-author",
+                    "alice",
+                    "--check-push",
+                    "--push-remote",
+                    "fork",
+                    "--json",
+                ]
+            )
+
+        self.assertEqual(returncode, 0)
+        self.assertEqual(mocked.call_args.args[0].push_remote, "fork")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- Bring the explicit `--push-remote` participant-preflight workflow to current `main`.
- Keep the selected remote consistent across dry-run validation, JSON output, and suggested upload commands.
- Render every displayed `git push` command with `shlex.join`, so remote and ref names containing shell punctuation remain one literal argument when copied.
- Add regression coverage for the real-world `fork;echo-unsafe` remote-name case and document legacy `origin`/writable-`fork` layouts.

## Root cause

PR #755 correctly identified that workspaces may use a canonical `origin` plus a writable fork remote. Its implementation constructed user-facing commands with string interpolation. Git accepts remote names containing shell metacharacters; the subprocess dry-run was safe because it used an argv list, but copied output such as `git push -u fork;echo-unsafe HEAD` was not equivalent to the validated command.

This PR preserves the explicit-remote behavior while making the display/copy path shell-safe.

## Validation

- `python3 -m unittest tests.test_participant_preflight -q` — 7 passed
- `python3 -m py_compile scripts/participant_preflight.py tests/test_participant_preflight.py`
- `git diff --check`

Related: #755
