### PR TITLE
fix: make stale gallery index diagnostics actionable

### DIFF
--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -136,7 +136,9 @@ python3 scripts/generate_submissions_data.py
 python3 scripts/generate_submissions_data.py --check
 ```
 
-确认 `submissions-data.js` 已更新后，再提交展示索引变更。该提交应由维护者完成，不要求参赛者在 PR 中提供。
+`--check` 失败时会同时报告期望/现有公开方案数量，以及缺失或多出的方案目录样例，便于定位
+索引漂移。确认 `submissions-data.js` 已更新后，再提交展示索引变更。该提交应由维护者完成，
+不要求参赛者在 PR 中提供。
 生成器输出的展示项 `id` 使用 `github-login/proposal-slug` 路径键，另保留短 `slug` 供显示和排序；不要把方案 slug 当作跨作者全局唯一键。
 
 提交展示索引时，只提交 `submissions-data.js` 等展示页必要变更，不提交 `.maintainer-review/`、`docs/reviews/` 或任何 review packet。

--- a/scripts/generate_submissions_data.py
+++ b/scripts/generate_submissions_data.py
@@ -22,6 +22,11 @@ from urllib.parse import quote
 
 
 PUBLICATION_FILE = "gallery-publication.json"
+GALLERY_ASSIGNMENT_RE = re.compile(
+    r"window\.HAIDIAN_SUBMISSIONS\s*=\s*(\[.*\])\s*;?\s*$", re.S
+)
+GALLERY_SOURCE_SUFFIX = "/proposal.md"
+GALLERY_PATH_SAMPLE_LIMIT = 20
 
 
 REQUIRED_PACKAGE_FILES = {
@@ -467,6 +472,60 @@ def render_js(items: list[dict[str, Any]]) -> str:
     )
 
 
+def parse_rendered_items(text: str) -> list[dict[str, Any]] | None:
+    """Parse the generated assignment without executing JavaScript."""
+    match = GALLERY_ASSIGNMENT_RE.search(text)
+    if not match:
+        return None
+    try:
+        items = json.loads(match.group(1))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(items, list) or not all(isinstance(item, dict) for item in items):
+        return None
+    return items
+
+
+def gallery_source_paths(items: list[dict[str, Any]]) -> set[str]:
+    """Return proposal directories represented by gallery source URLs."""
+    return {
+        source[: -len(GALLERY_SOURCE_SUFFIX)]
+        for item in items
+        if isinstance(source := item.get("sourceUrl"), str) and source.endswith(GALLERY_SOURCE_SUFFIX)
+    }
+
+
+def describe_gallery_mismatch(existing: str, expected_items: list[dict[str, Any]]) -> str:
+    """Explain a stale gallery index in terms a maintainer can immediately fix."""
+    expected_paths = gallery_source_paths(expected_items)
+    actual_items = parse_rendered_items(existing)
+    if actual_items is None:
+        return (
+            "submissions-data.js is out of date and could not be parsed; "
+            "run scripts/generate_submissions_data.py"
+        )
+
+    actual_paths = gallery_source_paths(actual_items)
+    missing = sorted(expected_paths - actual_paths)
+    extra = sorted(actual_paths - expected_paths)
+    details = [
+        f"submissions-data.js is out of date: expected {len(expected_items)} public items, "
+        f"found {len(actual_items)}"
+    ]
+    if missing:
+        sample = ", ".join(missing[:GALLERY_PATH_SAMPLE_LIMIT])
+        if len(missing) > GALLERY_PATH_SAMPLE_LIMIT:
+            sample += ", ..."
+        details.append(f"missing {len(missing)} paths: {sample}")
+    if extra:
+        sample = ", ".join(extra[:GALLERY_PATH_SAMPLE_LIMIT])
+        if len(extra) > GALLERY_PATH_SAMPLE_LIMIT:
+            sample += ", ..."
+        details.append(f"unexpected {len(extra)} paths: {sample}")
+    details.append("run scripts/generate_submissions_data.py")
+    return "; ".join(details)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo-root", default=".")
@@ -489,11 +548,12 @@ def main() -> int:
     out_path = Path(args.out)
     if not out_path.is_absolute():
         out_path = repo_root / out_path
-    generated = render_js(build_data(repo_root))
+    expected_items = build_data(repo_root)
+    generated = render_js(expected_items)
     if args.check:
         existing = out_path.read_text(encoding="utf-8") if out_path.exists() else ""
         if existing != generated:
-            print(f"{out_path.relative_to(repo_root)} is out of date; run scripts/generate_submissions_data.py", file=sys.stderr)
+            print(describe_gallery_mismatch(existing, expected_items), file=sys.stderr)
             return 1
         return 0
     out_path.write_text(generated, encoding="utf-8")

--- a/tests/test_submissions_gallery.py
+++ b/tests/test_submissions_gallery.py
@@ -13,9 +13,11 @@ sys.path.insert(0, str(ROOT / "scripts"))
 from generate_submissions_data import (  # noqa: E402
     build_data,
     build_item,
+    describe_gallery_mismatch,
     discover_submissions,
     load_publication_registry,
     package_sha256,
+    render_js,
 )
 DATA_FILE = ROOT / "submissions-data.js"
 INDEX_FILE = ROOT / "index.html"
@@ -229,6 +231,17 @@ class TestSubmissionsGallery(unittest.TestCase):
             check=False,
         )
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+
+    def test_gallery_mismatch_reports_counts_and_paths(self):
+        expected = [
+            {"sourceUrl": "submissions/alice/alpha/proposal.md"},
+            {"sourceUrl": "submissions/bob/beta/proposal.md"},
+        ]
+        existing = render_js([expected[0]])
+        message = describe_gallery_mismatch(existing, expected)
+        self.assertIn("expected 2 public items, found 1", message)
+        self.assertIn("missing 1 paths: submissions/bob/beta", message)
+        self.assertTrue(message.endswith("run scripts/generate_submissions_data.py"))
 
     def test_public_gallery_matches_merged_submission_count(self):
         registry = json.loads((ROOT / "gallery-publication.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- make `generate_submissions_data.py --check` report expected/current public item counts;
- list missing or unexpected proposal directories when the generated gallery index drifts;
- add a regression test and document the maintainer recovery step.

## Why

The generated gallery index is maintainer-controlled, so participants must not repair it in a submission PR. On the current upstream `main`, the authoritative Git tree contains 273 proposal directories while `submissions-data.js` contains 262 items; the existing check only says that the file is out of date. This change makes the required maintainer action directly actionable without changing the generated index or participant scope rules.

## Verification

- targeted mismatch regression: passed;
- `python3 -m py_compile scripts/generate_submissions_data.py`: passed;
- `git diff --check`: passed;
- full suite on the clean `f809b8d` ancestor: 277 tests, 272 passed, 5 existing gallery/index freshness failures caused by the stale generated file; the failures now include the missing paths in their diagnostics.

Draft PR; it does not modify `submissions-data.js` or `gallery-publication.json`.
