### PR TITLE
fix: reject scaffold agent model placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ python3 scripts/scaffold_ai_submission.py \
   --proposal-title "<proposal title>"
 ```
 
-7. 按 formal 模板完善 `proposal.md`、图纸、HTML 可视化、合规矩阵、标准矩阵、深度矩阵和自检结果。脚手架默认是 `package_state=scaffold`，不能投稿；必须替换正文、至少一个设计图层、五张图、HTML 和有效 A3/A0 PDF，并移除 `SCAFFOLD-DRAFT`。在 `manifest.json` 与 `agent.json` 中把 `agent-declared-model` 替换为真实使用的模型/工具及准确披露，不能把脚手架占位符带入 v2 正式包。每次手动修改 `proposal.md` 后，重新生成 `report/proposal.html`。
+7. 按 formal 模板完善 `proposal.md`、图纸、HTML 可视化、合规矩阵、标准矩阵、深度矩阵和自检结果。脚手架默认是 `package_state=scaffold`，不能投稿；必须替换正文、至少一个设计图层、五张图、HTML 和有效 A3/A0 PDF，并移除 `SCAFFOLD-DRAFT`。在 `manifest.json` 与 `agent.json` 中把 `agent-declared-model` 替换为真实使用的模型/工具及准确披露，两个文件的模型字段必须一致，不能把脚手架占位符带入 v2 正式包。每次手动修改 `proposal.md` 后，重新生成 `report/proposal.html`。
 8. 运行 `python3 scripts/finalize_submission.py submissions/<your-github-login>/<proposal-slug>`；它会拒绝未修改模板和零页 PDF，成功后写入 `package_state=ready_for_review` 并刷新 manifest 哈希。随后运行一键自检，修复到 PASS 后发起 Pull Request。PR 作者只能修改自己 GitHub 用户名对应的目录。
    - 发起 PR 前运行 `python3 scripts/participant_preflight.py submissions/<your-github-login>/<proposal-slug> --pr-author <your-github-login> --check-push`，提前检查目录归属、变更范围、大文件、完整自检、fork 远程与推送权限。
 9. 发起 PR 后必须持续监控 CI、评审评论、合并队列和状态变化。审核通常实时启动，但繁忙时可能排队；上传完成不等于任务结束。检查失败或收到修改意见时，阅读完整日志与上下文，修复后重新运行渲染、finalize、自检和 preflight，推送并继续监控，直到 PR 合并或明确记录外部 blocker。可用 `gh pr checks <PR> --watch --interval 15` 与 `gh pr view <PR> --json state,mergeStateStatus,reviewDecision,statusCheckRollup,comments,reviews`；排队时使用通知或低频定时复查，不要高频轮询或发布空评论。

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ python3 scripts/scaffold_ai_submission.py \
   --proposal-title "<proposal title>"
 ```
 
