### PR TITLE
fix: persist Common Time readiness gate evidence

### DIFF
--- a/submissions/dw-zhu-si/jingzhang-common-time/manifest.json
+++ b/submissions/dw-zhu-si/jingzhang-common-time/manifest.json
@@ -264,7 +264,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "3b8164ea4bc32c2f30992bbdd7f366b3c64a163cd843bac1ab4e33f712051213"
+      "sha256": "9f01b503c155c1feff56dc8ae8d4aa4f9a9b2602a558cb3e68b7eec4b0bcb3b1"
     },
     {
       "path": "sources.json",
@@ -373,7 +373,7 @@
     }
   ],
   "validation_claim": {
-    "self_checked": false,
+    "self_checked": true,
     "known_blockers": [],
     "data_confidence": "medium"
   }

--- a/submissions/dw-zhu-si/jingzhang-common-time/self_check.json
+++ b/submissions/dw-zhu-si/jingzhang-common-time/self_check.json
@@ -1,8 +1,46 @@
 {
   "schema_version": "0.1.0",
+  "generated_at": "2026-08-09T05:24:44Z",
+  "ok": true,
   "review_status": "formal-review-ready",
   "can_enter_formal_review": true,
+  "package_type": "professional_design_package",
   "status_boundary": "Machine readiness is not maintainer confirmation, expert scoring, professional approval, selection or implementation authorization.",
+  "gates": {
+    "deterministic_validation": {
+      "ok": true,
+      "returncode": 0,
+      "status": "pass",
+      "evidence": "The official deterministic validator completed successfully on the current package bytes."
+    },
+    "spatial_review": {
+      "ok": true,
+      "returncode": 0,
+      "status": "pass_with_disclosed_minor_findings",
+      "evidence": "Topology and metric recalculation passed; three provisional key-area findings remain explicitly disclosed and non-blocking."
+    },
+    "visual_review": {
+      "ok": true,
+      "returncode": 0,
+      "status": "pass",
+      "evidence": "Offline visual packaging, required sections and metric consistency completed successfully."
+    },
+    "professional_review": {
+      "ok": true,
+      "returncode": 0,
+      "status": "pass",
+      "evidence": "Standards, design-depth, geometry, metrics, sources and assumptions completed the professional evidence review."
+    }
+  },
+  "spatial_issue_ids": [
+    "KEY_AREA_PROVISIONAL",
+    "KEY_AREA_PROVISIONAL",
+    "KEY_AREA_PROVISIONAL"
+  ],
+  "visual_issue_ids": [],
+  "professional_issue_ids": [],
+  "missing_review_dependencies": [],
+  "next_actions": [],
   "checks": [
     {
       "check_id": "ELIGIBILITY_AND_PATH",


### PR DESCRIPTION
## 目的

这是已合并 #859 的最小后续修复，回应合并前审查评论指出的 persisted readiness evidence 缺口。方案内容、图片、来源、几何和指标均不变。

## 变更

- 在 `self_check.json` 顶层持久化 `ok=true`；
- 持久化 deterministic、spatial、visual、professional 四个 gate 对象，每项均含 `ok=true`、返回码、状态与简洁证据；
- 保留 3 个 `KEY_AREA_PROVISIONAL` minor 项，不把临时几何表述为官方红线；
- 同步 `manifest.json` 中 `self_check.json` 的 SHA-256，并将 `validation_claim.self_checked` 更新为 `true`。

## 验证

- `validate_local_submission.py`: PASS
- `self_check_submission.py`: PASS / formal-review-ready
- `participant_preflight.py --check-push`: PASS，范围仅 2 个本人投稿目录文件
- `maintainer_review.py`: 四道 gate PASS，无 mandatory rejection
- staged secret/privacy scan: 0 个 Critical/High/Medium

## 状态边界

机器可审阅状态不等于正式评分、入展、获奖、实施批准或政府背书。场地与三处重点区仍使用已披露的 provisional geometry，正式数据发布后须整体复算。