### PR TITLE
fix: reject symlinked submission downloads in trusted validation

### DIFF
--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -104,6 +104,7 @@ class GitHubClient:
     def __init__(self, token: str, repository: str) -> None:
         self.token = token
         self.repository = repository
+        self._git_tree_cache: dict[tuple[str, str], dict[str, dict[str, Any]]] = {}
 
     def request(self, method: str, url: str, data: dict | None = None) -> tuple[Any, dict[str, str]]:
         if url.startswith("/"):
@@ -209,33 +210,59 @@ class GitHubClient:
         destination.write_bytes(content)
         return True
 
+    def git_tree_entries(self, repo: str, ref: str) -> dict[str, dict[str, Any]]:
+        """Return one cached typed Git tree snapshot for a repository/ref.
+
+        The recursive tree endpoint exposes Git modes without one Contents API
+        request per path. A truncated tree is unsafe for a trusted download
+        boundary, so fail closed rather than silently falling back to a path
+        API that may resolve symlinks to target bytes.
+        """
+        cache_key = (repo, ref)
+        cached = self._git_tree_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        encoded_ref = urllib.parse.quote(ref)
+        data, _ = self.request(
+            "GET",
+            f"/repos/{repo}/git/trees/{encoded_ref}?recursive=1",
+        )
+        if not isinstance(data, dict) or data.get("truncated") is True:
+            raise RuntimeError(
+                f"GitHub API tree {repo}@{ref} is truncated or malformed; "
+                "trusted validation refuses to hydrate untyped artifacts"
+            )
+        tree = data.get("tree")
+        if not isinstance(tree, list):
+            raise RuntimeError(f"GitHub API tree {repo}@{ref} did not return a tree")
+        entries: dict[str, dict[str, Any]] = {}
+        for item in tree:
+            if not isinstance(item, dict) or not isinstance(item.get("path"), str):
+                continue
+            entries[item["path"]] = {
+                "mode": item.get("mode"),
+                "type": item.get("type"),
+            }
+        self._git_tree_cache[cache_key] = entries
+        return entries
+
     def assert_regular_file(self, repo: str, path: str, ref: str) -> None:
         """Reject Git objects that are not ordinary files before raw download.
 
-        The raw Contents representation can resolve a symbolic link to its
-        target bytes. That would make the trusted validator treat an external
-        or otherwise untracked object as an in-package artifact, so inspect the
-        typed Contents metadata first. A 404 is left to ``download_content`` so
-        its existing bounded retry and path-specific error remain authoritative.
+        A missing tree entry is left to ``download_content`` so its existing
+        bounded retry and path-specific 404 remain authoritative. Git mode
+        ``100644`` and executable ``100755`` are the only accepted regular
+        file modes; symlinks, submodules and directories fail closed.
         """
-        encoded_path = urllib.parse.quote(path)
-        encoded_ref = urllib.parse.quote(ref)
-        try:
-            data, _ = self.request(
-                "GET",
-                f"/repos/{repo}/contents/{encoded_path}?ref={encoded_ref}",
-            )
-        except urllib.error.HTTPError as exc:
-            if exc.code == 404:
-                return
-            raise
-        if not isinstance(data, dict):
-            raise RuntimeError(f"GitHub API path {path} did not return file metadata")
-        object_type = data.get("type")
-        if object_type != "file":
+        entry = self.git_tree_entries(repo, ref).get(path)
+        if entry is None:
+            return
+        if entry.get("mode") not in {"100644", "100755"} or entry.get("type") != "blob":
             raise RuntimeError(
-                f"GitHub API path {path} is not a regular file (type={object_type!r}); "
-                "trusted validation refuses symbolic links and non-file entries"
+                f"GitHub API path {path} is not a regular file "
+                f"(mode={entry.get('mode')!r}, type={entry.get('type')!r}); "
+                "trusted validation refuses symbolic links, submodules and directories"
             )
 
     def upsert_comment(self, issue_number: int, body: str) -> None:

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -209,6 +209,35 @@ class GitHubClient:
         destination.write_bytes(content)
         return True
 
