### PR TITLE
fix: reject source indexes outside repository

### DIFF
--- a/scripts/validate_sources.py
+++ b/scripts/validate_sources.py
@@ -134,7 +134,15 @@ def validate_source_index(repo_root: Path, index_path: Path | None = None) -> So
     if not index_path.is_absolute():
         index_path = repo_root / index_path
 
-    report = SourceValidationReport(index_path=str(index_path.relative_to(repo_root)))
+    index_path = index_path.resolve()
+    try:
+        relative_index_path = index_path.relative_to(repo_root)
+    except ValueError:
+        report = SourceValidationReport(index_path=str(index_path))
+        report.add_error("source index must be inside the repository")
+        return report
+
+    report = SourceValidationReport(index_path=str(relative_index_path))
     if not index_path.exists():
         report.add_error(f"{report.index_path}: source index is missing")
         return report

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -89,6 +89,18 @@ class PublicSourcesTests(unittest.TestCase):
             self.assertFalse(report.ok)
             self.assertIn("unsafe path", "\n".join(report.errors))
 
+    def test_source_index_outside_repo_fails_without_reading_it(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            outside_index = root.parent / "outside.json"
+            self.write_json(outside_index.parent, outside_index.name, VALID_INDEX)
+
+            report = validate_source_index(root, Path("../outside.json"))
+
+            self.assertFalse(report.ok)
+            self.assertIn("must be inside the repository", "\n".join(report.errors))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- resolve the configured source index before validating it
- reject relative traversal and absolute paths outside the repository with a structured validation error
- add a regression test proving an external index is not read

## Why

`validate_source_index` previously called `relative_to(repo_root)` on absolute external paths, which raised an uncaught `ValueError`. Relative paths such as `../outside.json` were not normalized first and could therefore be read from outside the repository.

## Tests

- `python tests/test_public_sources.py` (6 tests passed)
- `python -m py_compile scripts/validate_sources.py tests/test_public_sources.py`
- `git diff --check`