### PR TITLE
fix: validate simulation aggregate consistency

### DIFF
--- a/docs/formal-submission-guide.md
+++ b/docs/formal-submission-guide.md
@@ -317,7 +317,7 @@ agent.6 一带全球AI创新活动体系与长期运营设计
 
 这些图应由 GeoJSON、metrics、compliance/standard/depth 矩阵和自检结果派生；不得使用远程图片、data URI、未清权地图截图或把图片当作权威面积/边界来源。图是解释层，权威数据仍是 GeoJSON/JSON。
 
-如果提交包包含 `simulation.json`，仿真结果也必须能够从任务台账复算：`task_count` 要等于 `tasks.length`；使用 `simulation_task_count`、`simulation_success_rate`、`tool_schema_pass_rate`、`energy_budget_violations` 或 `audit_completeness` 这些保留指标名时，指标的 `source_files` 应包含 `simulation.json`，并与任务记录逐项一致。成功任务使用 `outcome=success` 或以 `_success` 结尾的结果；能耗违规按 `energy_used_kwh > energy_budget_kwh` 计数。若同时提供 `baselines.urban_llm_harness` 或 `visual/assets/evaluation-baseline.json`，同名聚合值必须一致；不同评测范围应显式增加 scope，而不能在同一个指标名下并列两个结果。`ready_for_review` / 双语 v2 包中的冲突会阻断校验，legacy v1 仅给出迁移警告。
+如果提交包包含 `simulation.json`，仿真结果也必须能够从任务台账复算：`task_count` 要等于 `tasks.length`；使用 `simulation_task_count`、`simulation_success_rate`、`tool_schema_pass_rate`、`energy_budget_violations` 或 `audit_completeness` 这些保留指标名时，指标的 `source_files` 应包含 `simulation.json`，并与任务记录逐项一致。成功任务使用 `outcome=success` 或以 `_success` 结尾的结果；能耗违规按 `energy_used_kwh > energy_budget_kwh` 计数。若同时提供 `baselines.urban_llm_harness` 或 `visual/assets/evaluation-baseline.json`，同名聚合值必须一致：`urban_llm_harness` 被定义为任务台账的镜像，不能用一个 scope 字段绕过冲突。其他评测范围须放在不同、说明用途的基线名下，不能在同一个保留指标名下并列两个结果。`ready_for_review` / 双语 v2 包中的冲突会阻断校验，legacy v1 仅给出迁移警告。
 
 ### 图面表达质量要求
 

--- a/docs/formal-submission-guide.md
+++ b/docs/formal-submission-guide.md
@@ -317,6 +317,8 @@ agent.6 一带全球AI创新活动体系与长期运营设计
 
 这些图应由 GeoJSON、metrics、compliance/standard/depth 矩阵和自检结果派生；不得使用远程图片、data URI、未清权地图截图或把图片当作权威面积/边界来源。图是解释层，权威数据仍是 GeoJSON/JSON。
 
