### PR TITLE
fix: hash manifests as Git blobs

### DIFF
--- a/scripts/finalize_submission.py
+++ b/scripts/finalize_submission.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 from pathlib import Path
 
+from git_blob_hashes import git_blob_sha256
 from validate_submission import (
     DISPLAY_BASE_FILES,
     is_empty_pdf,
@@ -39,6 +40,15 @@ READABLE_OUTPUTS = ["proposal.md", "report/proposal.html", "visual/index.html"]
 
 def digest(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def manifest_digests(root: Path, relative_paths: list[str]) -> dict[str, str]:
+    """Hash listed files using Git's pending blobs when available."""
+    files = {relative: root / relative for relative in relative_paths}
+    git_digests = git_blob_sha256(files.values(), cwd=root)
+    if git_digests is None:
+        return {relative: digest(path) for relative, path in files.items()}
+    return {relative: git_digests[path.resolve()] for relative, path in files.items()}
 
 
 def main() -> int:
@@ -166,12 +176,21 @@ def main() -> int:
                 translated_item["language"] = translation_language
                 translated_item["translation_of"] = rel
                 translated_item["required"] = strict_bilingual
+    hash_paths = [
+        str(item["path"])
+        for item in manifest_files
+        if isinstance(item, dict)
+        and item.get("path")
+        and item.get("path") != "manifest.json"
+        and (root / str(item["path"])).is_file()
+    ]
+    hashes = manifest_digests(root, hash_paths)
     for item in manifest_files:
         if not isinstance(item, dict):
             continue
         rel = item.get("path")
-        if rel and rel != "manifest.json" and (root / rel).is_file():
-            item["sha256"] = digest(root / rel)
+        if rel and rel != "manifest.json" and str(rel) in hashes:
+            item["sha256"] = hashes[str(rel)]
     manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     print(f"Review-ready package: {root}")
     print("Run self_check_submission.py now. Any later file edit requires refreshed manifest hashes and another full validation.")

--- a/scripts/git_blob_hashes.py
+++ b/scripts/git_blob_hashes.py
@@ -1,0 +1,75 @@
+"""Hash files as Git will store them after clean filters run."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Iterable
+
+
+def git_blob_sha256(paths: Iterable[Path], *, cwd: Path) -> dict[Path, str] | None:
+    """Return SHA-256 digests of staged Git blobs without touching the real index.
+
+    A contributor may have CRLF files in the worktree while Git stores their LF
+    form. Manifests are checked against repository bytes in trusted CI, so use
+    a temporary index to mirror the pending ``git add`` result. ``None`` means
+    that no usable Git repository/HEAD is available; callers can then retain
+    their file-byte fallback for standalone package work.
+    """
+    unique_paths = list(dict.fromkeys(Path(path).resolve() for path in paths))
+    if not unique_paths:
+        return {}
+
+    completed = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode:
+        return None
+    repo_root = Path(completed.stdout.strip()).resolve()
+
+    relative_paths: dict[Path, str] = {}
+    for path in unique_paths:
+        if not path.is_file():
+            return None
+        try:
+            relative_paths[path] = path.relative_to(repo_root).as_posix()
+        except ValueError:
+            return None
+
+    environment = os.environ.copy()
+    with tempfile.TemporaryDirectory(prefix="haidian-manifest-index-") as directory:
+        environment["GIT_INDEX_FILE"] = str(Path(directory) / "index")
+        for command in (
+            ["git", "read-tree", "HEAD"],
+            ["git", "add", "--all", "--", *relative_paths.values()],
+        ):
+            staged = subprocess.run(
+                command,
+                cwd=repo_root,
+                capture_output=True,
+                env=environment,
+                check=False,
+            )
+            if staged.returncode:
+                return None
+
+        digests: dict[Path, str] = {}
+        for path, relative_path in relative_paths.items():
+            blob = subprocess.run(
+                ["git", "show", f":{relative_path}"],
+                cwd=repo_root,
+                capture_output=True,
+                env=environment,
+                check=False,
+            )
+            if blob.returncode:
+                return None
+            digests[path] = hashlib.sha256(blob.stdout).hexdigest()
+    return digests

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Iterable
 
+from git_blob_hashes import git_blob_sha256
+
 
 POLICY_ROOT = Path(__file__).resolve().parents[1]
 
@@ -1018,6 +1020,22 @@ def validate_manifest_file(report: ValidationReport, repo_root: Path, proposal_d
     strict_bilingual = requires_bilingual_display(repo_root, proposal_dir)
     files = data.get("files")
     listed_paths: set[str] = set()
+    git_digests: dict[Path, str] | None = None
+    if isinstance(files, list):
+        manifest_files: list[Path] = []
+        for item in files:
+            if not isinstance(item, dict) or not item.get("path"):
+                continue
+            try:
+                safe_path = normalize_changed_path(str(item["path"]))
+            except ValueError:
+                continue
+            if safe_path == "manifest.json":
+                continue
+            listed_file = repo_root / proposal_dir / safe_path
+            if listed_file.is_file():
+                manifest_files.append(listed_file)
+        git_digests = git_blob_sha256(manifest_files, cwd=repo_root)
     if not isinstance(files, list) or not files:
         report.add_error(f"{proposal_dir}/manifest.json: files must be a non-empty array")
     else:
@@ -1058,7 +1076,11 @@ def validate_manifest_file(report: ValidationReport, repo_root: Path, proposal_d
                 else:
                     report.add_warning(message + " (legacy package compatibility)")
             elif declared_digest:
-                actual_digest = hashlib.sha256(listed_file.read_bytes()).hexdigest()
+                actual_digest = (
+                    git_digests.get(listed_file.resolve())
+                    if git_digests is not None
+                    else hashlib.sha256(listed_file.read_bytes()).hexdigest()
+                )
                 if declared_digest != actual_digest:
                     message = f"{proposal_dir}/manifest.json: sha256 mismatch for `{safe_path}`"
                     if translation_entry and not strict_bilingual:

--- a/tests/test_git_blob_hashes.py
+++ b/tests/test_git_blob_hashes.py
@@ -1,0 +1,87 @@
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from git_blob_hashes import git_blob_sha256  # noqa: E402
+from finalize_submission import manifest_digests  # noqa: E402
+from validate_submission import ValidationReport, validate_manifest_file  # noqa: E402
+
+
+class GitBlobHashTests(unittest.TestCase):
+    def git(self, root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args], cwd=root, capture_output=True, text=True, check=False
+        )
+
+    def make_autocrlf_package(self, root: Path) -> tuple[Path, Path, str]:
+        self.assertEqual(0, self.git(root, "init").returncode)
+        self.assertEqual(0, self.git(root, "config", "user.email", "test@example.com").returncode)
+        self.assertEqual(0, self.git(root, "config", "user.name", "Test User").returncode)
+        self.assertEqual(0, self.git(root, "config", "core.autocrlf", "true").returncode)
+        (root / ".gitattributes").write_text("*.md text\n", encoding="utf-8")
+        package = root / "submissions" / "alice" / "git-hashes"
+        package.mkdir(parents=True)
+        proposal = package / "proposal.md"
+        proposal.write_text("initial\n", encoding="utf-8")
+        self.assertEqual(0, self.git(root, "add", ".").returncode)
+        self.assertEqual(0, self.git(root, "commit", "-m", "initial package").returncode)
+
+        proposal.write_bytes(b"updated proposal\r\n")
+        expected = hashlib.sha256(b"updated proposal\n").hexdigest()
+        return package, proposal, expected
+
+    def test_hashes_pending_git_clean_blobs_without_mutating_real_index(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package, proposal, expected = self.make_autocrlf_package(root)
+
+            hashes = git_blob_sha256([proposal], cwd=package)
+
+            self.assertIsNotNone(hashes)
+            self.assertEqual(expected, hashes[proposal.resolve()])
+            self.assertNotEqual(expected, hashlib.sha256(proposal.read_bytes()).hexdigest())
+            self.assertEqual(0, self.git(root, "diff", "--cached", "--quiet").returncode)
+
+    def test_manifest_validation_uses_the_same_git_blob_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package, _proposal, expected = self.make_autocrlf_package(root)
+            (package / "manifest.json").write_text(
+                json.dumps(
+                    {
+                        "submission_stage": "formal",
+                        "package_type": "professional_design_package",
+                        "package_state": "ready_for_review",
+                        "submission_type": "ai_agent",
+                        "project_id": "centennial-jingzhang-ai-belt",
+                        "files": [{"path": "proposal.md", "sha256": expected}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            report = ValidationReport()
+            validate_manifest_file(report, root, "submissions/alice/git-hashes")
+
+            self.assertFalse(any("sha256 mismatch for `proposal.md`" in item for item in report.errors))
+
+    def test_finalizer_hashes_the_pending_git_blob(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package, _proposal, expected = self.make_autocrlf_package(root)
+
+            hashes = manifest_digests(package, ["proposal.md"])
+
+            self.assertEqual(expected, hashes["proposal.md"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Hash manifest entries from the bytes Git will actually commit, using an isolated temporary index so the contributor's real index is untouched.
- Use the same Git-blob view during local manifest validation; standalone directories without Git retain the existing file-byte behavior.
- Add regression coverage for `core.autocrlf=true`, including finalizer, validator, and index non-mutation.

## Root cause

Several participant packages generated manifest digests from CRLF working-copy bytes, while Git committed LF blobs. Local checks could pass but trusted validation then rejected many artifacts. This makes local finalization and validation use the same bytes that trusted CI receives.

## Validation

- `python3 -m unittest tests.test_submission_workflow -v` — 89 passed
- `python3 -m unittest tests.test_agent_scaffold_and_self_check tests.test_git_blob_hashes -v` — 21 passed
- `python3 -m py_compile scripts/git_blob_hashes.py scripts/finalize_submission.py scripts/validate_submission.py`
- `git diff --check`
