### PR TITLE
fix: validate proposal metric table values

### DIFF
--- a/scripts/professional_review.py
+++ b/scripts/professional_review.py
@@ -28,8 +28,12 @@ from validate_submission import (
 
 REFERENCE_RE = re.compile(r"\[(source|standard|depth|data|metric):([^\]\s]+)\]")
 TABLE_NUMBER_RE = re.compile(
-    r"(?P<number>[+-]?(?:\d{1,3}(?:,\d{3})+|\d+(?:\.\d+)?))\s*"
-    r"(?P<unit>km²|km2|m²|sqm|ha|公顷|平方公里|平方千米|公里|米|km|m|㎡|%|％|ratio|比例|个|处|项)?",
+    r"^\s*"
+    r"(?P<approx>~|≈|约|about|approximately|approx\.?)?\s*"
+    r"(?P<number>[+-]?(?:\d{1,3}(?:,\d{3})+|\d+(?:\.\d+)?|\.\d+))\s*"
+    r"(?P<unit>square\s+kilometers?|square\s+kilometres?|"
+    r"km²|km2|m²|sqm|ha|公顷|平方公里|平方千米|公里|米|km|m|㎡|%|％|ratio|比例|个|处|项)?"
+    r"\s*[，,。.]?\s*$",
     re.IGNORECASE,
 )
 
@@ -64,12 +68,13 @@ class ProposalMetricClaim:
 
 
 def _parse_table_value(value_cell: str) -> tuple[float, str] | None:
-    """Parse one unambiguous numeric value from a metric table value cell."""
-    # Ranges and compound values are deliberately left to human review rather
-    # than guessed from their first number.
-    if re.search(r"\d\s*(?:-|–|—|至|到)\s*\d", value_cell):
-        return None
-    match = TABLE_NUMBER_RE.search(value_cell)
+    """Parse a whole metric cell, never a number embedded in prose or a formula."""
+    # References are metadata, not a second numeric claim. Everything else
+    # must fit the complete numeric-cell grammar below; ranges, lists,
+    # formulas, and explanatory prose remain human-review territory.
+    normalized = re.sub(r"\s*\[[^\]]+\]\s*", " ", value_cell)
+    normalized = normalized.strip().strip("`*")
+    match = TABLE_NUMBER_RE.fullmatch(normalized)
     if not match:
         return None
     try:
@@ -121,7 +126,16 @@ def _metric_value_in_base_units(claim: ProposalMetricClaim, metric: dict[str, An
         return value * 1000
     if unit in {"ha", "公顷"} and target in {"sqm", "m²", "㎡"}:
         return value * 10000
-    if unit in {"km²", "km2", "平方公里", "平方千米"} and target in {"sqm", "m²", "㎡"}:
+    if unit in {
+        "km²",
+        "km2",
+        "平方公里",
+        "平方千米",
+        "square kilometers",
+        "square kilometer",
+        "square kilometres",
+        "square kilometre",
+    } and target in {"sqm", "m²", "㎡"}:
         return value * 1_000_000
     return value
 
@@ -147,6 +161,25 @@ def validate_proposal_metric_table_claims(
             )
             continue
         if status != "known" or not isinstance(metric.get("value"), (int, float)):
+            continue
+        target_unit = str(metric.get("unit", "")).casefold()
+        if not claim.unit and target_unit in {
+            "sqm",
+            "m²",
+            "㎡",
+            "m",
+            "米",
+            "km",
+            "ha",
+            "公顷",
+        }:
+            # A bare 11.4 may be km², ha, or a rounded base-unit value. Do not
+            # invent a unit and turn an otherwise reviewable statement into a
+            # blocking mismatch.
+            continue
+        if not claim.unit and target_unit in {"ratio", "比例"} and not 0 <= claim.value <= 1:
+            # Ratios may be written as a base fraction without a suffix, but a
+            # bare 28.5 is more likely an unlabelled percentage than 28.5x.
             continue
         expected = float(metric["value"])
         actual = _metric_value_in_base_units(claim, metric)

--- a/scripts/professional_review.py
+++ b/scripts/professional_review.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 import sys
 from dataclasses import dataclass, field
@@ -26,6 +27,137 @@ from validate_submission import (
 
 
 REFERENCE_RE = re.compile(r"\[(source|standard|depth|data|metric):([^\]\s]+)\]")
+TABLE_NUMBER_RE = re.compile(
+    r"(?P<number>[+-]?(?:\d{1,3}(?:,\d{3})+|\d+(?:\.\d+)?))\s*"
+    r"(?P<unit>km²|km2|m²|sqm|ha|公顷|平方公里|平方千米|公里|米|km|m|㎡|%|％|ratio|比例|个|处|项)?",
+    re.IGNORECASE,
+)
+
+# These aliases are intentionally limited to unambiguous metric-table labels.
+# The checker does not interpret arbitrary prose or unlabeled numbers.
+METRIC_TABLE_ALIASES: dict[str, tuple[str, ...]] = {
+    "site_area_sqm": ("范围面积", "site area", "overall design area"),
+    "green_ratio": ("绿地率", "green ratio"),
+    "public_space_ratio": ("公共空间比例", "public-space ratio", "public space ratio"),
+    "building_footprint_area_sqm": ("建筑基底面积", "building footprint area"),
+    "road_network_length_m": ("道路网络长度", "road network length"),
+    "heritage_spine_length_m": ("双轨慢行主脊长度", "heritage spine length", "slow-mobility spine length"),
+    "second_line_length_m": ("AI智轨复线长度", "AI smart-line length", "second-line length"),
+    "ai_scenario_node_count": ("AI场景节点数", "AI scenario node count"),
+    "ai_service_zone_count": ("AI服务区数量", "AI service-zone count"),
+    "renewal_project_count": ("更新项目数量", "renewal project count"),
+    "building_count": ("建筑数量", "building count"),
+    "land_use_parcel_count": ("用地分区数量", "land-use parcel count"),
+    "floor_area_ratio": ("容积率", "floor area ratio", "FAR"),
+    "building_height_m": ("建筑高度", "building height"),
+    "building_density": ("建筑密度", "building density"),
+}
+
+
+@dataclass(frozen=True)
+class ProposalMetricClaim:
+    metric_id: str
+    raw_value: str
+    value: float
+    unit: str
+    line_number: int
+
+
+def _parse_table_value(value_cell: str) -> tuple[float, str] | None:
+    """Parse one unambiguous numeric value from a metric table value cell."""
+    # Ranges and compound values are deliberately left to human review rather
+    # than guessed from their first number.
+    if re.search(r"\d\s*(?:-|–|—|至|到)\s*\d", value_cell):
+        return None
+    match = TABLE_NUMBER_RE.search(value_cell)
+    if not match:
+        return None
+    try:
+        number = float(match.group("number").replace(",", ""))
+    except ValueError:
+        return None
+    if not math.isfinite(number):
+        return None
+    return number, (match.group("unit") or "").casefold()
+
+
+def extract_proposal_metric_claims(text: str) -> list[ProposalMetricClaim]:
+    """Extract only explicit metric-table rows with a known display alias."""
+    claims: list[ProposalMetricClaim] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if line.count("|") < 2 or re.match(r"^\s*\|?\s*:?-{3,}", line):
+            continue
+        cells = [cell.strip().strip("`*") for cell in line.strip().strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+        label = cells[0].casefold()
+        parsed = _parse_table_value(cells[1])
+        if parsed is None:
+            continue
+        value, unit = parsed
+        for metric_id, aliases in METRIC_TABLE_ALIASES.items():
+            if any(alias.casefold() in label for alias in aliases):
+                claims.append(
+                    ProposalMetricClaim(
+                        metric_id=metric_id,
+                        raw_value=cells[1],
+                        value=value,
+                        unit=unit,
+                        line_number=line_number,
+                    )
+                )
+                break
+    return claims
+
+
+def _metric_value_in_base_units(claim: ProposalMetricClaim, metric: dict[str, Any]) -> float:
+    """Convert a displayed table value using its explicit unit."""
+    unit = claim.unit
+    value = claim.value
+    target = str(metric.get("unit", "")).casefold()
+    if unit in {"%", "％"} and target in {"ratio", "比例"}:
+        return value / 100
+    if unit in {"km", "公里"} and target in {"m", "米"}:
+        return value * 1000
+    if unit in {"ha", "公顷"} and target in {"sqm", "m²", "㎡"}:
+        return value * 10000
+    if unit in {"km²", "km2", "平方公里", "平方千米"} and target in {"sqm", "m²", "㎡"}:
+        return value * 1_000_000
+    return value
+
+
+def validate_proposal_metric_table_claims(
+    report: ProfessionalReport,
+    target_file: str,
+    text: str,
+    metrics: dict[str, Any],
+) -> None:
+    """Reject explicit table values that contradict the machine metric ledger."""
+    for claim in extract_proposal_metric_claims(text):
+        metric = metrics.get(claim.metric_id)
+        if not isinstance(metric, dict):
+            continue
+        status = metric.get("status")
+        if status in {"unknown", "not_applicable"}:
+            report.add(
+                "PROPOSAL_UNKNOWN_METRIC_NUMERIC_CLAIM",
+                "major",
+                target_file,
+                f"line {claim.line_number}: `{claim.metric_id}` is {status!r} in metrics.json but the table displays `{claim.raw_value}`; use an explicit non-numeric pending label.",
+            )
+            continue
+        if status != "known" or not isinstance(metric.get("value"), (int, float)):
+            continue
+        expected = float(metric["value"])
+        actual = _metric_value_in_base_units(claim, metric)
+        tolerance = max(abs(expected) * 0.01, 0.01)
+        if abs(actual - expected) > tolerance:
+            report.add(
+                "PROPOSAL_METRIC_VALUE_MISMATCH",
+                "major",
+                target_file,
+                f"line {claim.line_number}: table value `{claim.raw_value}` for `{claim.metric_id}` resolves to {actual:g}, but metrics.json says {expected:g}; regenerate the narrative from the final metric ledger.",
+            )
 
 
 @dataclass
@@ -147,6 +279,20 @@ def build_professional_review(repo_root: Path, submission_dir: Path) -> Professi
                 report.add("DATA_PROPOSAL_REF", "major", "proposal.md", f"Missing [data:{rel_path}#...] reference.")
 
     metric_items = metrics.get("metrics") if isinstance(metrics, dict) else {}
+    if isinstance(metric_items, dict):
+        validate_proposal_metric_table_claims(report, "proposal.md", proposal_text, metric_items)
+        english_proposal_path = submission_dir / "proposal.en.md"
+        if english_proposal_path.exists():
+            try:
+                english_proposal_text = english_proposal_path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                english_proposal_text = ""
+            validate_proposal_metric_table_claims(
+                report,
+                "proposal.en.md",
+                english_proposal_text,
+                metric_items,
+            )
     known_metric_ids = {
         name
         for name, value in metric_items.items()

--- a/tests/test_professional_metric_tables.py
+++ b/tests/test_professional_metric_tables.py
@@ -50,6 +50,44 @@ class ProfessionalMetricTableTests(unittest.TestCase):
         text = "| 建筑高度 | 18–24 m | range |\n| 重点区域 | 3 | count |\n"
         self.assertEqual([], extract_proposal_metric_claims(text))
 
+    def test_prose_formulas_and_multi_value_cells_are_not_guessed(self) -> None:
+        text = (
+            "| 范围面积 | Approximately 11.4 square kilometers, including urban areas | note |\n"
+            "| 公共空间比例 | 29.04% / 3.77% / 6.49% | note |\n"
+            "| 范围面积 | polygon_area(site_boundary) @EPSG:4548 | formula |\n"
+        )
+        self.assertEqual([], extract_proposal_metric_claims(text))
+
+    def test_spelled_square_kilometer_unit_is_normalized(self) -> None:
+        report = ProfessionalReport()
+        validate_proposal_metric_table_claims(
+            report,
+            "proposal.md",
+            "| 范围面积 | 约11.4 square kilometers | metric:site_area_sqm |\n",
+            {"site_area_sqm": {"status": "known", "value": 11400000, "unit": "sqm"}},
+        )
+        self.assertTrue(report.ok, [issue.__dict__ for issue in report.issues])
+
+    def test_bare_physical_values_are_not_assumed_to_be_base_units(self) -> None:
+        report = ProfessionalReport()
+        validate_proposal_metric_table_claims(
+            report,
+            "proposal.md",
+            "| 范围面积 | 11.4 | metric:site_area_sqm |\n",
+            {"site_area_sqm": {"status": "known", "value": 11400000, "unit": "sqm"}},
+        )
+        self.assertTrue(report.ok, [issue.__dict__ for issue in report.issues])
+
+    def test_bare_ratio_above_one_is_not_assumed_to_be_a_base_ratio(self) -> None:
+        report = ProfessionalReport()
+        validate_proposal_metric_table_claims(
+            report,
+            "proposal.md",
+            "| 绿地率 | 28.5 | metric:green_ratio |\n",
+            {"green_ratio": {"status": "known", "value": 0.285, "unit": "ratio"}},
+        )
+        self.assertTrue(report.ok, [issue.__dict__ for issue in report.issues])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_professional_metric_tables.py
+++ b/tests/test_professional_metric_tables.py
@@ -1,0 +1,55 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from professional_review import (  # noqa: E402
+    ProfessionalReport,
+    extract_proposal_metric_claims,
+    validate_proposal_metric_table_claims,
+)
+
+
+class ProfessionalMetricTableTests(unittest.TestCase):
+    def test_length_units_are_normalized_and_mismatch_is_blocked(self) -> None:
+        report = ProfessionalReport()
+        validate_proposal_metric_table_claims(
+            report,
+            "proposal.md",
+            "| 双轨慢行主脊长度 | 约18.1 km | geometry/roads.geojson |\n",
+            {"heritage_spine_length_m": {"status": "known", "value": 39760.64, "unit": "m"}},
+        )
+        self.assertFalse(report.ok)
+        self.assertEqual("PROPOSAL_METRIC_VALUE_MISMATCH", report.issues[0].check_id)
+
+    def test_rounded_percentage_with_matching_metric_passes(self) -> None:
+        report = ProfessionalReport()
+        validate_proposal_metric_table_claims(
+            report,
+            "proposal.md",
+            "| 绿地率 | 28.4% | metric:green_ratio |\n",
+            {"green_ratio": {"status": "known", "value": 0.2836, "unit": "ratio"}},
+        )
+        self.assertTrue(report.ok, [issue.__dict__ for issue in report.issues])
+
+    def test_unknown_metric_numeric_table_claim_is_blocked(self) -> None:
+        report = ProfessionalReport()
+        validate_proposal_metric_table_claims(
+            report,
+            "proposal.md",
+            "| 容积率 | 2.0 | 待控规确认 |\n",
+            {"floor_area_ratio": {"status": "unknown", "value": None, "unit": "ratio"}},
+        )
+        self.assertFalse(report.ok)
+        self.assertEqual("PROPOSAL_UNKNOWN_METRIC_NUMERIC_CLAIM", report.issues[0].check_id)
+
+    def test_ranges_and_unrelated_numbers_are_not_guessed(self) -> None:
+        text = "| 建筑高度 | 18–24 m | range |\n| 重点区域 | 3 | count |\n"
+        self.assertEqual([], extract_proposal_metric_claims(text))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a conservative professional-review check for explicit proposal metric tables
- normalize common display units before comparing table values with `metrics.json`
- check both `proposal.md` and `proposal.en.md` when present
- add coverage for mismatches, rounded percentages, unknown metrics, and ranges

## Why

PR #838 exposed a reproducible evidence-contract gap: `metrics.json` records `heritage_spine_length_m = 39760.64 m`, while the proposal table displayed approximately `18.1 km`. Both files could otherwise pass independently. This check makes the contradiction a deterministic review failure before publication.

## Scope

The parser only considers Markdown table rows whose first cell matches a small set of unambiguous Chinese/English metric aliases. It ignores ordinary prose, unlabeled numbers, and numeric ranges instead of guessing their meaning. Unknown or not-applicable metrics cannot display a numeric table value.

## Validation

- `python3 -m py_compile scripts/professional_review.py`
- `python3 -m unittest tests.test_professional_metric_tables tests.test_agent_scaffold_and_self_check` (22 passed)
- full test discovery: 275 passed; 5 existing generated-gallery/data-sync failures remain in the baseline because `submissions-data.js` is stale on the current main snapshot