+如果提交包包含 `simulation.json`，仿真结果也必须能够从任务台账复算：`task_count` 要等于 `tasks.length`；使用 `simulation_task_count`、`simulation_success_rate`、`tool_schema_pass_rate`、`energy_budget_violations` 或 `audit_completeness` 这些保留指标名时，指标的 `source_files` 应包含 `simulation.json`，并与任务记录逐项一致。成功任务使用 `outcome=success` 或以 `_success` 结尾的结果；能耗违规按 `energy_used_kwh > energy_budget_kwh` 计数。若同时提供 `baselines.urban_llm_harness` 或 `visual/assets/evaluation-baseline.json`，同名聚合值必须一致；不同评测范围应显式增加 scope，而不能在同一个指标名下并列两个结果。`ready_for_review` / 双语 v2 包中的冲突会阻断校验，legacy v1 仅给出迁移警告。
+
 ### 图面表达质量要求
 
 本项目要求的图面不是 raw data 截图，也不是把 GeoJSON polygon 直接填色后的 debug map。GeoJSON、metrics 和矩阵是证据层；`assets/figures/*.png`、A3/A0 和 `visual/index.html` 是解释层，必须让非技术评审者一眼看懂设计判断、空间主次和资料边界。

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -973,6 +973,215 @@ def validate_metrics_file(report: ValidationReport, path: Path, display_path: st
                 report.add_error(f"{label}: ratio value must be between 0 and 1")
 
 
+def _simulation_source_declared(metric: object) -> bool:
+    if not isinstance(metric, dict):
+        return False
+    source_files = metric.get("source_files")
+    if not isinstance(source_files, list):
+        return False
+    for source in source_files:
+        if not isinstance(source, str):
+            continue
+        normalized = source.split("#", 1)[0].strip().lstrip("./")
+        if normalized == "simulation.json":
+            return True
+    return False
+
+
+def _simulation_scalar_equal(left: object, right: object) -> bool:
+    if isinstance(left, bool) or isinstance(right, bool):
+        return left == right
+    if not isinstance(left, (int, float)) or not isinstance(right, (int, float)):
+        return left == right
+    scale = max(1.0, abs(float(left)), abs(float(right)))
+    return abs(float(left) - float(right)) <= 1e-9 * scale
+
+
+def _simulation_issue(report: ValidationReport, strict: bool, message: str) -> None:
+    if strict:
+        report.add_error(message)
+    else:
+        report.add_warning(message + "; legacy simulation remains compatible")
+
+
+def validate_simulation_consistency(
+    report: ValidationReport,
+    repo_root: Path,
+    proposal_dir: str,
+    metrics_path: Path,
+    simulation_path: Path,
+    *,
+    strict: bool,
+) -> None:
+    """Check that claimed simulation aggregates are reproducible from task records."""
+    simulation_display = f"{proposal_dir}/simulation.json"
+    simulation = load_json_file(report, simulation_path, simulation_display)
+    if not isinstance(simulation, dict):
+        return
+
+    tasks = simulation.get("tasks")
+    if not isinstance(tasks, list) or not tasks or not all(isinstance(task, dict) for task in tasks):
+        _simulation_issue(
+            report,
+            strict,
+            f"{simulation_display}: tasks must be a non-empty array of objects for reproducible aggregates",
+        )
+        return
+
+    task_count = simulation.get("task_count")
+    if isinstance(task_count, bool) or not isinstance(task_count, int):
+        _simulation_issue(
+            report,
+            strict,
+            f"{simulation_display}: task_count must be an integer matching tasks.length",
+        )
+    elif task_count != len(tasks):
+        _simulation_issue(
+            report,
+            strict,
+            f"{simulation_display}: task_count={task_count} does not match tasks.length={len(tasks)}",
+        )
+
+    derived: dict[str, int | float] = {"simulation_task_count": len(tasks)}
+    derivation_problems: dict[str, str] = {}
+
+    outcomes = [task.get("outcome") for task in tasks]
+    if all(isinstance(outcome, str) and outcome.strip() for outcome in outcomes):
+        successful = sum(
+            1
+            for outcome in outcomes
+            if outcome == "success" or outcome.endswith("_success")
+        )
+        derived["simulation_success_rate"] = successful / len(tasks)
+    else:
+        derivation_problems["simulation_success_rate"] = (
+            "each task needs a non-empty outcome; use `success` or an outcome ending in `_success` for successful tasks"
+        )
+
+    schema_values = [task.get("dispatch_schema_valid") for task in tasks]
+    if all(isinstance(value, bool) for value in schema_values):
+        derived["tool_schema_pass_rate"] = sum(schema_values) / len(tasks)
+    else:
+        derivation_problems["tool_schema_pass_rate"] = "each task needs boolean dispatch_schema_valid"
+
+    energy_values = [
+        (task.get("energy_used_kwh"), task.get("energy_budget_kwh"))
+        for task in tasks
+    ]
+    if all(
+        isinstance(used, (int, float))
+        and not isinstance(used, bool)
+        and isinstance(budget, (int, float))
+        and not isinstance(budget, bool)
+        for used, budget in energy_values
+    ):
+        derived["energy_budget_violations"] = sum(
+            1 for used, budget in energy_values if used > budget
+        )
+    else:
+        derivation_problems["energy_budget_violations"] = (
+            "each task needs numeric energy_used_kwh and energy_budget_kwh"
+        )
+
+    audit_values = [task.get("audit_complete") for task in tasks]
+    if all(isinstance(value, bool) for value in audit_values):
+        derived["audit_completeness"] = sum(audit_values) / len(tasks)
+    else:
+        derivation_problems["audit_completeness"] = "each task needs boolean audit_complete"
+
+    metrics_data = load_json_file(report, metrics_path, f"{proposal_dir}/metrics.json")
+    metric_items = metrics_data.get("metrics") if isinstance(metrics_data, dict) else None
+    if not isinstance(metric_items, dict):
+        return
+
+    for name, problem in derivation_problems.items():
+        metric = metric_items.get(name)
+        if isinstance(metric, dict) and metric.get("status") == "known" and _simulation_source_declared(metric):
+            _simulation_issue(
+                report,
+                strict,
+                f"{simulation_display}: metrics.{name} cannot be recomputed; {problem}",
+            )
+
+    for name, expected in derived.items():
+        metric = metric_items.get(name)
+        if not isinstance(metric, dict) or metric.get("status") != "known":
+            continue
+        if not _simulation_source_declared(metric):
+            continue
+        actual = metric.get("value")
+        if not isinstance(actual, (int, float)) or isinstance(actual, bool):
+            continue
+        if not _simulation_scalar_equal(actual, expected):
+            _simulation_issue(
+                report,
+                strict,
+                f"{simulation_display}: metrics.{name}={actual} does not match the task-derived value {expected}",
+            )
+
+    baseline = simulation.get("baselines")
+    if not isinstance(baseline, dict):
+        return
+
+    metric_to_baseline = {
+        "simulation_success_rate": "success_rate",
+        "tool_schema_pass_rate": "tool_schema_pass_rate",
+        "high_risk_intercept_rate": "high_risk_intercept_rate",
+        "energy_budget_violations": "energy_budget_violations",
+        "replan_p95_seconds": "replan_p95_seconds",
+        "audit_completeness": "audit_completeness",
+    }
+    harness_baseline = baseline.get("urban_llm_harness")
+    if isinstance(harness_baseline, dict):
+        for metric_name, baseline_name in metric_to_baseline.items():
+            metric = metric_items.get(metric_name)
+            baseline_value = harness_baseline.get(baseline_name)
+            if (
+                isinstance(metric, dict)
+                and metric.get("status") == "known"
+                and _simulation_source_declared(metric)
+                and isinstance(metric.get("value"), (int, float))
+                and not isinstance(metric.get("value"), bool)
+                and isinstance(baseline_value, (int, float))
+                and not isinstance(baseline_value, bool)
+                and not _simulation_scalar_equal(metric["value"], baseline_value)
+            ):
+                _simulation_issue(
+                    report,
+                    strict,
+                    f"{simulation_display}: metrics.{metric_name}={metric['value']} conflicts with baselines.urban_llm_harness.{baseline_name}={baseline_value}; add an explicit scope or use one aggregate",
+                )
+
+    evaluation_path = repo_root / proposal_dir / "visual" / "assets" / "evaluation-baseline.json"
+    if not evaluation_path.is_file():
+        return
+    evaluation_display = f"{proposal_dir}/visual/assets/evaluation-baseline.json"
+    evaluation = load_json_file(report, evaluation_path, evaluation_display)
+    if not isinstance(evaluation, dict):
+        return
+    evaluation_metrics = evaluation.get("metrics")
+    if not isinstance(evaluation_metrics, dict):
+        return
+    for baseline_name, values in baseline.items():
+        evaluation_values = evaluation_metrics.get(baseline_name)
+        if not isinstance(values, dict) or not isinstance(evaluation_values, dict):
+            continue
+        for key, value in values.items():
+            other = evaluation_values.get(key)
+            if (
+                isinstance(value, (int, float))
+                and not isinstance(value, bool)
+                and isinstance(other, (int, float))
+                and not isinstance(other, bool)
+                and not _simulation_scalar_equal(value, other)
+            ):
+                _simulation_issue(
+                    report,
+                    strict,
+                    f"{evaluation_display}: metrics.{baseline_name}.{key}={other} conflicts with simulation.json baselines.{baseline_name}.{key}={value}",
+                )
+
+
 def validate_manifest_file(report: ValidationReport, repo_root: Path, proposal_dir: str) -> tuple[dict | None, str]:
     manifest_path = repo_root / proposal_dir / "manifest.json"
     data = load_json_file(report, manifest_path, f"{proposal_dir}/manifest.json")
@@ -1646,6 +1855,10 @@ def validate_ai_package_dir(report: ValidationReport, repo_root: Path, proposal_
     if not (base / "manifest.json").exists():
         return
     manifest, stage = validate_manifest_file(report, repo_root, proposal_dir)
+    strict_bilingual = requires_bilingual_display(repo_root, proposal_dir)
+    strict_simulation = strict_bilingual or (
+        isinstance(manifest, dict) and manifest.get("package_state") == "ready_for_review"
+    )
 
     for name in ["agent.json", "assumptions.json", "sources.json"]:
         path = base / name
@@ -1660,6 +1873,17 @@ def validate_ai_package_dir(report: ValidationReport, repo_root: Path, proposal_
     metrics_path = base / "metrics.json"
     if metrics_path.exists():
         validate_metrics_file(report, metrics_path, f"{proposal_dir}/metrics.json")
+
+    simulation_path = base / "simulation.json"
+    if simulation_path.exists() and metrics_path.exists():
+        validate_simulation_consistency(
+            report,
+            repo_root,
+            proposal_dir,
+            metrics_path,
+            simulation_path,
+            strict=strict_simulation,
+        )
 
     compliance_path = base / "compliance_matrix.json"
     if compliance_path.exists():
@@ -1684,7 +1908,6 @@ def validate_ai_package_dir(report: ValidationReport, repo_root: Path, proposal_
     proposal_html_path = base / "report" / "proposal.html"
     if proposal_html_path.exists():
         validate_proposal_html_file(report, proposal_html_path, f"{proposal_dir}/report/proposal.html")
-    strict_bilingual = requires_bilingual_display(repo_root, proposal_dir)
     for language in ["zh", "en"]:
         translated_html = base / "report" / f"proposal.{language}.html"
         if translated_html.exists():

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1149,7 +1149,7 @@ def validate_simulation_consistency(
                 _simulation_issue(
                     report,
                     strict,
-                    f"{simulation_display}: metrics.{metric_name}={metric['value']} conflicts with baselines.urban_llm_harness.{baseline_name}={baseline_value}; add an explicit scope or use one aggregate",
+                    f"{simulation_display}: metrics.{metric_name}={metric['value']} conflicts with baselines.urban_llm_harness.{baseline_name}={baseline_value}; urban_llm_harness must mirror the task-derived aggregate, so record any distinct evaluation under a different documented baseline",
                 )
 
     evaluation_path = repo_root / proposal_dir / "visual" / "assets" / "evaluation-baseline.json"

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -1919,6 +1919,7 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertFalse(report.ok)
             errors = "\n".join(report.errors)
             self.assertIn("conflicts with baselines.urban_llm_harness.success_rate=1.0", errors)
+            self.assertIn("urban_llm_harness must mirror the task-derived aggregate", errors)
             self.assertIn("evaluation-baseline.json", errors)
 
     def test_language_neutral_cannot_bypass_primary_display_pair(self) -> None:

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -1764,6 +1764,163 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertNotIn("bilingual", "\n".join(report.warnings))
             self.assertNotIn("counterpart", "\n".join(report.warnings))
 
+    def test_v2_simulation_metrics_must_match_task_records(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            self.add_bilingual_v2_display(root, base, changed)
+
+            metrics_path = root / base / "metrics.json"
+            metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+            metrics["metrics"].update(
+                {
+                    "simulation_task_count": {
+                        "status": "known",
+                        "value": 2,
+                        "unit": "count",
+                        "source_files": ["simulation.json"],
+                    },
+                    "simulation_success_rate": {
+                        "status": "known",
+                        "value": 0.5,
+                        "unit": "ratio",
+                        "source_files": ["simulation.json"],
+                    },
+                    "tool_schema_pass_rate": {
+                        "status": "known",
+                        "value": 1.0,
+                        "unit": "ratio",
+                        "source_files": ["simulation.json"],
+                    },
+                    "energy_budget_violations": {
+                        "status": "known",
+                        "value": 0,
+                        "unit": "count",
+                        "source_files": ["simulation.json"],
+                    },
+                    "audit_completeness": {
+                        "status": "known",
+                        "value": 0.5,
+                        "unit": "ratio",
+                        "source_files": ["simulation.json"],
+                    },
+                }
+            )
+            metrics_path.write_text(
+                json.dumps(metrics, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            self.write_json(
+                root,
+                f"{base}/simulation.json",
+                {
+                    "schema_version": "0.1.0",
+                    "task_count": 2,
+                    "tasks": [
+                        {
+                            "task_id": "SIM-001",
+                            "outcome": "success",
+                            "dispatch_schema_valid": True,
+                            "energy_used_kwh": 3.0,
+                            "energy_budget_kwh": 2.0,
+                            "audit_complete": True,
+                        },
+                        {
+                            "task_id": "SIM-002",
+                            "outcome": "failed",
+                            "dispatch_schema_valid": False,
+                            "energy_used_kwh": 1.0,
+                            "energy_budget_kwh": 2.0,
+                            "audit_complete": False,
+                        },
+                    ],
+                },
+            )
+            changed.extend([f"{base}/metrics.json", f"{base}/simulation.json"])
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertFalse(report.ok)
+            errors = "\n".join(report.errors)
+            self.assertIn("metrics.tool_schema_pass_rate=1.0", errors)
+            self.assertIn("task-derived value 0.5", errors)
+            self.assertIn("metrics.energy_budget_violations=0", errors)
+            self.assertIn("task-derived value 1", errors)
+
+    def test_simulation_baseline_must_match_mirror_file_and_metric_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            self.add_bilingual_v2_display(root, base, changed)
+
+            metrics_path = root / base / "metrics.json"
+            metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+            metrics["metrics"]["simulation_success_rate"] = {
+                "status": "known",
+                "value": 0.5,
+                "unit": "ratio",
+                "source_files": ["simulation.json"],
+            }
+            metrics_path.write_text(
+                json.dumps(metrics, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            self.write_json(
+                root,
+                f"{base}/simulation.json",
+                {
+                    "schema_version": "0.1.0",
+                    "task_count": 2,
+                    "tasks": [
+                        {
+                            "task_id": "SIM-001",
+                            "outcome": "success",
+                            "dispatch_schema_valid": True,
+                            "energy_used_kwh": 1.0,
+                            "energy_budget_kwh": 2.0,
+                            "audit_complete": True,
+                        },
+                        {
+                            "task_id": "SIM-002",
+                            "outcome": "failed",
+                            "dispatch_schema_valid": True,
+                            "energy_used_kwh": 1.0,
+                            "energy_budget_kwh": 2.0,
+                            "audit_complete": True,
+                        },
+                    ],
+                    "baselines": {
+                        "urban_llm_harness": {"success_rate": 1.0},
+                    },
+                },
+            )
+            self.write_json(
+                root,
+                f"{base}/visual/assets/evaluation-baseline.json",
+                {
+                    "schema_version": "0.1.0",
+                    "metrics": {
+                        "urban_llm_harness": {"success_rate": 0.9},
+                    },
+                },
+            )
+            changed.extend(
+                [
+                    f"{base}/metrics.json",
+                    f"{base}/simulation.json",
+                    f"{base}/visual/assets/evaluation-baseline.json",
+                ]
+            )
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertFalse(report.ok)
+            errors = "\n".join(report.errors)
+            self.assertIn("conflicts with baselines.urban_llm_harness.success_rate=1.0", errors)
+            self.assertIn("evaluation-baseline.json", errors)
+
     def test_language_neutral_cannot_bypass_primary_display_pair(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary

- validate optional `simulation.json` task ledgers when a package declares simulation metrics;
- recompute task count, success rate, tool-schema pass rate, energy-budget violations, and audit completeness from task records;
- reject conflicting `metrics.json`, `simulation.json` baselines, and `visual/assets/evaluation-baseline.json` values for ready-for-review / bilingual v2 packages;
- retain warnings for legacy v1 packages and document the contract.

## Motivation

PR #798 currently exposes a reproducibility gap: its exact head declares `simulation_success_rate=0.92`, while `simulation.json.baselines.urban_llm_harness.success_rate=1.0`; the 100 task records also contain 5 energy-budget violations while the declared metric is 0. The existing deterministic validator does not inspect simulation.json.

## Validation

- `python3 -m unittest discover -s tests` — 271 passed
- targeted simulation consistency tests — passed
- `python3 -m py_compile scripts/validate_submission.py tests/test_submission_workflow.py`
- `git diff --check`