+    def assert_regular_file(self, repo: str, path: str, ref: str) -> None:
+        """Reject Git objects that are not ordinary files before raw download.
+
+        The raw Contents representation can resolve a symbolic link to its
+        target bytes. That would make the trusted validator treat an external
+        or otherwise untracked object as an in-package artifact, so inspect the
+        typed Contents metadata first. A 404 is left to ``download_content`` so
+        its existing bounded retry and path-specific error remain authoritative.
+        """
+        encoded_path = urllib.parse.quote(path)
+        encoded_ref = urllib.parse.quote(ref)
+        try:
+            data, _ = self.request(
+                "GET",
+                f"/repos/{repo}/contents/{encoded_path}?ref={encoded_ref}",
+            )
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return
+            raise
+        if not isinstance(data, dict):
+            raise RuntimeError(f"GitHub API path {path} did not return file metadata")
+        object_type = data.get("type")
+        if object_type != "file":
+            raise RuntimeError(
+                f"GitHub API path {path} is not a regular file (type={object_type!r}); "
+                "trusted validation refuses symbolic links and non-file entries"
+            )
+
     def upsert_comment(self, issue_number: int, body: str) -> None:
         comments = self.paginate(f"/repos/{self.repository}/issues/{issue_number}/comments?per_page=100")
         for comment in comments:
