### PR TITLE
fix: guard participant pull request scope

### DIFF
--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -40,6 +40,18 @@ RETRYABLE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 # retries bounded and limited to GETs; a permanent missing file still fails
 # with the path and head-specific download error after the retry budget.
 RETRYABLE_STATUS_CODES = frozenset({404, 429, 500, 502, 503, 504})
+# These root-level paths are package entry points in the participant contract.
+# A non-maintainer PR that creates them outside submissions/<author>/ is a
+# misplaced submission, not an ordinary code/docs/test PR.
+ROOT_SUBMISSION_ENTRY_PATHS = frozenset(
+    {
+        "manifest.json",
+        "agent.json",
+        "proposal.md",
+        "proposal.en.md",
+        "self_check.json",
+    }
+)
 
 
 def _http_error_message(error: urllib.error.HTTPError) -> str:
@@ -283,6 +295,20 @@ def validation_paths_for(files: list[dict], maintainer_bypass: bool) -> list[str
     ]
 
 
+def _pull_request_paths(files: list[dict] | list[str]) -> list[str]:
+    """Return current and previous GitHub PR paths in one normalized list."""
+    paths: list[str] = []
+    for item in files:
+        if isinstance(item, dict):
+            for key in ("filename", "previous_filename"):
+                value = item.get(key)
+                if isinstance(value, str):
+                    paths.append(value)
+        elif isinstance(item, str):
+            paths.append(item)
+    return paths
+
+
 def is_review_queue_candidate(changed_files: list[str], pr_author: str) -> bool:
     """Return true only for a single participant-owned submission directory."""
     roots: set[str] = set()
