### PR TITLE
fix: keep peer catalog output UTF-8 on Windows

### DIFF
--- a/scripts/read_peer_proposals.py
+++ b/scripts/read_peer_proposals.py
@@ -52,6 +52,18 @@ class PeerReaderError(RuntimeError):
     pass
 
 
+def configure_stdout() -> None:
+    """Prefer UTF-8 for human-readable output on legacy Windows consoles."""
+    reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if reconfigure is None:
+        return
+    try:
+        reconfigure(encoding="utf-8", errors="backslashreplace")
+    except (OSError, ValueError):
+        # Keep embedded/test streams and older Python implementations usable.
+        return
+
+
 def safe_repo_path(value: str) -> str:
     path = PurePosixPath(value)
     if path.is_absolute() or ".." in path.parts or not path.parts:
@@ -224,6 +236,7 @@ def render_list(items: list[dict[str, Any]], source: str) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
+    configure_stdout()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo-root", default=".", help="Sparse workspace containing submissions-data.js")
     parser.add_argument("--latest", type=int, default=20, help="Maximum catalog entries to show")

--- a/tests/test_read_peer_proposals.py
+++ b/tests/test_read_peer_proposals.py
@@ -1,0 +1,62 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class ReadPeerProposalsEncodingTests(unittest.TestCase):
+    def test_human_output_survives_gbk_console_with_superscript_two(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            item = {
+                "id": "octocat/agent-city",
+                "title": "Transit ²",
+                "titleEn": "Transit ²",
+                "summary": "A resident and vehicle test with ².",
+                "summaryEn": "A resident and vehicle test with ².",
+                "author": "octocat",
+                "authorName": "Octo Cat",
+                "date": "2026-08-09",
+                "status": "正式评分就绪",
+                "statusEn": "Formal review ready",
+                "statusKey": "formal_review_ready",
+                "sourceUrl": "submissions/octocat/agent-city/proposal.md",
+                "proposalUrl": "submissions/octocat/agent-city/proposal.md",
+                "visualUrl": "submissions/octocat/agent-city/visual/index.html",
+            }
+            (root / "submissions-data.js").write_text(
+                "window.HAIDIAN_SUBMISSIONS = "
+                + json.dumps([item], ensure_ascii=False)
+                + ";\n",
+                encoding="utf-8",
+            )
+
+            env = os.environ.copy()
+            env["PYTHONIOENCODING"] = "gbk"
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "read_peer_proposals.py"),
+                    "--repo-root",
+                    str(root),
+                    "--latest",
+                    "1",
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr.decode("utf-8", "replace"))
+            self.assertIn("Transit ²", completed.stdout.decode("utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #874 by configuring `read_peer_proposals.py` to reconfigure stdout as UTF-8 when the console supports it, with `backslashreplace` as a safe fallback for unrepresentable characters.

Adds a regression test that runs the human-readable catalog command under `PYTHONIOENCODING=gbk` with a summary containing `²`.

## Verification

- `python3 -m unittest discover -s tests -p 'test_read_peer_proposals.py'`
- `python3 -m py_compile scripts/read_peer_proposals.py tests/test_read_peer_proposals.py`
- `git diff --check`

This PR is based on the current `upstream/main` and is limited to the reader script and its regression test.
