### PR TITLE
fix: verify formal source claims against registry

### DIFF
--- a/docs/data-workflow.md
+++ b/docs/data-workflow.md
@@ -26,6 +26,8 @@
 6. 在 `proposal.md` 中用 `[source:...]` 标签解释资料如何支撑文字、图层、指标和图纸。
 7. 对不能确认的资料，写入 `assumptions.json`、`self_check.json` 和 `proposal.md` 的风险/缺资料章节。
 
+`sources.json` 中的 `source_type` 只说明资料类别，不等于它已通过 formal 审核。若条目明确写出 `type: "formal_usable"`、`usable_for_formal: "yes"` 或 `usable_for: "formal"`，还必须写出 `source_registry_id`，并且该 ID 必须对应 `data/source_registry.json` 中 `review_status="approved"` 且 `usable_for_formal="yes"` 的记录。发现的新 URL 在维护者完成登记和复核前只能作为背景或待核资料，不能由投稿者自行升级为 formal 依据。此规则在 v2 提交包中阻断，在历史 v1 包中保留可见警告以维持兼容。
+
 `scripts/scaffold_ai_submission.py` 会在初始 `sources.json` 中加入 `SOURCE-REGISTRY`，并在 `proposal.md` 中解释当前 registry 的 formal/background/provisional 摘要。`scripts/review_submission.py` 会把 `source_registry_summary` 写入 review packet，供维护者或外部评审模型判断资料是否被越界使用。
 
 `data/processed/` 是给 agent 的阅读导航层，不是新的权威来源。正文和矩阵可以引用处理表说明工作流，但所有事实依据仍要回到 `source_registry.json` 中的原始 `source_id`，例如官方公告、清权任务书、专业标准或 provisional 边界。
@@ -104,5 +106,7 @@ python3 scripts/prepare_source_registry_draft.py --json
 - `authority_level`
 - `usable_for`
 - `not_usable_for`