@@ -304,16 +330,17 @@ def participant_scope_violations(
     participant must not use that exclusion to delete repository-owned files.
     """
     prefix = f"submissions/{pr_author.strip()}/".casefold()
-    paths: set[str] = set()
-    for item in files:
-        if isinstance(item, dict):
-            for key in ("filename", "previous_filename"):
-                value = item.get(key)
-                if isinstance(value, str) and value.strip():
-                    paths.add(value.strip())
-        elif isinstance(item, str) and item.strip():
-            paths.add(item.strip())
+    paths = {path.strip() for path in _pull_request_paths(files) if path.strip()}
     return sorted(path for path in paths if not path.casefold().startswith(prefix))
+
+
+def is_root_submission_pr(files: list[dict] | list[str]) -> bool:
+    """Return true when a PR contains a root-level participant package entry."""
+    return any(
+        path.strip().casefold() in ROOT_SUBMISSION_ENTRY_PATHS
+        for path in _pull_request_paths(files)
+        if path.strip()
+    )
 
 
 def is_non_submission_pr(files: list[dict] | list[str]) -> bool:
@@ -444,12 +471,13 @@ def main() -> int:
     validation_files = validation_paths_for(files, maintainer_bypass)
     queue_candidate = is_review_queue_candidate(changed_files, pr_author)
     scope_violations = participant_scope_violations(files, pr_author)
+    root_submission_pr = is_root_submission_pr(files)
 
     # Code/docs/test PRs do not need participant-package hydration.  Decide
     # this immediately after the file listing so a non-submission change
     # cannot spend API calls downloading its whole diff before receiving the
     # informational validation comment.
-    if is_non_submission_pr(files):
+    if is_non_submission_pr(files) and (not root_submission_pr or maintainer_bypass):
         validation = ValidationReport(changed_files=changed_files)
         validation.add_warning(
             "non-submission code/docs/test PR; participant package validation was not applicable"
@@ -491,7 +519,17 @@ def main() -> int:
                 proposal_path,
             )
 
-        if not validation_files and (maintainer_bypass or queue_candidate):
+        if root_submission_pr and not maintainer_bypass:
+            validation = ValidationReport(changed_files=changed_files)
+            validation.add_error(
+                "participant submission artifacts must be under submissions/"
+                f"{pr_author}/; root-level package entry files are not accepted"
+            )
+            for path in scope_violations:
+                validation.add_error(
+                    f"{path}: participant PRs may only change submissions/{pr_author}/"
+                )
+        elif not validation_files and (maintainer_bypass or queue_candidate):
             validation = ValidationReport(
                 changed_files=changed_files,
                 maintainer_bypass=maintainer_bypass,

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -173,6 +173,34 @@ class GitHubClient:
             url = next_link(headers.get("Link", ""))
         return results
 
+    def tree_blob_map(self, sha: str) -> dict[str, str]:
+        """Return the recursive blob map for a trusted base or head commit."""
+        encoded_sha = urllib.parse.quote(sha, safe="")
+        data, _ = self.request(
+            "GET",
+            f"/repos/{self.repository}/git/trees/{encoded_sha}?recursive=1",
+        )
+        if not isinstance(data, dict) or data.get("truncated"):
+            raise RuntimeError(
+                f"GitHub tree response for `{sha}` was missing or truncated"
+            )
+        entries = data.get("tree")
+        if not isinstance(entries, list):
+            raise RuntimeError(f"GitHub tree response for `{sha}` was malformed")
+        blobs: dict[str, str] = {}
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            path = entry.get("path")
+            blob_sha = entry.get("sha")
+            if (
+                entry.get("type") == "blob"
+                and isinstance(path, str)
+                and isinstance(blob_sha, str)
+            ):
+                blobs[path] = blob_sha
+        return blobs
+
     def download_content(
         self,
         repo: str,
@@ -347,6 +375,29 @@ def participant_scope_violations(
     return sorted(path for path in paths if not path.casefold().startswith(prefix))
 
 
+def participant_tree_scope_violations(
+    base_tree: dict[str, str],
+    head_tree: dict[str, str],
+    pr_author: str,
+    maintainer_bypass: bool,
+) -> list[str]:
+    """Return changed tree paths outside a participant package.
+
+    This catches deletions hidden by a pull request's merge-base calculation,
+    including a branch based on the first parent of a merge commit.
+    """
+    if maintainer_bypass:
+        return []
+
+    prefix = f"submissions/{pr_author.strip()}/".casefold()
+    changed_paths = {
+        path
+        for path in base_tree.keys() | head_tree.keys()
+        if base_tree.get(path) != head_tree.get(path)
+    }
+    return sorted(path for path in changed_paths if not path.casefold().startswith(prefix))
+
+
 def is_root_submission_pr(files: list[dict] | list[str]) -> bool:
     """Return true for root files or a nested package-shaped root directory.
 
@@ -499,6 +550,65 @@ def main() -> int:
     queue_candidate = is_review_queue_candidate(changed_files, pr_author)
     scope_violations = participant_scope_violations(files, pr_author)
     root_submission_pr = is_root_submission_pr(files)
+    scope_verification_error = None
+    base_sha = pull_request.get("base", {}).get("sha")
+    tree_scope_check = (
+        not maintainer_bypass
+        and isinstance(base_sha, str)
+        and bool(base_sha)
+        and (not is_non_submission_pr(files) or root_submission_pr)
+    )
+    if tree_scope_check:
+        try:
+            base_tree = client.tree_blob_map(base_sha)
+            head_tree = client.tree_blob_map(head_sha)
+            scope_violations.extend(
+                participant_tree_scope_violations(
+                    base_tree,
+                    head_tree,
+                    pr_author,
+                    maintainer_bypass,
+                )
+            )
+            scope_violations = sorted(set(scope_violations))
+        except RuntimeError as exc:
+            scope_verification_error = str(exc)
+
+    if tree_scope_check and (scope_verification_error or scope_violations):
+        validation = ValidationReport(
+            changed_files=changed_files,
+            maintainer_bypass=maintainer_bypass,
+        )
+        if root_submission_pr:
+            validation.add_error(
+                "participant submission artifacts must be under submissions/"
+                f"{pr_author}/; root-level package entry files are not accepted"
+            )
+        if scope_verification_error:
+            validation.add_error(
+                "submission path ownership could not be verified: "
+                f"{scope_verification_error}"
+            )
+        for path in scope_violations:
+            validation.add_error(
+                f"{path}: participant PRs may only change submissions/{pr_author}/"
+            )
+        validation_markdown = format_report(validation)
+        if not is_current_pull_request_head(client, pr_number, head_sha):
+            print(
+                f"Skipping stale validation side effects for PR #{pr_number}: "
+                f"the PR head changed before the submission-scope failure was reported."
+            )
+            return 0
+        comment = (
+            f"{COMMENT_MARKER}\n"
+            "# Haidian Submission Validation\n\n"
+            f"{validation_markdown}\n\n"
+            "> This CI check is deterministic. It does not call AI models and does not make content-quality judgments."
+        )
+        write_step_summary(comment)
+        client.upsert_comment(pr_number, comment)
+        return 1
 
     # Code/docs/test PRs do not need participant-package hydration.  Decide
     # this immediately after the file listing so a non-submission change

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -52,6 +52,19 @@ ROOT_SUBMISSION_ENTRY_PATHS = frozenset(
         "self_check.json",
     }
 )
