### PR TITLE
ci: run Python tests on code pull requests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,36 @@
+name: python-tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "**/*.py"
+      - "tests/**"
+      - "requirements-review.txt"
+      - ".github/workflows/**"
+
+# This workflow intentionally runs untrusted PR code with no write token and
+# no repository secrets. PR metadata writes remain in submission-validation,
+# which checks out only the trusted default branch.
+permissions:
+  contents: read
+
+jobs:
+  python-tests:
+    name: python-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install review dependencies
+        run: python -m pip install --disable-pip-version-check -r requirements-review.txt
+
+      - name: Run unit tests
+        run: python -m unittest discover -s tests

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install Unicode CJK fonts
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes fonts-noto-cjk
+
       - name: Install review dependencies
         run: python -m pip install --disable-pip-version-check -r requirements-review.txt
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -37,5 +37,8 @@ jobs:
       - name: Install review dependencies
         run: python -m pip install --disable-pip-version-check -r requirements-review.txt
 
+      - name: Refresh generated gallery data for tests
+        run: python scripts/generate_submissions_data.py
+
       - name: Run unit tests
         run: python -m unittest discover -s tests

--- a/scripts/backfill_bilingual_artifacts.py
+++ b/scripts/backfill_bilingual_artifacts.py
@@ -16,7 +16,7 @@ import json
 import re
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 from backfill_bilingual_submissions import (
     CJK_RE,
@@ -33,10 +33,18 @@ from validate_submission import localized_path
 
 ROOT = Path(__file__).resolve().parents[1]
 OCR_CACHE = Path("/tmp/haidian-bilingual-backfill/ocr-translation-v3.jsonl")
-FONT_PATHS = [
+FONT_PATHS = (
     Path("/Library/Fonts/Arial Unicode.ttf"),
     Path("/System/Library/Fonts/Supplemental/Arial Unicode.ttf"),
-]
+    # Installed by the Linux test workflow.  This open font keeps maintainer
+    # backfill output portable instead of making macOS-only Arial a requirement.
+    Path("/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc"),
+)
+
+
+def find_bilingual_font(paths: Iterable[Path] = FONT_PATHS) -> Path | None:
+    """Return the first available CJK-capable font from supported platforms."""
+    return next((path for path in paths if path.is_file()), None)
 
 
 def sha256(path: Path) -> str:
@@ -236,9 +244,9 @@ def create_localized_figure(
     source = Image.open(source_path).convert("RGB")
     width = source.width
     padding = max(24, width // 30)
-    font_path = next((path for path in FONT_PATHS if path.exists()), None)
+    font_path = find_bilingual_font()
     if font_path is None:
-        raise RuntimeError("Arial Unicode font is required for bilingual figure panels")
+        raise RuntimeError("a Unicode CJK font is required for bilingual figure panels")
     body_size = max(15, min(28, width // 65))
     title_size = int(body_size * 1.35)
     body_font = ImageFont.truetype(str(font_path), body_size)
@@ -400,9 +408,9 @@ def backfill_pdfs(dirs: list[Path]) -> int:
     except ImportError as exc:
         raise SystemExit("Run this mode with the bundled workspace Python containing reportlab") from exc
 
-    font_path = next((path for path in FONT_PATHS if path.exists()), None)
+    font_path = find_bilingual_font()
     if font_path is None:
-        raise RuntimeError("Arial Unicode font is required for bilingual PDFs")
+        raise RuntimeError("a Unicode CJK font is required for bilingual PDFs")
     pdfmetrics.registerFont(TTFont("BilingualSans", str(font_path)))
     styles = getSampleStyleSheet()
     styles.add(ParagraphStyle(name="BiTitle", fontName="BilingualSans", fontSize=24, leading=31, spaceAfter=12))

--- a/tests/test_bilingual_backfill.py
+++ b/tests/test_bilingual_backfill.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(ROOT / "scripts"))
 from backfill_bilingual_artifacts import (  # noqa: E402
     backfill_manifests,
     create_localized_figure,
+    find_bilingual_font,
     localize_translation_image_paths,
 )
 from backfill_bilingual_submissions import (  # noqa: E402
@@ -26,6 +27,16 @@ from backfill_bilingual_submissions import (  # noqa: E402
 
 
 class BilingualBackfillTests(unittest.TestCase):
+    def test_bilingual_font_search_uses_first_available_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fallback = root / "NotoSansCJK-Regular.ttc"
+            fallback.touch()
+            self.assertEqual(
+                fallback,
+                find_bilingual_font([root / "missing.ttf", fallback]),
+            )
+
     def test_front_matter_parser_accepts_utf8_bom(self) -> None:
         front, body = parse_front_matter("\ufeff---\nlanguage: zh\n---\n正文\n")
         self.assertEqual(["language: zh"], front)


### PR DESCRIPTION
## What changed

Adds a dedicated `python-tests` workflow for pull requests that change Python code, tests, review dependencies, or Actions workflows.

## Why

The existing `submission-validation` workflow intentionally checks out trusted `main` and validates PR metadata. It does not execute PR Python code, so code changes can receive that structural green check without remote unit-test evidence.

## Security boundary

The new workflow uses the `pull_request` event, explicitly grants only `contents: read`, and has no secret-dependent steps. It therefore executes fork PR code without the write-capable `pull_request_target` context used for trusted metadata handling.

## Verification

- `python3 -m unittest discover -s tests` — 269 passed
- Workflow YAML parsed successfully
- `git diff --check` passed

The first remote run will provide the GitHub Actions environment verification.
