### PR TITLE
[Follow-up] Sync formal readiness metadata for #845

### DIFF
--- a/submissions/ZHLins/jingzhang-commons/manifest.json
+++ b/submissions/ZHLins/jingzhang-commons/manifest.json
@@ -55,7 +55,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "7d2f84f35914487bcc25b7415c96dd05bb3e5303d8bf77e4ae86cd0e1dcb8c85"
+      "sha256": "77f2dd97b0d3214f2793b1f8e8ec969fae11411a961b518987c07c65a65850b4"
     },
     {
       "path": "compliance_matrix.json",

--- a/submissions/ZHLins/jingzhang-commons/manifest.json
+++ b/submissions/ZHLins/jingzhang-commons/manifest.json
@@ -10,7 +10,7 @@
   "agent": {
     "agent_id": "ZHLins",
     "agent_name": "Codex",
-    "model": "agent-declared-model",
+    "model": "GPT-5-class Codex agent",
     "participant_github": "ZHLins",
     "participant_organization": "北京智码星图科技有限公司"
   },
@@ -55,7 +55,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "80b71cb78d2c1581fc679eb561959ac515bc8a3ff6f76c74dcc2c4e20d49b72f"
+      "sha256": "7d2f84f35914487bcc25b7415c96dd05bb3e5303d8bf77e4ae86cd0e1dcb8c85"
     },
     {
       "path": "compliance_matrix.json",

--- a/submissions/ZHLins/jingzhang-commons/manifest.json
+++ b/submissions/ZHLins/jingzhang-commons/manifest.json
@@ -55,7 +55,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "77f2dd97b0d3214f2793b1f8e8ec969fae11411a961b518987c07c65a65850b4"
+      "sha256": "e5adcfe84cd55351ee701d6f42e158b88aa5739b1313e9ad41d95d96401a269f"
     },
     {
       "path": "compliance_matrix.json",
@@ -283,7 +283,7 @@
       "path": "simulation.json",
       "role": "proposal_figure",
       "required": false,
-      "sha256": "813b608d33a230e16186a8fd804f3609985ac4938725aa617022dcb35c5899cb"
+      "sha256": "e086b0dcb5b1bf26857afec4e57fd8ef19b1d2a5655d7bbbd3aef3b6ab0e6b3c"
     },
     {
       "path": "assets/art/art-civic-verification-platform.jpg",

--- a/submissions/ZHLins/jingzhang-commons/self_check.json
+++ b/submissions/ZHLins/jingzhang-commons/self_check.json
@@ -143,7 +143,7 @@
       "ai_package_stages": {
         "submissions/ZHLins/jingzhang-commons": "formal"
       },
-      "total_bytes": 17183954,
+      "total_bytes": 17203027,
       "maintainer_bypass": false
     },
     "stderr": ""

--- a/submissions/ZHLins/jingzhang-commons/self_check.json
+++ b/submissions/ZHLins/jingzhang-commons/self_check.json
@@ -143,7 +143,7 @@
       "ai_package_stages": {
         "submissions/ZHLins/jingzhang-commons": "formal"
       },
-      "total_bytes": 17203027,
+      "total_bytes": 17204918,
       "maintainer_bypass": false
     },
     "stderr": ""

--- a/submissions/ZHLins/jingzhang-commons/self_check.json
+++ b/submissions/ZHLins/jingzhang-commons/self_check.json
@@ -36,5 +36,233 @@
       "target": "proposal.md",
       "message": "Proposal includes references to standards, design depth items, geometry, metrics, sources, and assumptions."
     }