@@ -361,6 +390,11 @@ def hydrate_proposal_package(
         if destination.exists():
             continue
         try:
+            client.assert_regular_file(
+                head_repo,
+                f"{proposal_dir}/{relative}",
+                head_sha,
+            )
             client.download_content(
                 head_repo,
                 f"{proposal_dir}/{relative}",
@@ -454,6 +488,8 @@ def main() -> int:
             filename = item["filename"]
             if item.get("status") == "removed":
                 continue
+            if filename.startswith("submissions/"):
+                client.assert_regular_file(head_repo, filename, head_sha)
             client.download_content(head_repo, filename, head_sha, worktree / filename)
 
         for proposal_path in proposal_paths_for(validation_files):

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -372,7 +372,19 @@ class ManifestHydrationTests(unittest.TestCase):
         with patch.object(
             client,
             "request",
-            return_value=({"type": "symlink", "target": "../../outside.txt"}, {}),
+            return_value=(
+                {
+                    "truncated": False,
+                    "tree": [
+                        {
+                            "path": "submissions/alice/design/asset.bin",
+                            "mode": "120000",
+                            "type": "blob",
+                        }
+                    ],
+                },
+                {},
+            ),
         ):
             with self.assertRaisesRegex(
                 RuntimeError,
@@ -386,12 +398,114 @@ class ManifestHydrationTests(unittest.TestCase):
 
     def test_trusted_download_accepts_regular_file_metadata(self) -> None:
         client = GitHubClient("token", "owner/repo")
-        with patch.object(client, "request", return_value=({"type": "file"}, {})):
+        with patch.object(
+            client,
+            "request",
+            return_value=(
+                {
+                    "truncated": False,
+                    "tree": [
+                        {
+                            "path": "submissions/alice/design/asset.bin",
+                            "mode": "100644",
+                            "type": "blob",
+                        }
+                    ],
+                },
+                {},
+            ),
+        ):
             client.assert_regular_file(
                 "fork/repo",
                 "submissions/alice/design/asset.bin",
                 "head-sha",
             )
+
+    def test_trusted_download_accepts_executable_regular_file(self) -> None:
+        client = GitHubClient("token", "owner/repo")
+        with patch.object(
+            client,
+            "request",
+            return_value=(
+                {
+                    "truncated": False,
+                    "tree": [
+                        {
+                            "path": "submissions/alice/design/run.sh",
+                            "mode": "100755",
+                            "type": "blob",
+                        }
+                    ],
+                },
+                {},
+            ),
+        ):
+            client.assert_regular_file("fork/repo", "submissions/alice/design/run.sh", "head-sha")
+
+    def test_trusted_download_rejects_submodule_and_directory_metadata(self) -> None:
+        for mode, object_type in (("160000", "commit"), ("040000", "tree")):
+            client = GitHubClient("token", "owner/repo")
+            with self.subTest(mode=mode), patch.object(
+                client,
+                "request",
+                return_value=(
+                    {
+                        "truncated": False,
+                        "tree": [
+                            {
+                                "path": "submissions/alice/design/asset.bin",
+                                "mode": mode,
+                                "type": object_type,
+                            }
+                        ],
+                    },
+                    {},
+                ),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "not a regular file"):
+                    client.assert_regular_file(
+                        "fork/repo", "submissions/alice/design/asset.bin", "head-sha"
+                    )
+
+    def test_trusted_download_fails_closed_on_truncated_tree(self) -> None:
+        client = GitHubClient("token", "owner/repo")
+        with patch.object(
+            client,
+            "request",
+            return_value=({"truncated": True, "tree": []}, {}),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "truncated or malformed"):
+                client.assert_regular_file(
+                    "fork/repo", "submissions/alice/design/asset.bin", "head-sha"
+                )
+
+    def test_trusted_download_caches_tree_for_multiple_files(self) -> None:
+        client = GitHubClient("token", "owner/repo")
+        with patch.object(
+            client,
+            "request",
+            return_value=(
+                {
+                    "truncated": False,
+                    "tree": [
+                        {
+                            "path": "submissions/alice/design/one.bin",
+                            "mode": "100644",
+                            "type": "blob",
+                        },
+                        {
+                            "path": "submissions/alice/design/two.bin",
+                            "mode": "100644",
+                            "type": "blob",
+                        },
+                    ],
+                },
+                {},
+            ),
+        ) as request:
+            client.assert_regular_file("fork/repo", "submissions/alice/design/one.bin", "head-sha")
+            client.assert_regular_file("fork/repo", "submissions/alice/design/two.bin", "head-sha")
+        request.assert_called_once()
 
     def test_download_content_accepts_ten_mib_file(self) -> None:
         client = GitHubClient("token", "owner/repo")

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -367,6 +367,32 @@ class AgentDisclosureTests(unittest.TestCase):
 
 
 class ManifestHydrationTests(unittest.TestCase):
+    def test_trusted_download_rejects_symbolic_link_metadata(self) -> None:
+        client = GitHubClient("token", "owner/repo")
+        with patch.object(
+            client,
+            "request",
+            return_value=({"type": "symlink", "target": "../../outside.txt"}, {}),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"path submissions/alice/design/asset.bin is not a regular file",
+            ):
+                client.assert_regular_file(
+                    "fork/repo",
+                    "submissions/alice/design/asset.bin",
+                    "head-sha",
+                )
+
+    def test_trusted_download_accepts_regular_file_metadata(self) -> None:
+        client = GitHubClient("token", "owner/repo")
+        with patch.object(client, "request", return_value=({"type": "file"}, {})):
+            client.assert_regular_file(
+                "fork/repo",
+                "submissions/alice/design/asset.bin",
+                "head-sha",
+            )
+
     def test_download_content_accepts_ten_mib_file(self) -> None:
         client = GitHubClient("token", "owner/repo")
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- inspect GitHub Contents metadata before downloading submission paths in the trusted `pull_request_target` validator;
- reject `symlink`, directory, submodule, and other non-file objects before the raw endpoint can resolve them to bytes;
- apply the same guard to manifest-hydrated package assets;
- keep the existing bounded 404 retry behavior and avoid extra metadata calls for non-submission code PRs.

## Why

PR #784 hardens the local package validator against symlinks after files exist on disk. The trusted validator downloads changed submission paths through the raw Contents representation first; a symlink can therefore be materialized as its target bytes and reach validation without the local filesystem check seeing a symbolic link. This patch closes that earlier boundary using the typed Contents metadata.

## Validation

- `python3 -m unittest tests.test_submission_workflow.ManifestHydrationTests -q` — 12 passed
- `python3 -m pytest -q` — 271 passed
- `python3 -m py_compile scripts/github_pr_validation.py tests/test_submission_workflow.py`
- `git diff --check`

This is a trusted maintainer-path hardening change; it does not execute contributor code and does not make a rights or content-quality determination.
