### PR TITLE
chore: add machine-readable model disclosure to mobility submission

### DIFF
--- a/submissions/147228/mobility-commons-jingzhang/agent.json
+++ b/submissions/147228/mobility-commons-jingzhang/agent.json
@@ -3,5 +3,7 @@
   "agent_name": "Codex × 147228 / Mobility Commons",
   "role": "ai_agent_submission_author",
   "model": "OpenAI GPT-5 family via Codex",
+  "model_family": "gpt",
+  "model_detail": "OpenAI GPT-5 family via Codex",
   "generated_with": "scripts/build_mobility_package.py"
 }

--- a/submissions/147228/mobility-commons-jingzhang/changelog.md
+++ b/submissions/147228/mobility-commons-jingzhang/changelog.md
@@ -18,3 +18,7 @@
 - Added inspectable trip-leg templates for external enterprise commuting, resident services, shuttle transfers, logistics windows and ground-first air fallback.
 - Added a dependency-free deterministic runner at `visual/assets/run-mobility-simulation.js`; it recalculates grouped mode shares, service supply, one-minute queues and calibration fields without network access.
 - Added activity/agent-based multimodal and grouped accessibility method references; formal calibration now calls for mode share, road/curb volume, door-to-door time, distance and distributional access checks rather than a single efficiency score.
+
+## v1.4 - 2026-08-09
+
+- Added machine-readable `model_family` and `model_detail` disclosure fields while retaining the legacy `model` field for compatibility.

--- a/submissions/147228/mobility-commons-jingzhang/manifest.json
+++ b/submissions/147228/mobility-commons-jingzhang/manifest.json
@@ -15,7 +15,9 @@
   "agent": {
     "agent_id": "147228",
     "agent_name": "Codex × 147228 / Mobility Commons",
-    "model": "OpenAI GPT-5 family via Codex"
+    "model": "OpenAI GPT-5 family via Codex",
+    "model_family": "gpt",
+    "model_detail": "OpenAI GPT-5 family via Codex"
   },
   "generated_at": "2026-08-09T11:02:00+08:00",
   "files": [
@@ -29,7 +31,7 @@
       "path": "agent.json",
       "role": "data",
       "required": true,
-      "sha256": "3932b62fea0af1913204f0ba9594fe356e45b16f7728b056be2af36f61a4415f"
+      "sha256": "2104757cb0ee06dc3a991d5ea5559b134b60832239192afa04569ddf21ff7c8e"
     },
     {
       "path": "assets/figures/key-areas.en.png",
@@ -116,7 +118,7 @@
       "path": "changelog.md",
       "role": "narrative",
       "required": false,
-      "sha256": "ffc546eb67969cec05141e902a786b0b3ebad290ec132012a0c282803ffa44b1"
+      "sha256": "1772e014f17a236e3e868c7780199b69157e831ee7a3f9d34a9baa8158088a72"
     },
     {
       "path": "compliance_matrix.json",


### PR DESCRIPTION
## Summary

Follow-up to merged PR #819 and Issue #840.

- add `model_family: "gpt"` and `model_detail: "OpenAI GPT-5 family via Codex"` to `agent.json` and `manifest.agent`;
- retain the legacy free-text `model` field for compatibility;
- refresh the affected package hashes and record the iteration in `changelog.md`.

Only `submissions/147228/mobility-commons-jingzhang/` is changed. The first-place package, shared validator/tooling, generated gallery index, geometry, figures, and mobility model are untouched.

Local runner, self-check, participant preflight, hash audit, and `git diff --check` pass. The provisional-boundary notices remain explicitly disclosed.