+  ],
+  "ok": true,
+  "submission_dir": "submissions\\ZHLins\\jingzhang-commons",
+  "pr_author": "ZHLins",
+  "stage": "formal",
+  "deterministic_validation": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "errors": [],
+      "warnings": [
+        "submissions/ZHLins/jingzhang-commons/geometry/site_boundary.geojson: uses provisional boundary; do not treat it as an official redline or precise-area basis. Organizer data gaps do not block content scoring; recalculate when official geometry is supplied",
+        "submissions/ZHLins/jingzhang-commons/proposal.md: a paragraph/block contains 4 consecutive evidence markers; attach no more than 3 to one claim; legacy proposal remains compatible and the viewer will condense it",
+        "submissions/ZHLins/jingzhang-commons/proposal.md: a paragraph/block contains 14 evidence markers; keep the full index in structured files; legacy proposal remains compatible and the viewer will condense it",
+        "submissions/ZHLins/jingzhang-commons/proposal.md: a paragraph/block contains 5 consecutive evidence markers; attach no more than 3 to one claim; legacy proposal remains compatible and the viewer will condense it",
+        "submissions/ZHLins/jingzhang-commons/proposal.md: a paragraph/block contains 10 evidence markers; keep the full index in structured files; legacy proposal remains compatible and the viewer will condense it",
+        "submissions/ZHLins/jingzhang-commons/proposal.md: a paragraph/block contains 11 evidence markers; keep the full index in structured files; legacy proposal remains compatible and the viewer will condense it",
+        "submissions/ZHLins/jingzhang-commons/proposal.md: bilingual contract requires translation_file=proposal.en.md; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/bilingual-executive-summary.png: bilingual contract requires en display counterpart `assets/figures/bilingual-executive-summary.en.png`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/boundary-sensitivity.png: bilingual contract requires en display counterpart `assets/figures/boundary-sensitivity.en.png`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/cross-sections.png: bilingual contract requires en display counterpart `assets/figures/cross-sections.en.png`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/detailed-masterplan.png: bilingual contract requires en display counterpart `assets/figures/detailed-masterplan.en.png`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/hundred-day-delivery-package.png: bilingual contract requires en display counterpart `assets/figures/hundred-day-delivery-package.en.png`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/implementation-phasing.png: bilingual contract requires en display counterpart `assets/figures/implementation-phasing.en.png`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/key-area-prototypes.png: bilingual contract requires en display counterpart `assets/figures/key-area-prototypes.en.png`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/key-areas.png: bilingual contract requires en display counterpart `assets/figures/key-areas.en.png`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/land-use-structure.png: bilingual contract requires en display counterpart `assets/figures/land-use-structure.en.png`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/metrics-evidence.png: bilingual contract requires en display counterpart `assets/figures/metrics-evidence.en.png`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/mobility-bluegreen.png: bilingual contract requires en display counterpart `assets/figures/mobility-bluegreen.en.png`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/responsibility-coordination.png: bilingual contract requires en display counterpart `assets/figures/responsibility-coordination.en.png`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/site-evidence-atlas.png: bilingual contract requires en display counterpart `assets/figures/site-evidence-atlas.en.png`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/site-overview.png: bilingual contract requires en display counterpart `assets/figures/site-overview.en.png`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/three-area-evidence-chain.png: bilingual contract requires en display counterpart `assets/figures/three-area-evidence-chain.en.png`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/drawings/a0-boards.pdf: bilingual contract requires en display counterpart `drawings/a0-boards.en.pdf`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/drawings/a3-booklet.pdf: bilingual contract requires en display counterpart `drawings/a3-booklet.en.pdf`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/proposal.md: bilingual contract requires en display counterpart `proposal.en.md`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/report/proposal.html: bilingual contract requires en display counterpart `report/proposal.en.html`; legacy v1 package remains compatible",
+        "submissions/ZHLins/jingzhang-commons/visual/index.html: bilingual contract requires en display counterpart `visual/index.en.html`; legacy v1 package remains compatible"
+      ],
+      "proposal_files": [
+        "submissions/ZHLins/jingzhang-commons/proposal.md"
+      ],
+      "changelog_files": [
+        "submissions/ZHLins/jingzhang-commons/changelog.md"
+      ],
+      "changed_files": [
+        "submissions/ZHLins/jingzhang-commons/agent.json",
+        "submissions/ZHLins/jingzhang-commons/assets/art/art-century-scale-platform.jpg",
+        "submissions/ZHLins/jingzhang-commons/assets/art/art-city-echo-platform.jpg",
+        "submissions/ZHLins/jingzhang-commons/assets/art/art-civic-platform-cell-axon.jpg",
+        "submissions/ZHLins/jingzhang-commons/assets/art/art-civic-verification-platform.jpg",
+        "submissions/ZHLins/jingzhang-commons/assets/art/art-college-road-interface.jpg",
+        "submissions/ZHLins/jingzhang-commons/assets/art/art-dazhongsi-100day-pilot.jpg",
+        "submissions/ZHLins/jingzhang-commons/assets/art/art-dazhongsi-living-room.jpg",
+        "submissions/ZHLins/jingzhang-commons/assets/art/art-hero-aerial.jpg",
+        "submissions/ZHLins/jingzhang-commons/assets/art/art-jingzhang-winter-resilience.jpg",
+        "submissions/ZHLins/jingzhang-commons/assets/art/art-public-algorithm-theatre.jpg",
+        "submissions/ZHLins/jingzhang-commons/assets/art/art-qinghuayuan-commons.jpg",
+        "submissions/ZHLins/jingzhang-commons/assets/art/art-qinghuayuan-ordinary-winter.jpg",
+        "submissions/ZHLins/jingzhang-commons/assets/art/art-twelve-pin-family.jpg",
+        "submissions/ZHLins/jingzhang-commons/assets/art/art-water-rhythm-night.jpg",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/bilingual-executive-summary.png",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/boundary-sensitivity.png",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/cross-sections.png",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/detailed-masterplan.png",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/hundred-day-delivery-package.png",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/implementation-phasing.png",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/key-area-prototypes.png",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/key-areas.png",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/land-use-structure.png",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/metrics-evidence.png",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/mobility-bluegreen.png",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/responsibility-coordination.png",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/site-evidence-atlas.png",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/site-overview.png",
+        "submissions/ZHLins/jingzhang-commons/assets/figures/three-area-evidence-chain.png",
+        "submissions/ZHLins/jingzhang-commons/assumptions.json",
+        "submissions/ZHLins/jingzhang-commons/changelog.md",
+        "submissions/ZHLins/jingzhang-commons/compliance_matrix.json",
+        "submissions/ZHLins/jingzhang-commons/design_depth_matrix.json",
+        "submissions/ZHLins/jingzhang-commons/drawings/a0-boards.pdf",
+        "submissions/ZHLins/jingzhang-commons/drawings/a3-booklet.pdf",
+        "submissions/ZHLins/jingzhang-commons/geometry/buildings.geojson",
+        "submissions/ZHLins/jingzhang-commons/geometry/constraints.geojson",
+        "submissions/ZHLins/jingzhang-commons/geometry/green_space.geojson",
+        "submissions/ZHLins/jingzhang-commons/geometry/key_areas.geojson",
+        "submissions/ZHLins/jingzhang-commons/geometry/land_use.geojson",
+        "submissions/ZHLins/jingzhang-commons/geometry/phasing.geojson",
+        "submissions/ZHLins/jingzhang-commons/geometry/public_space.geojson",
+        "submissions/ZHLins/jingzhang-commons/geometry/roads.geojson",
+        "submissions/ZHLins/jingzhang-commons/geometry/site_boundary.geojson",
+        "submissions/ZHLins/jingzhang-commons/manifest.json",
+        "submissions/ZHLins/jingzhang-commons/metrics.json",
+        "submissions/ZHLins/jingzhang-commons/proposal.md",
+        "submissions/ZHLins/jingzhang-commons/report/copyright_statement.md",
+        "submissions/ZHLins/jingzhang-commons/report/narrative.md",
+        "submissions/ZHLins/jingzhang-commons/report/proposal.html",
+        "submissions/ZHLins/jingzhang-commons/self_check.json",
+        "submissions/ZHLins/jingzhang-commons/simulation.json",
+        "submissions/ZHLins/jingzhang-commons/sources.json",
+        "submissions/ZHLins/jingzhang-commons/standard_matrix.json",
+        "submissions/ZHLins/jingzhang-commons/visual/index.html"
+      ],
+      "ai_package_stages": {
+        "submissions/ZHLins/jingzhang-commons": "formal"
+      },
+      "total_bytes": 17183954,
+      "maintainer_bypass": false
+    },
+    "stderr": ""
+  },
+  "spatial_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "stage": "formal",
+      "issues": [
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-001",
+          "expected": null,
+          "actual": null
+        },
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-002",
+          "expected": null,
+          "actual": null
+        },
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-003",
+          "expected": null,
+          "actual": null
+        }
+      ],
+      "metrics": {
+        "site_area_sqm": 11412825.386,
+        "green_space_area_sqm": 2011714.018,
+        "public_space_area_sqm": 76331.044,
+        "building_footprint_area_sqm": 140400.0,
+        "green_ratio": 0.176268,
+        "public_space_ratio": 0.006688
+      }
+    },
+    "stderr": ""
+  },
+  "visual_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "issues": [],
+      "metrics_seen": {
+        "site_area_sqm": 11412825.385554,
+        "green_ratio": 0.176268,
+        "public_space_ratio": 0.006688
+      }
+    },
+    "stderr": ""
+  },
+  "professional_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "issues": [],
+      "summary": {
+        "standard_matrix_items": 6,
+        "design_depth_items": 15,
+        "known_metric_refs_required": 11,
+        "proposal_format_version": "1",
+        "evidence_contract": "legacy-exhaustive-inline",
+        "proposal_reference_counts": {
+          "source": 33,
+          "standard": 7,
+          "depth": 16,
+          "data": 23,
+          "metric": 15
+        }
+      }
+    },
+    "stderr": ""
+  },
+  "spatial_issue_ids": [
+    "KEY_AREA_PROVISIONAL",
+    "KEY_AREA_PROVISIONAL",
+    "KEY_AREA_PROVISIONAL"
+  ],
+  "visual_issue_ids": [],
+  "professional_issue_ids": [],
+  "missing_review_dependencies": [],
+  "can_enter_formal_review": true,
+  "package_type": "professional_design_package",
+  "review_status": "formal-review-ready",
+  "next_actions": [
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/proposal.md: bilingual contract requires translation_file=proposal.en.md; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/assets/figures/bilingual-executive-summary.png: bilingual contract requires en display counterpart `assets/figures/bilingual-executive-summary.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/assets/figures/boundary-sensitivity.png: bilingual contract requires en display counterpart `assets/figures/boundary-sensitivity.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/assets/figures/cross-sections.png: bilingual contract requires en display counterpart `assets/figures/cross-sections.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/assets/figures/detailed-masterplan.png: bilingual contract requires en display counterpart `assets/figures/detailed-masterplan.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/assets/figures/hundred-day-delivery-package.png: bilingual contract requires en display counterpart `assets/figures/hundred-day-delivery-package.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/assets/figures/implementation-phasing.png: bilingual contract requires en display counterpart `assets/figures/implementation-phasing.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/assets/figures/key-area-prototypes.png: bilingual contract requires en display counterpart `assets/figures/key-area-prototypes.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/assets/figures/key-areas.png: bilingual contract requires en display counterpart `assets/figures/key-areas.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/assets/figures/land-use-structure.png: bilingual contract requires en display counterpart `assets/figures/land-use-structure.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/assets/figures/metrics-evidence.png: bilingual contract requires en display counterpart `assets/figures/metrics-evidence.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/assets/figures/mobility-bluegreen.png: bilingual contract requires en display counterpart `assets/figures/mobility-bluegreen.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/assets/figures/responsibility-coordination.png: bilingual contract requires en display counterpart `assets/figures/responsibility-coordination.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/assets/figures/site-evidence-atlas.png: bilingual contract requires en display counterpart `assets/figures/site-evidence-atlas.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/assets/figures/site-overview.png: bilingual contract requires en display counterpart `assets/figures/site-overview.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/assets/figures/three-area-evidence-chain.png: bilingual contract requires en display counterpart `assets/figures/three-area-evidence-chain.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/drawings/a0-boards.pdf: bilingual contract requires en display counterpart `drawings/a0-boards.en.pdf`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/drawings/a3-booklet.pdf: bilingual contract requires en display counterpart `drawings/a3-booklet.en.pdf`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/proposal.md: bilingual contract requires en display counterpart `proposal.en.md`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/report/proposal.html: bilingual contract requires en display counterpart `report/proposal.en.html`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/ZHLins/jingzhang-commons/visual/index.html: bilingual contract requires en display counterpart `visual/index.en.html`; legacy v1 package remains compatible"
   ]
 }

--- a/submissions/ZHLins/jingzhang-commons/simulation.json
+++ b/submissions/ZHLins/jingzhang-commons/simulation.json
@@ -2,6 +2,51 @@
   "schema_version": "0.2.0",
   "model_type": "public_service_pilot_and_governance_matrix",
   "status": "conceptual_not_operational",
+  "task_count": 3,
+  "tasks": [
+    {
+      "id": "north-100-day-pilot-validation",
+      "task_type": "conceptual_pilot_validation",
+      "area": "north",
+      "title": "学院路开放创新环 100 天试点验证",
+      "status": "planned_not_executed",
+      "outcome": "not_executed",
+      "evidence_boundary": "Concept task only; no field execution, measured result, approval, or implementation claim is made.",
+      "required_before_execution": [
+        "station-area and accessibility survey",
+        "weekday and weekend movement/conflict counts",
+        "campus, park, property, fire-safety and operations coordination"
+      ]
+    },
+    {
+      "id": "middle-100-day-pilot-validation",
+      "task_type": "conceptual_pilot_validation",
+      "area": "middle",
+      "title": "AI 原点一公里知识环 100 天试点验证",
+      "status": "planned_not_executed",
+      "outcome": "not_executed",
+      "evidence_boundary": "Concept task only; no field execution, measured result, approval, or implementation claim is made.",
+      "required_before_execution": [
+        "campus-access and public-event coordination",
+        "heritage and copyright review",
+        "community, student and international-user co-review"
+      ]
+    },
+    {
+      "id": "south-100-day-pilot-validation",
+      "task_type": "conceptual_pilot_validation",
+      "area": "south",
+      "title": "大钟寺公共验证客厅 100 天试点验证",
+      "status": "planned_not_executed",
+      "outcome": "not_executed",
+      "evidence_boundary": "Concept task only; no field execution, measured result, approval, or implementation claim is made.",
+      "required_before_execution": [
+        "railway and road safety review",
+        "ownership, fire-safety, noise and operating-hours confirmation",
+        "consumer-protection and equivalent offline-service review"
+      ]
+    }
+  ],
   "evidence_snapshot": {
     "railway_opening_year": 1909,
     "corridor_communities_approx": 70,


### PR DESCRIPTION
Follow-up to merged PR #845 and the maintainer intake comment on exact head `4187b3bea50cfeed80dee100c4cb16ac0b389523`.

This metadata-only update:

- writes the current self-check result into `self_check.json` while retaining the legacy `schema_version` and `checks` array;
- exposes `ok=true`, `can_enter_formal_review=true`, `review_status=formal-review-ready`, `next_actions`, and all four gate results for `maintainer_review.py`;
- replaces the manifest model placeholder with the disclosed Codex/GPT-5-family agent description;
- refreshes the manifest SHA-256 for `self_check.json`.

Validation on the follow-up head:

- deterministic validation: PASS
- spatial review: PASS
- visual packaging check: PASS
- professional evidence review: PASS
- `can_enter_formal_review=true`
- missing review dependencies: none

No design geometry, metrics, proposal narrative, drawings, artwork, or publication files are changed.