### PR TITLE
fix: require explicit text-free neutral figures

### DIFF
--- a/brief/site-package/schemas/manifest.schema.json
+++ b/brief/site-package/schemas/manifest.schema.json
@@ -128,7 +128,7 @@
           "language": {
             "type": "string",
             "enum": ["zh", "en", "neutral"],
-            "description": "Language of a human-facing display artifact. Language-neutral assets may be shared by both versions."
+            "description": "Language of a human-facing display artifact. Language-neutral assets may be shared by both versions only when text_free is true."
           },
           "text_free": {
             "type": "boolean",

--- a/brief/site-package/schemas/manifest.schema.json
+++ b/brief/site-package/schemas/manifest.schema.json
@@ -130,6 +130,10 @@
             "enum": ["zh", "en", "neutral"],
             "description": "Language of a human-facing display artifact. Language-neutral assets may be shared by both versions."
           },
+          "text_free": {
+            "type": "boolean",
+            "description": "For a language-neutral figure, set true only when the asset contains no human-readable text and may be shared by both language versions."
+          },
           "translation_of": {
             "type": "string",
             "pattern": "^[A-Za-z0-9_./-]+$",

--- a/docs/formal-submission-guide.md
+++ b/docs/formal-submission-guide.md
@@ -10,7 +10,7 @@
 
 **要求双语言。** 新方案同时设置 `bilingual_contract_version: "1"`。`proposal.md` 可以中文或英文书写，但必须通过独立文件提供完整对照译文：中文主稿使用 `proposal.en.md`，英文主稿使用 `proposal.zh.md`。主稿设置 `translation_file`，译稿设置 `translation_of: "proposal.md"`；HTML、A3/A0 和含文字图件也使用 `.zh` / `.en` 语言副本。两版必须保持章节、主张、指标、证据引用和图件位置一致，并优先使用[赛事中英术语表](terminology-glossary.md)。自动校验会把缺少文件、错误语言映射、无效译稿 HTML/PDF 或过期 manifest 哈希视作阻断错误；翻译等义性仍由维护者人工核对。历史 v1 及早期 v2 单语方案继续兼容展示，不要求为了保留既有成果而补写；它们下一次完整升级时可显式加入新契约。
 
-无后缀文件是 `proposal.md` 所声明的主语言版本；译稿在扩展名前插入语言码，例如 `report/proposal.en.html`、`visual/index.en.html`、`drawings/a3-booklet.en.pdf` 和 `assets/figures/site-overview.en.png`。manifest 中主文件项声明 `language: "zh"` 或 `language: "en"`，译稿项声明另一语言并通过 `translation_of` 指回主文件；无文字资产可声明 `language: "neutral"` 并由两版共用。
+无后缀文件是 `proposal.md` 所声明的主语言版本；译稿在扩展名前插入语言码，例如 `report/proposal.en.html`、`visual/index.en.html`、`drawings/a3-booklet.en.pdf` 和 `assets/figures/site-overview.en.png`。manifest 中主文件项声明 `language: "zh"` 或 `language: "en"`，译稿项声明另一语言并通过 `translation_of` 指回主文件；只有确认不含任何人类可读文字的图件，才可同时声明 `language: "neutral"` 和 `text_free: true` 由两版共用。
 
 英文主稿必须使用以下正式章节标题；中文译稿保持对应顺序。这样英文正文可独立通过结构校验，不依赖同一文件中的中文章节。
 

--- a/docs/terminology-glossary.md
+++ b/docs/terminology-glossary.md
@@ -90,4 +90,4 @@
 
 ## 双语文件命名
 
-无后缀文件始终是主语言版本；另一语言在扩展名前加入 `.zh` 或 `.en`。例如中文主稿使用 `proposal.md`，英文译稿使用 `proposal.en.md`；对应阅读版为 `report/proposal.html` 和 `report/proposal.en.html`。A3/A0、可视化 HTML 和含文字图件使用同一规则。纯语言无关资产可由两版共用，并在 manifest 中标记 `language: "neutral"`。
+无后缀文件始终是主语言版本；另一语言在扩展名前加入 `.zh` 或 `.en`。例如中文主稿使用 `proposal.md`，英文译稿使用 `proposal.en.md`；对应阅读版为 `report/proposal.html` 和 `report/proposal.en.html`。A3/A0、可视化 HTML 和含文字图件使用同一规则。纯语言无关资产可由两版共用，并在 manifest 中标记 `language: "neutral"` 与 `text_free: true`；含有任何人类可读文字的图件不能仅靠 `neutral` 声明跳过配对检查。

--- a/scripts/finalize_submission.py
+++ b/scripts/finalize_submission.py
@@ -100,7 +100,18 @@ def main() -> int:
             for item in manifest.get("files", [])
             if isinstance(item, dict) and item.get("path")
         }