+
+如果把来源声明为 formal 可用，还应保留登记表中的 `source_registry_id`；不要用 `sources.json` 内的自我标记替代维护者的登记和复核。
 
 正文必须说明资料的设计作用。例如：该公告用于确认三层范围和设计任务；临时边界只用于 intake 可视化；专业标准用于风貌、公共空间和控规深度语言，不用于推导本项目已批控规指标。

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -718,6 +718,7 @@ def source_declares_formal_usability(source: dict) -> bool:
     """
     return (
         str(source.get("type", "")).strip().lower() == "formal_usable"
+        or str(source.get("formal_usable", "")).strip().lower() in {"yes", "true", "1"}
         or str(source.get("usable_for_formal", "")).strip().lower() == "yes"
         or str(source.get("usable_for", "")).strip().lower() in {"formal", "formal_usable"}
     )

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -719,7 +719,7 @@ def source_declares_formal_usability(source: dict) -> bool:
     return (
         str(source.get("type", "")).strip().lower() == "formal_usable"
         or str(source.get("formal_usable", "")).strip().lower() in {"yes", "true", "1"}
-        or str(source.get("usable_for_formal", "")).strip().lower() == "yes"
+        or str(source.get("usable_for_formal", "")).strip().lower() in {"yes", "true", "1"}
         or str(source.get("usable_for", "")).strip().lower() in {"formal", "formal_usable"}
     )
 

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -231,6 +231,7 @@ REQUIRED_DESIGN_DEPTH_IDS = {
 REFERENCE_RE = re.compile(r"\[(source|standard|depth|data|metric):([^\]\s]+)\]")
 PROPOSAL_FORMAT_VERSION = "2"
 BILINGUAL_CONTRACT_VERSION = "1"
+SOURCE_REGISTRY_PATH = "data/source_registry.json"
 MAX_INLINE_REFERENCES_PER_BLOCK = 8
 MAX_CONSECUTIVE_REFERENCES = 3
 MARKDOWN_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
@@ -706,6 +707,112 @@ def load_json_file(report: ValidationReport, path: Path, display_path: str) -> o
     except json.JSONDecodeError as exc:
         report.add_error(f"{display_path}: invalid JSON: {exc.msg} at line {exc.lineno}")
     return None
+
+
+def source_declares_formal_usability(source: dict) -> bool:
+    """Return whether a submission source asserts formal-evidence eligibility.
+
+    ``sources.json`` intentionally permits lightweight citation entries, so an
+    ``official_public`` source_type alone is not an assertion that the source
+    passed the repository's formal-use review.  These explicit fields are.
+    """
+    return (
+        str(source.get("type", "")).strip().lower() == "formal_usable"
+        or str(source.get("usable_for_formal", "")).strip().lower() == "yes"
+        or str(source.get("usable_for", "")).strip().lower() in {"formal", "formal_usable"}
+    )
+
+
+def load_source_registry_entries(repo_root: Path) -> dict[str, dict] | None:
+    """Load registry entries by ID, or return None when they cannot be verified."""
+    registry_path = repo_root / SOURCE_REGISTRY_PATH
+    try:
+        data = json.loads(registry_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    sources = data.get("sources") if isinstance(data, dict) else None
+    if not isinstance(sources, list):
+        return None
+    return {
+        source_id: source
+        for source in sources
+        if isinstance(source, dict)
+        and isinstance((source_id := source.get("source_id")), str)
+        and source_id
+    }
+
+
+def validate_formal_source_registry(
+    report: ValidationReport,
+    repo_root: Path,
+    proposal_dir: str,
+) -> None:
+    """Require explicit formal-use claims to point at a maintainer-approved source.
+
+    Version 1 packages predate this source-contract requirement, so they keep
+    validating with a visible warning.  Version 2 packages are the migration
+    boundary: a contributor may not turn a discovered public URL into formal
+    evidence by setting a flag in its own ``sources.json``.
+    """
+    sources_path = repo_root / proposal_dir / "sources.json"
+    try:
+        sources_data = json.loads(sources_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return
+    source_items = sources_data.get("sources") if isinstance(sources_data, dict) else None
+    if not isinstance(source_items, list):
+        return
+
+    proposal_path = repo_root / proposal_dir / "proposal.md"
+    try:
+        metadata, _ = parse_front_matter(proposal_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError):
+        return
+    strict_contract = proposal_format_version(metadata) == PROPOSAL_FORMAT_VERSION
+    registry_entries: dict[str, dict] | None = None
+
+    def report_problem(message: str) -> None:
+        if strict_contract:
+            report.add_error(message)
+        else:
+            report.add_warning(message + "; legacy v1 package remains compatible")
+
+    for index, source in enumerate(source_items):
+        if not isinstance(source, dict) or not source_declares_formal_usability(source):
+            continue
+        source_label = source.get("id")
+        if not isinstance(source_label, str) or not source_label.strip():
+            source_label = f"sources[{index}]"
+        registry_source_id = source.get("source_registry_id")
+        if not isinstance(registry_source_id, str) or not registry_source_id.strip():
+            report_problem(
+                f"{proposal_dir}/sources.json: `{source_label}` declares formal usability but must set "
+                "source_registry_id to an approved data/source_registry.json entry"
+            )
+            continue
+        if registry_entries is None:
+            registry_entries = load_source_registry_entries(repo_root)
+        if registry_entries is None:
+            report_problem(
+                f"{proposal_dir}/sources.json: cannot verify `{source_label}` source_registry_id "
+                f"because {SOURCE_REGISTRY_PATH} is unavailable or invalid"
+            )
+            continue
+        registry_source = registry_entries.get(registry_source_id)
+        if registry_source is None:
+            report_problem(
+                f"{proposal_dir}/sources.json: `{source_label}` source_registry_id "
+                f"`{registry_source_id}` is not registered in {SOURCE_REGISTRY_PATH}"
+            )
+            continue
+        if (
+            registry_source.get("review_status") != "approved"
+            or registry_source.get("usable_for_formal") != "yes"
+        ):
+            report_problem(
+                f"{proposal_dir}/sources.json: `{source_label}` source_registry_id "
+                f"`{registry_source_id}` is not approved for formal use"
+            )
 
 
 def policy_file(repo_root: Path, relative_path: str) -> Path:
@@ -1651,6 +1758,7 @@ def validate_ai_package_dir(report: ValidationReport, repo_root: Path, proposal_
         path = base / name
         if path.exists():
             load_json_file(report, path, f"{proposal_dir}/{name}")
+    validate_formal_source_registry(report, repo_root, proposal_dir)
     self_check_path = base / "self_check.json"
     if self_check_path.exists():
         validate_self_check_file(

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -1391,6 +1391,31 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertIn("EX-BOOLEAN-FORMAL", errors)
             self.assertIn("source_registry_id", errors)
 
+    def test_v2_usable_for_formal_boolean_claim_requires_approved_registry_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            self.make_v2_proposal_readable(root, base)
+            self.add_bilingual_v2_display(root, base, changed)
+            self.update_json(
+                root,
+                f"{base}/sources.json",
+                lambda data: data["sources"].append(
+                    {
+                        "id": "EX-BOOLEAN-USABLE",
+                        "usable_for_formal": True,
+                    }
+                ),
+            )
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertFalse(report.ok)
+            errors = "\n".join(report.errors)
+            self.assertIn("EX-BOOLEAN-USABLE", errors)
+            self.assertIn("source_registry_id", errors)
+
     def test_v2_formal_source_claim_accepts_approved_registry_mapping(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -1366,6 +1366,31 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertIn("EX-UNREGISTERED", "\n".join(report.errors))
             self.assertIn("source_registry_id", "\n".join(report.errors))
 
+    def test_v2_formal_usable_boolean_claim_requires_approved_registry_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            self.make_v2_proposal_readable(root, base)
+            self.add_bilingual_v2_display(root, base, changed)
+            self.update_json(
+                root,
+                f"{base}/sources.json",
+                lambda data: data["sources"].append(
+                    {
+                        "id": "EX-BOOLEAN-FORMAL",
+                        "formal_usable": True,
+                    }
+                ),
+            )
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertFalse(report.ok)
+            errors = "\n".join(report.errors)
+            self.assertIn("EX-BOOLEAN-FORMAL", errors)
+            self.assertIn("source_registry_id", errors)
+
     def test_v2_formal_source_claim_accepts_approved_registry_mapping(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -986,6 +986,27 @@ class SubmissionWorkflowTests(unittest.TestCase):
             changed.append(f"{base}/{localized_rel}")
         manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
+    def make_v2_proposal_readable(self, root: Path, base: str) -> None:
+        """Remove the v1 index dump so a v2 fixture tests only its target rule."""
+        path = root / base / "proposal.md"
+        readable = re.sub(
+            r"\[(?:source|standard|depth|data|metric):[^\]\s]+\]",
+            "",
+            path.read_text(encoding="utf-8"),
+        )
+        readable_explanation = re.sub(
+            r"\[(?:source|standard|depth|data|metric):[^\]\s]+\]",
+            "",
+            FORMAL_PARAGRAPH,
+        )
+        for heading in REQUIRED_SECTIONS:
+            readable = readable.replace(
+                f"## {heading}\n",
+                f"## {heading}\n\n本节关键判断依据 [source:SITE-PACKAGE]。{readable_explanation}\n",
+                1,
+            )
+        path.write_text(readable, encoding="utf-8")
+
     def update_json(self, root: Path, rel: str, updater) -> None:
         path = root / rel
         data = json.loads(path.read_text(encoding="utf-8"))
@@ -1288,6 +1309,110 @@ class SubmissionWorkflowTests(unittest.TestCase):
             base = "submissions/alice/ai-urban-loop"
             changed = self.write_minimal_ai_package(root, base)
             report = validate_submission(root, "alice", changed)
+            self.assertTrue(report.ok, report.errors)
+
+    def test_legacy_formal_source_claim_warns_without_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            self.update_json(
+                root,
+                f"{base}/sources.json",
+                lambda data: data["sources"].append(
+                    {
+                        "id": "EX-UNREGISTERED",
+                        "type": "formal_usable",
+                        "usable_for_formal": "yes",
+                    }
+                ),
+            )
+            proposal = root / base / "proposal.md"
+            proposal.write_text(
+                proposal.read_text(encoding="utf-8") + "\n[source:EX-UNREGISTERED]\n",
+                encoding="utf-8",
+            )
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertTrue(report.ok, report.errors)
+            warnings = "\n".join(report.warnings)
+            self.assertIn("EX-UNREGISTERED", warnings)
+            self.assertIn("source_registry_id", warnings)
+            self.assertIn("legacy v1 package remains compatible", warnings)
+
+    def test_v2_formal_source_claim_requires_approved_registry_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            self.make_v2_proposal_readable(root, base)
+            self.add_bilingual_v2_display(root, base, changed)
+            self.update_json(
+                root,
+                f"{base}/sources.json",
+                lambda data: data["sources"].append(
+                    {
+                        "id": "EX-UNREGISTERED",
+                        "type": "formal_usable",
+                        "usable_for_formal": "yes",
+                    }
+                ),
+            )
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertFalse(report.ok)
+            self.assertIn("EX-UNREGISTERED", "\n".join(report.errors))
+            self.assertIn("source_registry_id", "\n".join(report.errors))
+
+    def test_v2_formal_source_claim_accepts_approved_registry_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            self.make_v2_proposal_readable(root, base)
+            self.add_bilingual_v2_display(root, base, changed)
+            self.write_json(
+                root,
+                "data/source_registry.json",
+                {
+                    "sources": [
+                        {
+                            "source_id": "DATA-SRC-APPROVED-TEST",
+                            "review_status": "needs_review",
+                            "usable_for_formal": "background_only",
+                        }
+                    ]
+                },
+            )
+            self.update_json(
+                root,
+                f"{base}/sources.json",
+                lambda data: data["sources"].append(
+                    {
+                        "id": "EX-APPROVED",
+                        "type": "formal_usable",
+                        "usable_for_formal": "yes",
+                        "source_registry_id": "DATA-SRC-APPROVED-TEST",
+                    }
+                ),
+            )
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertFalse(report.ok)
+            self.assertIn("not approved for formal use", "\n".join(report.errors))
+
+            self.update_json(
+                root,
+                "data/source_registry.json",
+                lambda data: data["sources"][0].update(
+                    {"review_status": "approved", "usable_for_formal": "yes"}
+                ),
+            )
+            report = validate_submission(root, "alice", changed)
+
             self.assertTrue(report.ok, report.errors)
 
     def test_changelog_submission_passes_hard_validation(self) -> None:


### PR DESCRIPTION
## What changed

- Validates explicit formal-use claims in submission `sources.json` against `data/source_registry.json`.
- Recognizes the supported self-assertion forms `type: "formal_usable"`, `formal_usable: true`, `usable_for_formal: "yes"`/`true`, and `usable_for: "formal"`.
- Requires `source_registry_id` to resolve to a source with `review_status: "approved"` and `usable_for_formal: "yes"`.
- Keeps v1 packages compatible with visible warnings; v2 packages block unsupported formal-use claims.

## Why

`sources.json` previously accepted contributor-supplied formal-use labels without proving that a maintainer had reviewed the cited material. This let a public URL be presented as formal evidence without a registry decision.

## Impact

New v2 packages must map an explicitly formal source to the approved registry entry. Ordinary source categories such as `official_public` remain lightweight citations and do not trigger the gate. A registry mapping is an approval-state check, not a substitute for asset-level provenance or claim-scope review.

## Validation

- `python3 -m pytest -q tests/test_submission_workflow.py tests/test_data_registry.py tests/test_source_registry_draft.py tests/test_processed_data.py` — 105 passed
- `python3 scripts/validate_data_registry.py` — PASS (6 sources)
- `python3 -m py_compile scripts/validate_submission.py`
- `git diff --check`
- The full checkout-wide suite has 256 passing tests; 16 failures are sparse-checkout fixture absences (`.github/`, `skills/`, `examples/`, `sources/public-sources.json`, and historical submissions), not failures in this diff.
