### PR TITLE
fix: include actual digest in manifest errors

### DIFF
--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1348,7 +1348,10 @@ def validate_manifest_file(report: ValidationReport, repo_root: Path, proposal_d
             elif declared_digest:
                 actual_digest = hashlib.sha256(listed_file.read_bytes()).hexdigest()
                 if declared_digest != actual_digest:
-                    message = f"{proposal_dir}/manifest.json: sha256 mismatch for `{safe_path}`"
+                    message = (
+                        f"{proposal_dir}/manifest.json: sha256 mismatch for `{safe_path}`; "
+                        f"declared={declared_digest}, actual={actual_digest}"
+                    )
                     if translation_entry and not strict_bilingual:
                         report.add_warning(message + "; legacy bilingual metadata does not block review")
                     else:

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -2287,6 +2287,29 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertTrue(report.ok, report.errors)
             self.assertIn("sha256 mismatch for `proposal.en.md`", "\n".join(report.warnings))
 
+    def test_manifest_hash_mismatch_reports_declared_and_actual_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            proposal = root / base / "proposal.md"
+            proposal.write_text(proposal.read_text(encoding="utf-8") + "\nRevised.\n", encoding="utf-8")
+            manifest_path = root / base / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["files"].append(
+                {"path": "proposal.md", "role": "narrative", "required": True, "sha256": "0" * 64}
+            )
+            manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertFalse(report.ok)
+            mismatch = next(error for error in report.errors if "sha256 mismatch for `proposal.md`" in error)
+            declared = "0" * 64
+            actual = hashlib.sha256(proposal.read_bytes()).hexdigest()
+            self.assertIn(f"declared={declared}", mismatch)
+            self.assertIn(f"actual={actual}", mismatch)
+
     def test_removed_translation_file_is_non_blocking(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## What changed

When a professional submission manifest declares a stale SHA-256, validation now reports both the declared and actual digest. This makes package-integrity failures directly repairable from the trusted validation comment instead of requiring a local rehash of every file.

## Exact-head evidence

- Base `059243dfdb2956a7552fc8ef75924f1d580e87fc`
- Head `2aac508786c6af7547679d3f3846638f0aba564b`
- Only two files changed: `scripts/validate_submission.py` and `tests/test_submission_workflow.py`
- `python3 -m unittest tests.test_submission_workflow tests.test_agent_scaffold_and_self_check`: 118 passed
- `python3 -m py_compile scripts/validate_submission.py scripts/github_pr_validation.py tests/test_submission_workflow.py`: PASS
- `git diff --check`: PASS
- Trusted `submission-validation` run [31302297708](https://github.com/open-city-ai/haidian/actions/runs/31302297708) is pending for this exact head.

The generated-gallery freshness concern is handled separately in #900; this validator-only PR does not alter contributor submission data or the gallery snapshot.