-        bilingual_primary_files = [*sorted(DISPLAY_BASE_FILES), *FIGURES]
+        manifest_figure_files = [
+            rel
+            for rel in listed_items
+            if (
+                rel.startswith("assets/figures/")
+                and primary_path_from_localized(rel) is None
+                and (root / rel).is_file()
+            )
+        ]
+        bilingual_primary_files = list(
+            dict.fromkeys([*sorted(DISPLAY_BASE_FILES), *FIGURES, *sorted(manifest_figure_files)])
+        )
         for rel in bilingual_primary_files:
             item = listed_items.get(rel, {})
             if (

--- a/scripts/finalize_submission.py
+++ b/scripts/finalize_submission.py
@@ -103,7 +103,11 @@ def main() -> int:
         bilingual_primary_files = [*sorted(DISPLAY_BASE_FILES), *FIGURES]
         for rel in bilingual_primary_files:
             item = listed_items.get(rel, {})
-            if rel.startswith("assets/figures/") and item.get("language") == "neutral":
+            if (
+                rel.startswith("assets/figures/")
+                and item.get("language") == "neutral"
+                and item.get("text_free") is True
+            ):
                 continue
             translated_rel = localized_path(rel, translation_language)
             if not (root / translated_rel).is_file():

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1540,13 +1540,16 @@ def validate_bilingual_display(
         # The manifest is the package inventory. Some text-bearing figures are
         # used only by the rendered report or visual page and are not linked
         # directly from proposal.md, so they must not bypass the language gate.
-        for path, item in manifest_items.items():
+        for path in manifest_items:
             if (
                 path.startswith("assets/figures/")
                 and primary_path_from_localized(path) is None
-                and item.get("language") != "neutral"
                 and (base / path).is_file()
             ):
+                # The manifest is authoritative: a figure can be rendered by
+                # report/visual HTML without appearing in proposal.md.  Do
+                # not let an unreferenced neutral figure bypass the explicit
+                # text_free declaration or the zh/en counterpart check.
                 display_files.add(path)
     for match in MARKDOWN_IMAGE_RE.finditer(body):
         raw = match.group(2).split("#", 1)[0].split("?", 1)[0]

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1591,7 +1591,13 @@ def validate_bilingual_display(
             and primary_item
             and primary_item.get("language") == "neutral"
         ):
-            continue
+            if primary_item.get("text_free") is True:
+                continue
+            report_bilingual_problem(
+                f"{proposal_dir}/manifest.json: `{display_path}` declares language=neutral "
+                "without text_free=true; visually inspect the asset and either declare it "
+                "text-free or provide a bilingual counterpart"
+            )
         companion_path = localized_path(display_path, translation_language)
         companion = base / companion_path
         if not companion.is_file():

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -221,6 +221,17 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
             drawing = b"%PDF-1.4\n3 0 obj<</Type/Page/Parent 2 0 R>>endobj\n" + b"0" * 4096
             for rel in ["drawings/a3-booklet.pdf", "drawings/a0-boards.pdf"]:
                 (output_dir / rel).write_bytes(drawing)
+            manifest_path = output_dir / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            figure = next(
+                item for item in manifest["files"]
+                if item["path"] == "assets/figures/site-overview.png"
+            )
+            figure["language"] = "neutral"
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
 
             finalized = subprocess.run(
                 [sys.executable, str(REPO_ROOT / "scripts" / "finalize_submission.py"), str(output_dir)],
@@ -230,6 +241,7 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
             )
             self.assertNotEqual(0, finalized.returncode)
             self.assertIn("required bilingual counterpart is missing", finalized.stdout)
+            self.assertIn("assets/figures/site-overview.en.png", finalized.stdout)
 
     def test_finalize_registers_existing_language_counterparts(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -312,6 +312,45 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
             self.assertEqual("en", items[localized_rel]["language"])
             self.assertEqual(primary_rel, items[localized_rel]["translation_of"])
 
+    def test_finalize_checks_unreferenced_manifest_figure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "submissions" / "alice" / "unreferenced-figure"
+            scaffold = run_scaffold(output_dir)
+            self.assertEqual(0, scaffold.returncode, scaffold.stdout + scaffold.stderr)
+
+            completed = complete_scaffold(output_dir)
+            self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+
+            extra_rel = "assets/figures/report-only-map.png"
+            extra = output_dir / extra_rel
+            extra.write_bytes(b"PNG text-bearing figure")
+            manifest_path = output_dir / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["package_state"] = "scaffold"
+            manifest["files"].append(
+                {
+                    "path": extra_rel,
+                    "role": "proposal_figure",
+                    "required": True,
+                    "language": "neutral",
+                    "sha256": hashlib.sha256(extra.read_bytes()).hexdigest(),
+                }
+            )
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            finalized = subprocess.run(
+                [sys.executable, str(REPO_ROOT / "scripts" / "finalize_submission.py"), str(output_dir)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, finalized.returncode)
+            self.assertIn("assets/figures/report-only-map.en.png", finalized.stdout)
+
     def test_generated_scaffold_is_blocked_until_participant_finalizes_it(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -1819,6 +1819,54 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertIn("site-overview.png` declares language=neutral without text_free=true", errors)
             self.assertIn("site-overview.en.png", errors)
 
+    def test_v2_explicit_text_free_neutral_figure_can_skip_counterpart(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            primary = root / base / "proposal.md"
+            readable = re.sub(
+                r"\[(?:source|standard|depth|data|metric):[^\]\s]+\]",
+                "",
+                primary.read_text(encoding="utf-8"),
+            )
+            readable_explanation = re.sub(
+                r"\[(?:source|standard|depth|data|metric):[^\]\s]+\]",
+                "",
+                FORMAL_PARAGRAPH,
+            )
+            for heading in REQUIRED_SECTIONS:
+                readable = readable.replace(
+                    f"## {heading}\n",
+                    f"## {heading}\n\n本节关键判断依据 [source:SITE-PACKAGE]。{readable_explanation}\n",
+                    1,
+                )
+            primary.write_text(readable, encoding="utf-8")
+            self.add_bilingual_v2_display(root, base, changed)
+            companion_rel = "assets/figures/site-overview.en.png"
+            (root / base / companion_rel).unlink()
+            changed.remove(f"{base}/{companion_rel}")
+
+            manifest_path = root / base / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["files"] = [
+                item for item in manifest["files"] if item.get("path") != companion_rel
+            ]
+            primary = next(
+                item for item in manifest["files"]
+                if item["path"] == "assets/figures/site-overview.png"
+            )
+            primary.update({"language": "neutral", "text_free": True})
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertTrue(report.ok, report.errors)
+            self.assertNotIn("site-overview.en.png", "\n".join(report.warnings))
+
     def test_localized_visual_html_receives_static_safety_validation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -1867,6 +1867,57 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertTrue(report.ok, report.errors)
             self.assertNotIn("site-overview.en.png", "\n".join(report.warnings))
 
+    def test_v2_unreferenced_neutral_manifest_figure_is_not_exempt(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            primary = root / base / "proposal.md"
+            readable = re.sub(
+                r"\[(?:source|standard|depth|data|metric):[^\]\s]+\]",
+                "",
+                primary.read_text(encoding="utf-8"),
+            )
+            readable_explanation = re.sub(
+                r"\[(?:source|standard|depth|data|metric):[^\]\s]+\]",
+                "",
+                FORMAL_PARAGRAPH,
+            )
+            for heading in REQUIRED_SECTIONS:
+                readable = readable.replace(
+                    f"## {heading}\n",
+                    f"## {heading}\n\n本节关键判断依据 [source:SITE-PACKAGE]。{readable_explanation}\n",
+                    1,
+                )
+            primary.write_text(readable, encoding="utf-8")
+            self.add_bilingual_v2_display(root, base, changed)
+
+            manifest_path = root / base / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            extra_rel = "assets/figures/unreferenced-map.png"
+            extra = root / base / extra_rel
+            extra.write_bytes(b"PNG text-bearing figure")
+            manifest["files"].append({
+                "path": extra_rel,
+                "role": "proposal_figure",
+                "required": True,
+                "language": "neutral",
+                "sha256": hashlib.sha256(extra.read_bytes()).hexdigest(),
+            })
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            changed.append(f"{base}/{extra_rel}")
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertFalse(report.ok)
+            self.assertIn(
+                "unreferenced-map.png` declares language=neutral without text_free=true",
+                "\n".join(report.errors),
+            )
+
     def test_localized_visual_html_receives_static_safety_validation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -1744,6 +1744,9 @@ class SubmissionWorkflowTests(unittest.TestCase):
                     "translation_of": primary_rel,
                     "sha256": hashlib.sha256(companion.read_bytes()).hexdigest(),
                 })
+            by_path["assets/figures/site-overview.png"].update(
+                {"language": "neutral", "text_free": True}
+            )
             manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
             changed.extend(f"{base}/{path}" for path in companion_paths)
             report = validate_submission(root, "alice", changed)
@@ -1781,6 +1784,40 @@ class SubmissionWorkflowTests(unittest.TestCase):
             report = validate_submission(root, "alice", changed)
             self.assertTrue(report.ok, report.errors)
             self.assertIn("proposal.en.md", "\n".join(report.warnings))
+
+    def test_v2_neutral_figure_requires_explicit_text_free_declaration(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            proposal_path = root / base / "proposal.md"
+            proposal_path.write_text(
+                proposal_path.read_text(encoding="utf-8").replace(
+                    'language: "zh"',
+                    'language: "zh"\nproposal_format_version: "2"\n'
+                    'bilingual_contract_version: "1"\ntranslation_file: "proposal.en.md"',
+                    1,
+                ),
+                encoding="utf-8",
+            )
+            manifest_path = root / base / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            figure = next(
+                item for item in manifest["files"]
+                if item["path"] == "assets/figures/site-overview.png"
+            )
+            figure["language"] = "neutral"
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertFalse(report.ok)
+            errors = "\n".join(report.errors)
+            self.assertIn("site-overview.png` declares language=neutral without text_free=true", errors)
+            self.assertIn("site-overview.en.png", errors)
 
     def test_localized_visual_html_receives_static_safety_validation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

The v2 bilingual gate treated any figure declared as `language: "neutral"` as text-free. A package could therefore place readable English or Chinese labels in a single figure and bypass the required language counterpart check. PR #790 reproduces this with five figures that visibly contain English labels while declaring `neutral`.

This patch makes the declaration explicit and keeps the same migration boundary:

- add optional manifest item field `text_free`;
- only `language: "neutral", text_free: true` may skip figure counterpart validation;
- unverified `neutral` figures now fail the strict v2 contract and require an explicit `.zh`/`.en` counterpart;
- `finalize_submission.py` applies the same rule;
- update the formal submission docs and add regression tests.

`text_free: true` remains a contributor declaration and still requires human visual review; this change removes the silent validator bypass without pretending that OCR is a substitute for review.

## Verification

- `python3 -m pytest -q` — 270 passed
- `python3 -m py_compile scripts/validate_submission.py scripts/finalize_submission.py`
- `git diff --check`
- Replayed the exact PR #790 head (`866b54467fd743fa0466398de3e46dff392c5068`) against the patched validator: it now fails on all five neutral figures and reports the missing English counterparts.
