### PR TITLE
fix: verify manifest hashes against Git blobs

### DIFF
--- a/scripts/participant_preflight.py
+++ b/scripts/participant_preflight.py
@@ -4,10 +4,12 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -31,6 +33,97 @@ def run(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
         env=environment,
         check=False,
     )
+
+
+def git_blob_manifest_hashes(repo_root: Path, submission_rel: str) -> dict[str, Any]:
+    """Compare manifest digests with the bytes Git would actually commit.
+
+    Git can normalize CRLF or apply another clean filter during ``git add``.
+    A workspace-only self-check therefore cannot prove that a manifest digest
+    will still match after a contributor pushes. Use an isolated temporary
+    index so this preflight observes Git's real clean-filter output without
+    changing the contributor's index or worktree.
+    """
+    manifest_path = repo_root / submission_rel / "manifest.json"
+    if not manifest_path.is_file():
+        return {"ok": True, "checked_paths": [], "mismatches": [], "error": None}
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return {"ok": False, "checked_paths": [], "mismatches": [], "error": str(exc)}
+
+    entries = [
+        (str(item["path"]), str(item["sha256"]))
+        for item in manifest.get("files", [])
+        if isinstance(item, dict)
+        and isinstance(item.get("path"), str)
+        and isinstance(item.get("sha256"), str)
+    ]
+    if not entries:
+        return {"ok": True, "checked_paths": [], "mismatches": [], "error": None}
+
+    environment = os.environ.copy()
+    environment["PYTHONUTF8"] = "1"
+    environment["PYTHONIOENCODING"] = "utf-8"
+    with tempfile.TemporaryDirectory(prefix="haidian-preflight-index-") as directory:
+        environment["GIT_INDEX_FILE"] = str(Path(directory) / "index")
+
+        for command in (
+            ["git", "read-tree", "HEAD"],
+            ["git", "add", "--all", "--", submission_rel],
+        ):
+            completed = subprocess.run(
+                command,
+                cwd=repo_root,
+                capture_output=True,
+                env=environment,
+                check=False,
+            )
+            if completed.returncode:
+                detail = completed.stderr.decode("utf-8", "replace").strip()
+                return {
+                    "ok": False,
+                    "checked_paths": [],
+                    "mismatches": [],
+                    "error": f"{' '.join(command)} failed: {detail}",
+                }
+
+        mismatches: list[dict[str, str]] = []
+        checked_paths: list[str] = []
+        for relative_path, declared_sha256 in entries:
+            git_path = f"{submission_rel}/{relative_path}"
+            completed = subprocess.run(
+                ["git", "show", f":{git_path}"],
+                cwd=repo_root,
+                capture_output=True,
+                env=environment,
+                check=False,
+            )
+            if completed.returncode:
+                detail = completed.stderr.decode("utf-8", "replace").strip()
+                return {
+                    "ok": False,
+                    "checked_paths": checked_paths,
+                    "mismatches": mismatches,
+                    "error": f"cannot read staged Git blob for `{relative_path}`: {detail}",
+                }
+            checked_paths.append(relative_path)
+            actual_sha256 = hashlib.sha256(completed.stdout).hexdigest()
+            if declared_sha256 != actual_sha256:
+                mismatches.append(
+                    {
+                        "path": relative_path,
+                        "declared_sha256": declared_sha256,
+                        "git_blob_sha256": actual_sha256,
+                    }
+                )
+
+    return {
+        "ok": not mismatches,
+        "checked_paths": checked_paths,
+        "mismatches": mismatches,
+        "error": None,
+    }
 
 
 def git_output(repo_root: Path, *args: str, allow_failure: bool = False) -> str:
@@ -204,6 +297,22 @@ def inspect(args: argparse.Namespace) -> dict[str, Any]:
         if not self_check["ok"]:
             blockers.append("submission self-check failed; repair the reported issues before pushing")
 