+ROOT_NON_SUBMISSION_DIRS = frozenset(
+    {
+        ".github",
+        "brief",
+        "collections",
+        "data",
+        "docs",
+        "examples",
+        "scripts",
+        "skills",
+        "tests",
+    }
+)
 
 
 def _http_error_message(error: urllib.error.HTTPError) -> str:
@@ -335,12 +348,26 @@ def participant_scope_violations(
 
 
 def is_root_submission_pr(files: list[dict] | list[str]) -> bool:
-    """Return true when a PR contains a root-level participant package entry."""
-    return any(
-        path.strip().casefold() in ROOT_SUBMISSION_ENTRY_PATHS
-        for path in _pull_request_paths(files)
-        if path.strip()
-    )
+    """Return true for root files or a nested package-shaped root directory.
+
+    A package placed at ``jingzhang-zhiji-submission/manifest.json`` is just as
+    misplaced as a root ``manifest.json``.  Without this grouped check, a PR
+    containing only non-``submissions/`` paths is classified as ordinary code
+    and skips the participant package validator entirely.
+    """
+    nested_entries: dict[str, set[str]] = {}
+    for raw_path in _pull_request_paths(files):
+        path = raw_path.strip().casefold()
+        if not path:
+            continue
+        if path in ROOT_SUBMISSION_ENTRY_PATHS:
+            return True
+        parts = PurePosixPath(path).parts
+        if len(parts) < 2 or parts[0] in ROOT_NON_SUBMISSION_DIRS or parts[0] == "submissions":
+            continue
+        if parts[-1] in ROOT_SUBMISSION_ENTRY_PATHS:
+            nested_entries.setdefault(parts[0], set()).add(parts[-1])
+    return any(len(entries) >= 2 for entries in nested_entries.values())
 
 
 def is_non_submission_pr(files: list[dict] | list[str]) -> bool:

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -294,6 +294,28 @@ def is_review_queue_candidate(changed_files: list[str], pr_author: str) -> bool:
     return bool(changed_files) and len(roots) == 1
 
 
+def participant_scope_violations(
+    files: list[dict] | list[str], pr_author: str
+) -> list[str]:
+    """Return every current or previous path outside a participant package.
+
+    Removed files are intentionally included here.  They are excluded from
+    content validation because they are absent from the PR checkout, but a
+    participant must not use that exclusion to delete repository-owned files.
+    """
+    prefix = f"submissions/{pr_author.strip()}/".casefold()
+    paths: set[str] = set()
+    for item in files:
+        if isinstance(item, dict):
+            for key in ("filename", "previous_filename"):
+                value = item.get(key)
+                if isinstance(value, str) and value.strip():
+                    paths.add(value.strip())
+        elif isinstance(item, str) and item.strip():
+            paths.add(item.strip())
+    return sorted(path for path in paths if not path.casefold().startswith(prefix))
+
+
 def is_non_submission_pr(files: list[dict] | list[str]) -> bool:
     """Return true only for ordinary non-submission paths.
 
@@ -421,6 +443,7 @@ def main() -> int:
     maintainer_bypass = pr_author.lower() in {item.lower() for item in bypass}
     validation_files = validation_paths_for(files, maintainer_bypass)
     queue_candidate = is_review_queue_candidate(changed_files, pr_author)
+    scope_violations = participant_scope_violations(files, pr_author)
 
     # Code/docs/test PRs do not need participant-package hydration.  Decide
     # this immediately after the file listing so a non-submission change
@@ -483,6 +506,16 @@ def main() -> int:
                 )
         else:
             validation = validate_submission(worktree, pr_author, validation_files, bypass)
+            if not maintainer_bypass:
+                for path in scope_violations:
+                    validation.add_error(
+                        f"{path}: participant PRs may only change submissions/{pr_author}/"
+                    )
+            # Content validation receives only files present in the PR
+            # checkout.  The published report must still describe the full PR
+            # diff, including deletions, so scope defects cannot disappear
+            # from the CI summary.
+            validation.changed_files = changed_files
         validation_markdown = format_report(validation)
 
         if not is_current_pull_request_head(client, pr_number, head_sha):

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -575,6 +575,21 @@ class ManifestHydrationTests(unittest.TestCase):
         self.assertTrue(is_root_submission_pr(files))
         self.assertTrue(is_non_submission_pr(files))
 
+    def test_nested_root_submission_package_is_not_classified_as_code_pr(self) -> None:
+        files = [
+            "jingzhang-zhiji-submission/agent.json",
+            "jingzhang-zhiji-submission/manifest.json",
+            "jingzhang-zhiji-submission/proposal.md",
+            "jingzhang-zhiji-submission/self_check.json",
+        ]
+        self.assertTrue(is_root_submission_pr(files))
+        self.assertTrue(is_non_submission_pr(files))
+
+    def test_documentation_package_entries_do_not_trigger_root_submission_guard(self) -> None:
+        files = ["docs/manifest.json", "docs/proposal.md"]
+        self.assertFalse(is_root_submission_pr(files))
+        self.assertTrue(is_non_submission_pr(files))
+
     def test_root_level_submission_package_fails_scope_guard(self) -> None:
         event = {
             "pull_request": {

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -550,6 +550,8 @@ class ManifestHydrationTests(unittest.TestCase):
             json.dump(event, event_file)
             event_file.flush()
             client = MagicMock()
+            client.repository = "open-city-ai/haidian"
+            client.request.return_value = ({"head": {"sha": "head-sha"}}, {})
             client.paginate.return_value = files
             report = ValidationReport(
                 changed_files=["submissions/alice/design/proposal.md"]
@@ -608,6 +610,8 @@ class ManifestHydrationTests(unittest.TestCase):
             json.dump(event, event_file)
             event_file.flush()
             client = MagicMock()
+            client.repository = "open-city-ai/haidian"
+            client.request.return_value = ({"head": {"sha": "head-sha"}}, {})
             client.paginate.return_value = files
             with patch.dict(
                 os.environ,

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -38,6 +38,7 @@ from github_pr_validation import (  # noqa: E402
     is_root_submission_pr,
     is_review_queue_candidate,
     participant_scope_violations,
+    participant_tree_scope_violations,
     main,
     safe_manifest_paths,
     validation_paths_for,
@@ -124,6 +125,47 @@ class GitHubApiResilienceTests(unittest.TestCase):
                 client.request("POST", "/test", {"body": "comment"})
         self.assertEqual(1, urlopen.call_count)
         sleep.assert_not_called()
+
+    def test_tree_blob_map_extracts_blobs_and_rejects_truncation(self) -> None:
+        client = GitHubClient("token", "open-city-ai/haidian")
+        with patch.object(
+            client,
+            "request",
+            return_value=(
+                {
+                    "truncated": False,
+                    "tree": [
+                        {
+                            "path": "submissions/alice/proposal.md",
+                            "type": "blob",
+                            "sha": "blob-sha",
+                        },
+                        {
+                            "path": "submissions/alice",
+                            "type": "tree",
+                            "sha": "tree-sha",
+                        },
+                    ],
+                },
+                {},
+            ),
+        ) as request:
+            self.assertEqual(
+                {"submissions/alice/proposal.md": "blob-sha"},
+                client.tree_blob_map("head-sha"),
+            )
+        request.assert_called_once_with(
+            "GET",
+            "/repos/open-city-ai/haidian/git/trees/head-sha?recursive=1",
+        )
+
+        with patch.object(
+            client,
+            "request",
+            return_value=({"truncated": True, "tree": []}, {}),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "missing or truncated"):
+                client.tree_blob_map("large-sha")
 
     def test_download_404_retries_then_succeeds(self) -> None:
         client = GitHubClient("token", "open-city-ai/haidian")
@@ -533,6 +575,69 @@ class ManifestHydrationTests(unittest.TestCase):
             ["README.md", "docs/notes.md"],
             participant_scope_violations(files, "alice"),
         )
+
+    def test_participant_tree_scope_catches_hidden_cross_author_deletion(self) -> None:
+        base_tree = {
+            "submissions/bob/old-design/proposal.md": "old-blob",
+            "submissions/alice/old-design/manifest.json": "unchanged-blob",
+        }
+        head_tree = {
+            "submissions/alice/new-design/proposal.md": "new-blob",
+            "submissions/alice/old-design/manifest.json": "unchanged-blob",
+        }
+        self.assertEqual(
+            ["submissions/bob/old-design/proposal.md"],
+            participant_tree_scope_violations(base_tree, head_tree, "alice", False),
+        )
+        self.assertEqual(
+            [],
+            participant_tree_scope_violations(base_tree, head_tree, "alice", True),
+        )
+
+    def test_tree_guard_catches_deletion_hidden_by_pr_file_listing(self) -> None:
+        event = {
+            "pull_request": {
+                "number": 909,
+                "user": {"login": "alice"},
+                "base": {"sha": "base-sha"},
+                "head": {"repo": {"full_name": "alice/haidian"}, "sha": "head-sha"},
+            }
+        }
+        files = [
+            {"filename": "submissions/alice/new-design/proposal.md", "status": "added"},
+        ]
+        base_tree = {
+            "submissions/bob/old-design/proposal.md": "old-blob",
+        }
+        head_tree = {
+            "submissions/alice/new-design/proposal.md": "new-blob",
+        }
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
+            json.dump(event, event_file)
+            event_file.flush()
+            client = MagicMock()
+            client.repository = "open-city-ai/haidian"
+            client.request.side_effect = [
+                ({"head": {"sha": "head-sha"}}, {}),
+                ({"head": {"sha": "head-sha"}}, {}),
+                ({"head": {"sha": "head-sha"}}, {}),
+            ]
+            client.tree_blob_map.side_effect = [base_tree, head_tree]
+            client.paginate.return_value = files
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "token",
+                    "GITHUB_REPOSITORY": "open-city-ai/haidian",
+                    "GITHUB_EVENT_PATH": event_file.name,
+                },
+                clear=False,
+            ), patch("github_pr_validation.GitHubClient", return_value=client):
+                self.assertEqual(1, main())
+        client.download_content.assert_not_called()
+        client.fetch_content.assert_not_called()
+        comment = client.upsert_comment.call_args.args[1]
+        self.assertIn("submissions/bob/old-design/proposal.md", comment)
 
     def test_mixed_participant_scope_fails_even_when_root_file_is_removed(self) -> None:
         event = {

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -36,6 +36,7 @@ from github_pr_validation import (  # noqa: E402
     is_current_pull_request_head,
     is_non_submission_pr,
     is_review_queue_candidate,
+    participant_scope_violations,
     main,
     safe_manifest_paths,
     validation_paths_for,
@@ -516,6 +517,57 @@ class ManifestHydrationTests(unittest.TestCase):
                 "alice",
             )
         )
+
+    def test_participant_scope_violations_include_removed_and_renamed_paths(self) -> None:
+        files = [
+            {"filename": "submissions/alice/design/proposal.md", "status": "modified"},
+            {"filename": "README.md", "status": "removed"},
+            {
+                "filename": "submissions/alice/design/notes.md",
+                "previous_filename": "docs/notes.md",
+                "status": "renamed",
+            },
+        ]
+        self.assertEqual(
+            ["README.md", "docs/notes.md"],
+            participant_scope_violations(files, "alice"),
+        )
+
+    def test_mixed_participant_scope_fails_even_when_root_file_is_removed(self) -> None:
+        event = {
+            "pull_request": {
+                "number": 648,
+                "user": {"login": "alice"},
+                "head": {"repo": {"full_name": "alice/haidian"}, "sha": "head-sha"},
+            }
+        }
+        files = [
+            {"filename": "submissions/alice/design/proposal.md", "status": "modified"},
+            {"filename": "README.md", "status": "removed"},
+        ]
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
+            json.dump(event, event_file)
+            event_file.flush()
+            client = MagicMock()
+            client.paginate.return_value = files
+            report = ValidationReport(
+                changed_files=["submissions/alice/design/proposal.md"]
+            )
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "token",
+                    "GITHUB_REPOSITORY": "open-city-ai/haidian",
+                    "GITHUB_EVENT_PATH": event_file.name,
+                },
+                clear=False,
+            ), patch("github_pr_validation.GitHubClient", return_value=client), patch(
+                "github_pr_validation.validate_submission", return_value=report
+            ), patch("github_pr_validation.proposal_paths_for", return_value=set()):
+                self.assertEqual(1, main())
+        comment = client.upsert_comment.call_args.args[1]
+        self.assertIn("Changed files: 2", comment)
+        self.assertIn("README.md: participant PRs may only change submissions/alice/", comment)
 
     def test_non_submission_code_pr_is_not_sent_to_package_validator(self) -> None:
         self.assertTrue(is_non_submission_pr(["scripts/tool.py", "tests/test_tool.py"]))

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -35,6 +35,7 @@ from github_pr_validation import (  # noqa: E402
     _is_retryable_http_error,
     is_current_pull_request_head,
     is_non_submission_pr,
+    is_root_submission_pr,
     is_review_queue_candidate,
     participant_scope_violations,
     main,
@@ -568,6 +569,47 @@ class ManifestHydrationTests(unittest.TestCase):
         comment = client.upsert_comment.call_args.args[1]
         self.assertIn("Changed files: 2", comment)
         self.assertIn("README.md: participant PRs may only change submissions/alice/", comment)
+
+    def test_root_level_submission_package_is_not_classified_as_code_pr(self) -> None:
+        files = ["manifest.json", "agent.json", "proposal.md", "geometry/site_boundary.geojson"]
+        self.assertTrue(is_root_submission_pr(files))
+        self.assertTrue(is_non_submission_pr(files))
+
+    def test_root_level_submission_package_fails_scope_guard(self) -> None:
+        event = {
+            "pull_request": {
+                "number": 649,
+                "user": {"login": "alice"},
+                "head": {"repo": {"full_name": "alice/haidian"}, "sha": "head-sha"},
+            }
+        }
+        files = [
+            {"filename": "manifest.json", "status": "added"},
+            {"filename": "agent.json", "status": "added"},
+            {"filename": "proposal.md", "status": "added"},
+            {"filename": "geometry/site_boundary.geojson", "status": "added"},
+        ]
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
+            json.dump(event, event_file)
+            event_file.flush()
+            client = MagicMock()
+            client.paginate.return_value = files
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "token",
+                    "GITHUB_REPOSITORY": "open-city-ai/haidian",
+                    "GITHUB_EVENT_PATH": event_file.name,
+                },
+                clear=False,
+            ), patch("github_pr_validation.GitHubClient", return_value=client), patch(
+                "github_pr_validation.validate_submission"
+            ) as validate:
+                self.assertEqual(1, main())
+        validate.assert_not_called()
+        comment = client.upsert_comment.call_args.args[1]
+        self.assertIn("root-level package entry files are not accepted", comment)
+        self.assertIn("manifest.json: participant PRs may only change submissions/alice/", comment)
 
     def test_non_submission_code_pr_is_not_sent_to_package_validator(self) -> None:
         self.assertTrue(is_non_submission_pr(["scripts/tool.py", "tests/test_tool.py"]))


### PR DESCRIPTION
## What changed

Add a participant pull-request scope guard to the trusted submission validator.

- inspect both `filename` and `previous_filename` from the complete GitHub PR file list;
- include removed paths in participant scope checks, even though removed files remain excluded from content hydration;
- reject a participant submission PR when any current or previous path falls outside `submissions/<pr-author>/`;
- report the full PR file count, including deletions, instead of only the hydrated package files;
- preserve non-submission code/docs/test PRs and maintainer-authorized deletion-only behavior.

## Root cause

The validator excluded removed files before calling package validation. A mixed PR could therefore add a valid submission package while deleting repository-owned baseline files; the CI comment reported only the surviving package files and the deletion scope was not a blocking error. This was reproduced on PR #822: GitHub PR metadata reported 9,508 changed files and 3,870,235 deletions, while submission validation reported only 30 package files.

## Validation

- `python3 -m unittest tests.test_submission_workflow -v` — 93 passed
- `python3 -m unittest discover -s tests -p 'test_*.py'` — 276 passed
- `python3 -m py_compile scripts/github_pr_validation.py`
- `git diff --check`

The PR is intentionally draft until maintainers review the scope-policy compatibility.