-7. 按 formal 模板完善 `proposal.md`、图纸、HTML 可视化、合规矩阵、标准矩阵、深度矩阵和自检结果。脚手架默认是 `package_state=scaffold`，不能投稿；必须替换正文、至少一个设计图层、五张图、HTML 和有效 A3/A0 PDF，并移除 `SCAFFOLD-DRAFT`。在 `manifest.json` 与 `agent.json` 中把 `agent-declared-model` 替换为真实使用的模型/工具及准确披露，两个文件的模型字段必须一致，不能把脚手架占位符带入 v2 正式包。每次手动修改 `proposal.md` 后，重新生成 `report/proposal.html`。
+7. 按 formal 模板完善 `proposal.md`、图纸、HTML 可视化、合规矩阵、标准矩阵、深度矩阵和自检结果。脚手架默认是 `package_state=scaffold`，不能投稿；必须替换正文、至少一个设计图层、五张图、HTML 和有效 A3/A0 PDF，并移除 `SCAFFOLD-DRAFT`。在 `manifest.json` 与 `agent.json` 中把 `agent-declared-model` 替换为真实使用的模型/工具及准确披露，两个文件的模型字段必须一致；任何标记为 `ready_for_review` 的包都不能携带脚手架占位符。每次手动修改 `proposal.md` 后，重新生成 `report/proposal.html`。
 8. 运行 `python3 scripts/finalize_submission.py submissions/<your-github-login>/<proposal-slug>`；它会拒绝未修改模板和零页 PDF，成功后写入 `package_state=ready_for_review` 并刷新 manifest 哈希。随后运行一键自检，修复到 PASS 后发起 Pull Request。PR 作者只能修改自己 GitHub 用户名对应的目录。
    - 发起 PR 前运行 `python3 scripts/participant_preflight.py submissions/<your-github-login>/<proposal-slug> --pr-author <your-github-login> --check-push`，提前检查目录归属、变更范围、大文件、完整自检、fork 远程与推送权限。
 9. 发起 PR 后必须持续监控 CI、评审评论、合并队列和状态变化。审核通常实时启动，但繁忙时可能排队；上传完成不等于任务结束。检查失败或收到修改意见时，阅读完整日志与上下文，修复后重新运行渲染、finalize、自检和 preflight，推送并继续监控，直到 PR 合并或明确记录外部 blocker。可用 `gh pr checks <PR> --watch --interval 15` 与 `gh pr view <PR> --json state,mergeStateStatus,reviewDecision,statusCheckRollup,comments,reviews`；排队时使用通知或低频定时复查，不要高频轮询或发布空评论。

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ python3 scripts/scaffold_ai_submission.py \
   --proposal-title "<proposal title>"
 ```
 
-7. 按 formal 模板完善 `proposal.md`、图纸、HTML 可视化、合规矩阵、标准矩阵、深度矩阵和自检结果。脚手架默认是 `package_state=scaffold`，不能投稿；必须替换正文、至少一个设计图层、五张图、HTML 和有效 A3/A0 PDF，并移除 `SCAFFOLD-DRAFT`。每次手动修改 `proposal.md` 后，重新生成 `report/proposal.html`。
+7. 按 formal 模板完善 `proposal.md`、图纸、HTML 可视化、合规矩阵、标准矩阵、深度矩阵和自检结果。脚手架默认是 `package_state=scaffold`，不能投稿；必须替换正文、至少一个设计图层、五张图、HTML 和有效 A3/A0 PDF，并移除 `SCAFFOLD-DRAFT`。在 `manifest.json` 与 `agent.json` 中把 `agent-declared-model` 替换为真实使用的模型/工具及准确披露，不能把脚手架占位符带入 v2 正式包。每次手动修改 `proposal.md` 后，重新生成 `report/proposal.html`。
 8. 运行 `python3 scripts/finalize_submission.py submissions/<your-github-login>/<proposal-slug>`；它会拒绝未修改模板和零页 PDF，成功后写入 `package_state=ready_for_review` 并刷新 manifest 哈希。随后运行一键自检，修复到 PASS 后发起 Pull Request。PR 作者只能修改自己 GitHub 用户名对应的目录。
    - 发起 PR 前运行 `python3 scripts/participant_preflight.py submissions/<your-github-login>/<proposal-slug> --pr-author <your-github-login> --check-push`，提前检查目录归属、变更范围、大文件、完整自检、fork 远程与推送权限。
 9. 发起 PR 后必须持续监控 CI、评审评论、合并队列和状态变化。审核通常实时启动，但繁忙时可能排队；上传完成不等于任务结束。检查失败或收到修改意见时，阅读完整日志与上下文，修复后重新运行渲染、finalize、自检和 preflight，推送并继续监控，直到 PR 合并或明确记录外部 blocker。可用 `gh pr checks <PR> --watch --interval 15` 与 `gh pr view <PR> --json state,mergeStateStatus,reviewDecision,statusCheckRollup,comments,reviews`；排队时使用通知或低频定时复查，不要高频轮询或发布空评论。

--- a/scripts/finalize_submission.py
+++ b/scripts/finalize_submission.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from validate_submission import (
     DISPLAY_BASE_FILES,
     is_empty_pdf,
+    is_scaffold_agent_model,
     localized_path,
     parse_front_matter,
     primary_path_from_localized,
@@ -59,6 +60,18 @@ def main() -> int:
         if isinstance(item, dict) and item.get("path") and item.get("sha256")
     }
     errors: list[str] = []
+
+    manifest_agent = manifest.get("agent")
+    if isinstance(manifest_agent, dict) and is_scaffold_agent_model(manifest_agent.get("model")):
+        errors.append("manifest agent.model still has the scaffold placeholder; declare the actual model or an accurate disclosure")
+    agent_path = root / "agent.json"
+    if agent_path.is_file():
+        try:
+            agent_card = json.loads(agent_path.read_text(encoding="utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            agent_card = None
+        if isinstance(agent_card, dict) and is_scaffold_agent_model(agent_card.get("model")):
+            errors.append("agent.json model still has the scaffold placeholder; declare the actual model or an accurate disclosure")
 
     proposal_text = (root / "proposal.md").read_text(encoding="utf-8")
     proposal_metadata, _ = parse_front_matter(proposal_text)

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -231,6 +231,7 @@ REQUIRED_DESIGN_DEPTH_IDS = {
 REFERENCE_RE = re.compile(r"\[(source|standard|depth|data|metric):([^\]\s]+)\]")
 PROPOSAL_FORMAT_VERSION = "2"
 BILINGUAL_CONTRACT_VERSION = "1"
+SCAFFOLD_AGENT_MODEL = "agent-declared-model"
 MAX_INLINE_REFERENCES_PER_BLOCK = 8
 MAX_CONSECUTIVE_REFERENCES = 3
 MARKDOWN_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
@@ -698,6 +699,11 @@ def relative_to_proposal(path: str, proposal_dir: str) -> str:
     return path[len(prefix) :] if path.startswith(prefix) else path
 
 
+def is_scaffold_agent_model(value: object) -> bool:
+    """Return whether an agent model field still carries the scaffold placeholder."""
+    return isinstance(value, str) and value.strip().casefold() == SCAFFOLD_AGENT_MODEL
+
+
 def load_json_file(report: ValidationReport, path: Path, display_path: str) -> object | None:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
@@ -1009,13 +1015,23 @@ def validate_manifest_file(report: ValidationReport, repo_root: Path, proposal_d
         report.add_error(
             f"{proposal_dir}/manifest.json: package_state must be scaffold or ready_for_review"
         )
+    strict_bilingual = requires_bilingual_display(repo_root, proposal_dir)
     if data.get("submission_type") != "ai_agent":
         report.add_error(f"{proposal_dir}/manifest.json: submission_type must be ai_agent")
     if data.get("project_id") != "centennial-jingzhang-ai-belt":
         report.add_error(
             f"{proposal_dir}/manifest.json: project_id must be centennial-jingzhang-ai-belt"
         )
-    strict_bilingual = requires_bilingual_display(repo_root, proposal_dir)
+    agent = data.get("agent")
+    if isinstance(agent, dict) and is_scaffold_agent_model(agent.get("model")):
+        message = (
+            f"{proposal_dir}/manifest.json: agent.model must replace the scaffold "
+            f"placeholder `{SCAFFOLD_AGENT_MODEL}` with an accurate model or disclosure"
+        )
+        if strict_bilingual:
+            report.add_error(message)
+        else:
+            report.add_warning(message + "; legacy v1 package remains compatible")
     files = data.get("files")
     listed_paths: set[str] = set()
     if not isinstance(files, list) or not files:
@@ -1647,7 +1663,21 @@ def validate_ai_package_dir(report: ValidationReport, repo_root: Path, proposal_
         return
     manifest, stage = validate_manifest_file(report, repo_root, proposal_dir)
 
-    for name in ["agent.json", "assumptions.json", "sources.json"]:
+    strict_bilingual = requires_bilingual_display(repo_root, proposal_dir)
+    agent_path = base / "agent.json"
+    if agent_path.exists():
+        agent_data = load_json_file(report, agent_path, f"{proposal_dir}/agent.json")
+        if isinstance(agent_data, dict) and is_scaffold_agent_model(agent_data.get("model")):
+            message = (
+                f"{proposal_dir}/agent.json: model must replace the scaffold placeholder "
+                f"`{SCAFFOLD_AGENT_MODEL}` with an accurate model or disclosure"
+            )
+            if strict_bilingual:
+                report.add_error(message)
+            else:
+                report.add_warning(message + "; legacy v1 package remains compatible")
+
+    for name in ["assumptions.json", "sources.json"]:
         path = base / name
         if path.exists():
             load_json_file(report, path, f"{proposal_dir}/{name}")

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1676,6 +1676,24 @@ def validate_ai_package_dir(report: ValidationReport, repo_root: Path, proposal_
                 report.add_error(message)
             else:
                 report.add_warning(message + "; legacy v1 package remains compatible")
+        manifest_agent = manifest.get("agent") if isinstance(manifest, dict) else None
+        manifest_model = manifest_agent.get("model") if isinstance(manifest_agent, dict) else None
+        agent_model = agent_data.get("model") if isinstance(agent_data, dict) else None
+        if (
+            isinstance(manifest_model, str)
+            and manifest_model.strip()
+            and isinstance(agent_model, str)
+            and agent_model.strip()
+            and manifest_model.strip() != agent_model.strip()
+        ):
+            message = (
+                f"{proposal_dir}/agent.json: model `{agent_model.strip()}` does not match "
+                f"manifest.json agent.model `{manifest_model.strip()}`"
+            )
+            if strict_bilingual:
+                report.add_error(message)
+            else:
+                report.add_warning(message + "; legacy v1 package remains compatible")
 
     for name in ["assumptions.json", "sources.json"]:
         path = base / name

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1016,6 +1016,7 @@ def validate_manifest_file(report: ValidationReport, repo_root: Path, proposal_d
             f"{proposal_dir}/manifest.json: package_state must be scaffold or ready_for_review"
         )
     strict_bilingual = requires_bilingual_display(repo_root, proposal_dir)
+    requires_current_agent_disclosure = strict_bilingual or package_state == "ready_for_review"
     if data.get("submission_type") != "ai_agent":
         report.add_error(f"{proposal_dir}/manifest.json: submission_type must be ai_agent")
     if data.get("project_id") != "centennial-jingzhang-ai-belt":
@@ -1028,7 +1029,7 @@ def validate_manifest_file(report: ValidationReport, repo_root: Path, proposal_d
             f"{proposal_dir}/manifest.json: agent.model must replace the scaffold "
             f"placeholder `{SCAFFOLD_AGENT_MODEL}` with an accurate model or disclosure"
         )
-        if strict_bilingual:
+        if requires_current_agent_disclosure:
             report.add_error(message)
         else:
             report.add_warning(message + "; legacy v1 package remains compatible")
@@ -1664,6 +1665,9 @@ def validate_ai_package_dir(report: ValidationReport, repo_root: Path, proposal_
     manifest, stage = validate_manifest_file(report, repo_root, proposal_dir)
 
     strict_bilingual = requires_bilingual_display(repo_root, proposal_dir)
+    requires_current_agent_disclosure = strict_bilingual or (
+        isinstance(manifest, dict) and manifest.get("package_state") == "ready_for_review"
+    )
     agent_path = base / "agent.json"
     if agent_path.exists():
         agent_data = load_json_file(report, agent_path, f"{proposal_dir}/agent.json")
@@ -1672,7 +1676,7 @@ def validate_ai_package_dir(report: ValidationReport, repo_root: Path, proposal_
                 f"{proposal_dir}/agent.json: model must replace the scaffold placeholder "
                 f"`{SCAFFOLD_AGENT_MODEL}` with an accurate model or disclosure"
             )
-            if strict_bilingual:
+            if requires_current_agent_disclosure:
                 report.add_error(message)
             else:
                 report.add_warning(message + "; legacy v1 package remains compatible")
@@ -1690,7 +1694,7 @@ def validate_ai_package_dir(report: ValidationReport, repo_root: Path, proposal_
                 f"{proposal_dir}/agent.json: model `{agent_model.strip()}` does not match "
                 f"manifest.json agent.model `{manifest_model.strip()}`"
             )
-            if strict_bilingual:
+            if requires_current_agent_disclosure:
                 report.add_error(message)
             else:
                 report.add_warning(message + "; legacy v1 package remains compatible")

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -65,7 +65,7 @@ def run_scaffold(output_dir: Path, stage: str = "formal", cwd: Path = REPO_ROOT)
     )
 
 
-def complete_scaffold(output_dir: Path) -> subprocess.CompletedProcess:
+def complete_scaffold(output_dir: Path, *, declare_model: bool = True) -> subprocess.CompletedProcess:
     proposal = output_dir / "proposal.md"
     proposal.write_text(
         proposal.read_text(encoding="utf-8").replace("SCAFFOLD-DRAFT", "PARTICIPANT-DESIGN")
@@ -119,6 +119,15 @@ def complete_scaffold(output_dir: Path) -> subprocess.CompletedProcess:
         target = source.with_name(f"{source.stem}.en{source.suffix}")
         if not target.exists():
             target.write_bytes(source.read_bytes())
+    if declare_model:
+        manifest_path = output_dir / "manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["agent"]["model"] = "test-scaffold-model"
+        manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        agent_path = output_dir / "agent.json"
+        agent = json.loads(agent_path.read_text(encoding="utf-8"))
+        agent["model"] = "test-scaffold-model"
+        agent_path.write_text(json.dumps(agent, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     return subprocess.run(
         [sys.executable, str(REPO_ROOT / "scripts" / "finalize_submission.py"), str(output_dir)],
         capture_output=True,
@@ -193,6 +202,17 @@ def write_provisional_site_package(root: Path) -> None:
 
 @unittest.skipUnless(HAS_REVIEW_DEPS, "Install requirements-review.txt to run scaffold/self-check tests")
 class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
+    def test_finalize_rejects_scaffold_model_placeholder(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "submissions" / "alice" / "placeholder-model"
+            scaffold = run_scaffold(output_dir)
+            self.assertEqual(0, scaffold.returncode, scaffold.stdout + scaffold.stderr)
+
+            finalized = complete_scaffold(output_dir, declare_model=False)
+
+            self.assertNotEqual(0, finalized.returncode)
+            self.assertIn("scaffold placeholder", finalized.stdout)
+
     def test_finalize_blocks_v2_package_without_required_bilingual_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             output_dir = Path(tmp) / "submissions" / "alice" / "missing-bilingual"

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -1311,6 +1311,34 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertTrue(report.ok, report.errors)
             self.assertIn("scaffold placeholder", "\n".join(report.warnings))
 
+    def test_review_ready_legacy_scaffold_model_placeholder_fails_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            self.update_json(
+                root,
+                f"{base}/manifest.json",
+                lambda data: data.update(
+                    {
+                        "package_state": "ready_for_review",
+                        "agent": {**data["agent"], "model": "agent-declared-model"},
+                    }
+                ),
+            )
+            self.update_json(
+                root,
+                f"{base}/agent.json",
+                lambda data: data.update({"model": "agent-declared-model"}),
+            )
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertFalse(report.ok)
+            errors = "\n".join(report.errors)
+            self.assertIn("manifest.json: agent.model", errors)
+            self.assertIn("agent.json: model", errors)
+
     def test_v2_scaffold_model_placeholder_fails_validation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -1357,6 +1385,27 @@ class SubmissionWorkflowTests(unittest.TestCase):
             base = "submissions/alice/ai-urban-loop"
             changed = self.write_minimal_ai_package(root, base)
             self.add_bilingual_v2_display(root, base, changed)
+            self.update_json(
+                root,
+                f"{base}/agent.json",
+                lambda data: data.update({"model": "other-agent-model"}),
+            )
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertFalse(report.ok)
+            self.assertIn("does not match manifest.json agent.model", "\n".join(report.errors))
+
+    def test_review_ready_legacy_agent_model_mismatch_fails_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            self.update_json(
+                root,
+                f"{base}/manifest.json",
+                lambda data: data.update({"package_state": "ready_for_review"}),
+            )
             self.update_json(
                 root,
                 f"{base}/agent.json",

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -1335,6 +1335,39 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertIn("manifest.json: agent.model", errors)
             self.assertIn("agent.json: model", errors)
 
+    def test_legacy_agent_model_mismatch_warns_without_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            self.update_json(
+                root,
+                f"{base}/agent.json",
+                lambda data: data.update({"model": "other-agent-model"}),
+            )
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertTrue(report.ok, report.errors)
+            self.assertIn("does not match manifest.json agent.model", "\n".join(report.warnings))
+
+    def test_v2_agent_model_mismatch_fails_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            self.add_bilingual_v2_display(root, base, changed)
+            self.update_json(
+                root,
+                f"{base}/agent.json",
+                lambda data: data.update({"model": "other-agent-model"}),
+            )
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertFalse(report.ok)
+            self.assertIn("does not match manifest.json agent.model", "\n".join(report.errors))
+
     def test_changelog_submission_passes_hard_validation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -1290,6 +1290,51 @@ class SubmissionWorkflowTests(unittest.TestCase):
             report = validate_submission(root, "alice", changed)
             self.assertTrue(report.ok, report.errors)
 
+    def test_legacy_scaffold_model_placeholder_warns_without_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            self.update_json(
+                root,
+                f"{base}/manifest.json",
+                lambda data: data["agent"].update({"model": "agent-declared-model"}),
+            )
+            self.update_json(
+                root,
+                f"{base}/agent.json",
+                lambda data: data.update({"model": "agent-declared-model"}),
+            )
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertTrue(report.ok, report.errors)
+            self.assertIn("scaffold placeholder", "\n".join(report.warnings))
+
+    def test_v2_scaffold_model_placeholder_fails_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            self.add_bilingual_v2_display(root, base, changed)
+            self.update_json(
+                root,
+                f"{base}/manifest.json",
+                lambda data: data["agent"].update({"model": "agent-declared-model"}),
+            )
+            self.update_json(
+                root,
+                f"{base}/agent.json",
+                lambda data: data.update({"model": "agent-declared-model"}),
+            )
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertFalse(report.ok)
+            errors = "\n".join(report.errors)
+            self.assertIn("manifest.json: agent.model", errors)
+            self.assertIn("agent.json: model", errors)
+
     def test_changelog_submission_passes_hard_validation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## What changed

- Reject the literal scaffold model placeholder `agent-declared-model` during v2 validation and for every package explicitly marked `ready_for_review`, in both `manifest.json` and `agent.json`.
- Require the declared model values in those two files to match for v2 and review-ready packages.
- Preserve a visible warning for genuinely legacy v1 packages that do not declare `package_state=ready_for_review`.
- Refuse finalization while either field retains the placeholder.
- Document the required model/tool disclosure and add regression coverage.

## Why

A submission can manually switch a scaffold to `ready_for_review` while retaining the template model identifier, or make conflicting model declarations. Either case makes AI provenance and generated-asset claims unauditable. The readiness declaration is a current assertion, so it must not use legacy compatibility to bypass that disclosure.

## Validation

- `python3 -m pytest -q tests/test_submission_workflow.py tests/test_agent_scaffold_and_self_check.py` — 114 passed
- `python3 -m pytest -q` — 276 passed
- `python3 -m py_compile scripts/validate_submission.py tests/test_submission_workflow.py`
- `git diff --check`