+    manifest_git_blob_check: dict[str, Any] | None = None
+    if submission_dir.is_dir():
+        manifest_git_blob_check = git_blob_manifest_hashes(repo_root, submission_rel)
+        if manifest_git_blob_check.get("error"):
+            blockers.append(
+                "cannot verify manifest hashes against bytes Git will commit: "
+                + str(manifest_git_blob_check["error"])
+            )
+        elif manifest_git_blob_check.get("mismatches"):
+            paths = ", ".join(
+                item["path"] for item in manifest_git_blob_check["mismatches"]
+            )
+            blockers.append(
+                "manifest sha256 values do not match bytes Git will commit: " + paths
+            )
+
     push_check: dict[str, Any] | None = None
     if args.check_push and branch and origin_url:
         push_check = check_push(repo_root, branch)
@@ -229,6 +338,7 @@ def inspect(args: argparse.Namespace) -> dict[str, Any]:
         "package_file_count": len(inventory),
         "package_bytes": package_bytes,
         "self_check": self_check,
+        "manifest_git_blob_check": manifest_git_blob_check,
         "push_dry_run": push_check,
         "blockers": blockers,
         "warnings": warnings,

--- a/tests/test_participant_preflight.py
+++ b/tests/test_participant_preflight.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import importlib.util
+import hashlib
+import json
 import os
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -75,6 +78,58 @@ class ParticipantPreflightEncodingTests(unittest.TestCase):
         self.assertEqual("1", kwargs["env"]["PYTHONUTF8"])
         self.assertEqual("utf-8", kwargs["env"]["PYTHONIOENCODING"])
         self.assertEqual(completed.stdout, "海淀规划\n")
+
+
+class ParticipantPreflightGitBlobTests(unittest.TestCase):
+    def git(self, root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_detects_manifest_hash_calculated_before_git_crlf_normalization(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.assertEqual(0, self.git(root, "init", "-b", "main").returncode)
+            self.assertEqual(0, self.git(root, "config", "user.email", "test@example.com").returncode)
+            self.assertEqual(0, self.git(root, "config", "user.name", "Test").returncode)
+            (root / "README.md").write_text("base\n", encoding="utf-8")
+            self.assertEqual(0, self.git(root, "add", "README.md").returncode)
+            self.assertEqual(0, self.git(root, "commit", "-m", "base").returncode)
+            self.assertEqual(0, self.git(root, "config", "core.autocrlf", "true").returncode)
+
+            submission = root / "submissions" / "alice" / "line-endings"
+            submission.mkdir(parents=True)
+            proposal_bytes = b"# Proposal\r\n\r\nCRLF content\r\n"
+            (submission / "proposal.md").write_bytes(proposal_bytes)
+            (submission / "manifest.json").write_text(
+                json.dumps(
+                    {
+                        "files": [
+                            {
+                                "path": "proposal.md",
+                                "sha256": hashlib.sha256(proposal_bytes).hexdigest(),
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            report = participant_preflight.git_blob_manifest_hashes(
+                root, "submissions/alice/line-endings"
+            )
+
+            self.assertFalse(report["ok"])
+            self.assertEqual("", self.git(root, "diff", "--cached", "--name-only").stdout)
+            self.assertEqual(["proposal.md"], [item["path"] for item in report["mismatches"]])
+            self.assertEqual(
+                hashlib.sha256(b"# Proposal\n\nCRLF content\n").hexdigest(),
+                report["mismatches"][0]["git_blob_sha256"],
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Extend participant preflight with a manifest SHA-256 check against the bytes Git will actually commit.
- Build that view in an isolated temporary Git index, so CRLF normalization and clean filters are represented without mutating the contributor's index or worktree.
- Add a regression that reproduces `core.autocrlf=true`: a manifest hashed from CRLF workspace bytes is rejected because Git would commit LF bytes.

## Why

PR #812 demonstrated that workspace-only self-check and preflight can pass while trusted validation later fails on every normalized text asset. This makes the platform-specific failure visible before a contributor pushes.

## Validation

- `python3 -m py_compile scripts/participant_preflight.py`
- `python3 -m unittest tests.test_participant_preflight -v` — 5 passed
- `git diff --check`
