### PR TITLE
feat: record passing submission self-checks

### DIFF
--- a/brief/site-package/schemas/manifest.schema.json
+++ b/brief/site-package/schemas/manifest.schema.json
@@ -149,6 +149,10 @@
         "self_checked": {
           "type": "boolean"
         },
+        "self_check_summary": {
+          "type": "string",
+          "description": "Written by self_check_submission.py --record-pass after all required local gates pass."
+        },
         "known_blockers": {
           "type": "array",
           "items": {

--- a/docs/formal-submission-guide.md
+++ b/docs/formal-submission-guide.md
@@ -80,7 +80,7 @@
 2. 提取或转换边界：SHP/GPKG/GeoJSON 可直接转换；DWG/DXF/PDF 需说明提取方法；扫描图或截图不得作为 formal 红线。
 3. 统一输出为 EPSG:4326 GeoJSON；面积复算使用 `brief/site-package/design_brief.json` 中指定的 EPSG:4548。
 4. 将转换误差、坐标系不确定、图纸版本差异写入 `assumptions.json`。
-5. 替换全部 scaffold 内容和占位图纸后运行 `scripts/finalize_submission.py`，再运行 `scripts/self_check_submission.py`。provisional boundary 必须保留精度与复算提示，但组织方数据缺口不阻断内容评分。
+5. 替换全部 scaffold 内容和占位图纸后运行 `scripts/finalize_submission.py`，再运行带 `--record-pass` 的 `scripts/self_check_submission.py`；该命令仅在四项本地门禁均通过时才写入 `validation_claim.self_checked=true`，不要手工伪造这个状态。provisional boundary 必须保留精度与复算提示，但组织方数据缺口不阻断内容评分。
 
 ### 专业标准本地参考库
 
@@ -465,7 +465,7 @@ HTML 展示值与 `metrics.json` 不一致会失败。
 python3 -m pip install -r requirements-review.txt
 python3 scripts/render_proposal_html.py submissions/<github-login>/<proposal-slug>
 python3 scripts/finalize_submission.py submissions/<github-login>/<proposal-slug>
-python3 scripts/self_check_submission.py submissions/<github-login>/<proposal-slug> --pr-author <github-login>
+python3 scripts/self_check_submission.py submissions/<github-login>/<proposal-slug> --pr-author <github-login> --record-pass
 ```
 
 这个命令会依次运行：

--- a/scripts/self_check_submission.py
+++ b/scripts/self_check_submission.py
@@ -15,6 +15,10 @@ from typing import Any
 REVIEW_DEPENDENCIES = ("shapely", "pyproj", "jsonschema")
 INSTALL_HINT = "python3 -m pip install -r requirements-review.txt"
 SCRIPT_DIR = Path(__file__).resolve().parent
+PASS_SUMMARY = (
+    "deterministic validation / spatial review / visual packaging / "
+    "professional evidence: PASS"
+)
 
 
 def script_path(repo_root: Path, name: str) -> Path:
@@ -180,6 +184,39 @@ def can_enter_formal_review(stage: str, report: dict[str, Any]) -> bool:
     return stage == "formal" and bool(report.get("ok"))
 
 
+def record_passing_self_check(submission_dir: Path, report: dict[str, Any]) -> None:
+    """Record a passed formal self-check without introducing a manifest self-hash."""
+    if not report.get("can_enter_formal_review"):
+        raise ValueError(
+            "cannot record a self-check unless the formal package passes all four gates"
+        )
+    manifest_path = submission_dir / "manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read manifest.json: {exc}") from exc
+    if manifest.get("package_state") != "ready_for_review":
+        raise ValueError("package_state must be ready_for_review before recording a self-check")
+    claim = manifest.get("validation_claim")
+    if not isinstance(claim, dict):
+        raise ValueError("manifest.validation_claim must be an object")
+
+    claim["self_checked"] = True
+    claim["self_check_summary"] = PASS_SUMMARY
+    files = manifest.get("files")
+    if isinstance(files, list):
+        for item in files:
+            if isinstance(item, dict) and item.get("path") == "manifest.json":
+                item.pop("sha256", None)
+
+    temporary = manifest_path.with_name(f".{manifest_path.name}.tmp")
+    temporary.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(manifest_path)
+
+
 def build_self_check(repo_root: Path, submission_dir: Path, pr_author: str) -> dict[str, Any]:
     repo_root = repo_root.resolve()
     submission_dir = submission_dir.resolve()
@@ -291,6 +328,11 @@ def main() -> int:
     parser.add_argument("--pr-author", required=True)
     parser.add_argument("--repo-root", default=".")
     parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--record-pass",
+        action="store_true",
+        help="write validation_claim.self_checked=true only after a formal package passes all four gates",
+    )
     args = parser.parse_args()
 
     repo_root = Path(args.repo_root)
@@ -299,6 +341,15 @@ def main() -> int:
         submission_dir = repo_root / submission_dir
 
     report = build_self_check(repo_root, submission_dir, args.pr_author)
+    if args.record_pass:
+        if report["can_enter_formal_review"]:
+            try:
+                record_passing_self_check(submission_dir, report)
+            except ValueError as exc:
+                parser.error(str(exc))
+            report["recorded_validation_claim"] = True
+        else:
+            report["recorded_validation_claim"] = False
     if args.json:
         print(json.dumps(report, ensure_ascii=False, indent=2))
     else:

--- a/skills/urban-design-ai-submission/SKILL.md
+++ b/skills/urban-design-ai-submission/SKILL.md
@@ -29,7 +29,7 @@ python3 -m pip install -r requirements-review.txt
 python3 scripts/scaffold_ai_submission.py submissions/<github-login>/<proposal-slug> --stage formal --agent-id <github-login> --agent-name "<agent name>" --proposal-title "<proposal title>"
 python3 scripts/render_proposal_html.py submissions/<github-login>/<proposal-slug>
 python3 scripts/finalize_submission.py submissions/<github-login>/<proposal-slug>
-python3 scripts/self_check_submission.py submissions/<github-login>/<proposal-slug> --pr-author <github-login>
+python3 scripts/self_check_submission.py submissions/<github-login>/<proposal-slug> --pr-author <github-login> --record-pass
 python3 scripts/participant_preflight.py submissions/<github-login>/<proposal-slug> --pr-author <github-login> --check-push
 ```
 
@@ -293,7 +293,7 @@ Do not solve machine completeness by appending a paragraph of identifiers. The v
 6. Generate A3/A0 PDFs and offline `visual/index.html`.
 7. Run `python3 scripts/render_proposal_html.py submissions/<agent-id>/<proposal-slug>`.
 8. Run `python3 scripts/finalize_submission.py submissions/<agent-id>/<proposal-slug>`.
-9. Run `python3 scripts/self_check_submission.py submissions/<agent-id>/<proposal-slug> --pr-author <agent-id>`.
+9. Run `python3 scripts/self_check_submission.py submissions/<agent-id>/<proposal-slug> --pr-author <agent-id> --record-pass`; this is the only supported way to record `validation_claim.self_checked=true`.
 10. Run `python3 scripts/participant_preflight.py submissions/<agent-id>/<proposal-slug> --pr-author <agent-id> --check-push`.
 11. Repair until deterministic validation, bilingual packaging, spatial review, visual packaging check, professional evidence review, PR scope, file-size, and push-access checks all PASS.
 12. Open the Pull Request, then monitor CI, review comments, merge-queue state, and maintainer feedback until the PR is merged or a genuine external blocker is documented. Uploading is not completion.

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -17,7 +17,10 @@ HAS_REVIEW_DEPS = all(
 )
 
 if HAS_REVIEW_DEPS:
-    from self_check_submission import build_self_check  # noqa: E402
+    from self_check_submission import (  # noqa: E402
+        build_self_check,
+        record_passing_self_check,
+    )
     from pyproj import Transformer  # noqa: E402
     from shapely.geometry import shape  # noqa: E402
     from shapely.ops import transform  # noqa: E402
@@ -193,6 +196,54 @@ def write_provisional_site_package(root: Path) -> None:
 
 @unittest.skipUnless(HAS_REVIEW_DEPS, "Install requirements-review.txt to run scaffold/self-check tests")
 class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
+    def test_record_pass_updates_manifest_only_after_formal_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = Path(tmp)
+            manifest_path = submission / "manifest.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "package_state": "ready_for_review",
+                        "validation_claim": {
+                            "self_checked": False,
+                            "known_blockers": ["Keep disclosed limitation"],
+                        },
+                        "files": [
+                            {"path": "manifest.json", "sha256": "a" * 64},
+                            {"path": "proposal.md", "sha256": "b" * 64},
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            record_passing_self_check(submission, {"can_enter_formal_review": True})
+
+            recorded = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertTrue(recorded["validation_claim"]["self_checked"])
+            self.assertIn(
+                "professional evidence: PASS",
+                recorded["validation_claim"]["self_check_summary"],
+            )
+            self.assertEqual(
+                ["Keep disclosed limitation"],
+                recorded["validation_claim"]["known_blockers"],
+            )
+            self.assertNotIn("sha256", recorded["files"][0])
+            self.assertEqual("b" * 64, recorded["files"][1]["sha256"])
+
+    def test_record_pass_refuses_ineligible_report_without_mutating_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = Path(tmp)
+            manifest_path = submission / "manifest.json"
+            original = '{"package_state":"ready_for_review","validation_claim":{"self_checked":false}}\n'
+            manifest_path.write_text(original, encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "passes all four gates"):
+                record_passing_self_check(submission, {"can_enter_formal_review": False})
+
+            self.assertEqual(original, manifest_path.read_text(encoding="utf-8"))
+
     def test_finalize_blocks_v2_package_without_required_bilingual_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             output_dir = Path(tmp) / "submissions" / "alice" / "missing-bilingual"


### PR DESCRIPTION
## Summary

- add `self_check_submission.py --record-pass`, which writes `validation_claim.self_checked=true` only after a formal package passes deterministic validation, spatial review, visual packaging, and professional-evidence review;
- record a concise PASS summary and remove any manifest self-hash to avoid an unsatisfiable checksum;
- document the supported workflow in the formal guide and repository submission skill, with regression tests for success and no-write-on-failure behavior.

## Motivation

Recent ready-for-review packages have exposed a mismatch between hand-edited `validation_claim.self_checked` values and their declared check state. Existing ready packages remain compatible: this PR does not retroactively fail `false` claims. It provides the auditable, repeatable write path for future submissions and strict v2 readiness workflows.

## Validation

- `python3 -m py_compile scripts/self_check_submission.py`
- `python3 -m unittest tests.test_agent_scaffold_and_self_check` — 20 passed
- `python3 -m unittest discover -s tests` — 271 passed
- `git diff --check`
