### PR TITLE
Support refreshing ready submission revisions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -68,6 +68,8 @@ python3 scripts/self_check_submission.py submissions/<my-github-login>/<proposal
 python3 scripts/participant_preflight.py submissions/<my-github-login>/<proposal-slug> --pr-author <my-github-login> --check-push
 ```
 
+如果是已存在 `package_state=ready_for_review` 包的后续修订，将 finalize 命令替换为 `python3 scripts/finalize_submission.py <submission-dir> --refresh`，再重新运行 self-check 和 preflight。
+
 - [ ] 一键自检 `self_check_submission.py` 已通过
 - [ ] 投稿预检 `participant_preflight.py --check-push` 已通过，目录归属、变更范围、文件大小和远程推送均无 blocker
 - [ ] deterministic validation、spatial review、visual packaging check、professional evidence review 均为 PASS

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ python3 scripts/scaffold_ai_submission.py \
 ```
 
 7. 按 formal 模板完善 `proposal.md`、图纸、HTML 可视化、合规矩阵、标准矩阵、深度矩阵和自检结果。脚手架默认是 `package_state=scaffold`，不能投稿；必须替换正文、至少一个设计图层、五张图、HTML 和有效 A3/A0 PDF，并移除 `SCAFFOLD-DRAFT`。每次手动修改 `proposal.md` 后，重新生成 `report/proposal.html`。
-8. 运行 `python3 scripts/finalize_submission.py submissions/<your-github-login>/<proposal-slug>`；它会拒绝未修改模板和零页 PDF，成功后写入 `package_state=ready_for_review` 并刷新 manifest 哈希。随后运行一键自检，修复到 PASS 后发起 Pull Request。PR 作者只能修改自己 GitHub 用户名对应的目录。
+8. 首次完成脚手架内容后运行 `python3 scripts/finalize_submission.py submissions/<your-github-login>/<proposal-slug>`；它会拒绝未修改模板和零页 PDF，成功后写入 `package_state=ready_for_review` 并刷新 manifest 哈希。后续对已 ready 包进行展示或内容修订后，使用同一命令加 `--refresh`，它会保留反占位检查、刷新已列文件哈希并重置 self-check claim。随后运行一键自检，修复到 PASS 后发起 Pull Request。PR 作者只能修改自己 GitHub 用户名对应的目录。
    - 发起 PR 前运行 `python3 scripts/participant_preflight.py submissions/<your-github-login>/<proposal-slug> --pr-author <your-github-login> --check-push`，提前检查目录归属、变更范围、大文件、完整自检、fork 远程与推送权限。
 9. 发起 PR 后必须持续监控 CI、评审评论、合并队列和状态变化。审核通常实时启动，但繁忙时可能排队；上传完成不等于任务结束。检查失败或收到修改意见时，阅读完整日志与上下文，修复后重新运行渲染、finalize、自检和 preflight，推送并继续监控，直到 PR 合并或明确记录外部 blocker。可用 `gh pr checks <PR> --watch --interval 15` 与 `gh pr view <PR> --json state,mergeStateStatus,reviewDecision,statusCheckRollup,comments,reviews`；排队时使用通知或低频定时复查，不要高频轮询或发布空评论。
 10. 方案合并到 `main` 后会自动进入公开展示页。`gallery-publication.json` 仅用于首页精选，或由维护者明确暂停某个已合并方案的展示；`published=false` 表示暂停，`published=true` 可记录经人工内容、视觉和版权审核的版本，`featured=true` 决定首页精选。然后运行 `scripts/generate_submissions_data.py`；参赛者不得修改该清单或 `submissions-data.js`。

--- a/docs/formal-submission-guide.md
+++ b/docs/formal-submission-guide.md
@@ -358,6 +358,14 @@ python3 scripts/render_proposal_html.py submissions/<github-login>/<proposal-slu
 python3 scripts/finalize_submission.py submissions/<github-login>/<proposal-slug>
 ```
 
+以上无参数命令用于首次把 `package_state=scaffold` 提升为 `ready_for_review`。如果包已经是 `ready_for_review`，后续修改展示或正文后应改用：
+
+```bash
+python3 scripts/finalize_submission.py submissions/<github-login>/<proposal-slug> --refresh
+```
+
+`--refresh` 仍会检查反占位条件、必需展示文件和非空图纸，只刷新 manifest 已列文件的哈希，并把 self-check claim 重置为未完成；随后必须重新运行 `self_check_submission.py`。
+
 规则：
 
 - 路径固定为 `report/proposal.html`。

--- a/scripts/finalize_submission.py
+++ b/scripts/finalize_submission.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Promote a materially edited scaffold to a review-ready submission package."""
+"""Promote a scaffold or refresh an existing review-ready submission package."""
 
 from __future__ import annotations
 
@@ -44,13 +44,24 @@ def digest(path: Path) -> str:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("submission_dir")
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="refresh hashes for an existing ready_for_review package after a revision",
+    )
     args = parser.parse_args()
     root = Path(args.submission_dir).resolve()
     manifest_path = root / "manifest.json"
     if not manifest_path.is_file():
         parser.error(f"manifest.json not found under {root}")
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    if manifest.get("package_state") != "scaffold":
+    package_state = manifest.get("package_state")
+    refresh_mode = package_state == "ready_for_review"
+    if args.refresh and not refresh_mode:
+        parser.error("--refresh requires package_state=ready_for_review")
+    if not args.refresh and package_state != "scaffold":
+        if refresh_mode:
+            parser.error("package_state is ready_for_review; use --refresh to refresh a revision")
         parser.error("package_state must be scaffold before finalization")
 
     declared = {
@@ -60,7 +71,24 @@ def main() -> int:
     }
     errors: list[str] = []
 
-    proposal_text = (root / "proposal.md").read_text(encoding="utf-8")
+    def require_non_empty_file(rel: str) -> None:
+        path = root / rel
+        if not path.is_file():
+            errors.append(f"{rel} is missing")
+        elif path.stat().st_size == 0:
+            errors.append(f"{rel} is empty")
+
+    if refresh_mode:
+        for rel in [*READABLE_OUTPUTS, *FIGURES]:
+            require_non_empty_file(rel)
+        for rel in DRAWINGS:
+            require_non_empty_file(rel)
+            path = root / rel
+            if path.is_file() and is_empty_pdf(path.read_bytes()):
+                errors.append(f"{rel} has no pages")
+
+    proposal_path = root / "proposal.md"
+    proposal_text = proposal_path.read_text(encoding="utf-8") if proposal_path.is_file() else ""
     proposal_metadata, _ = parse_front_matter(proposal_text)
     if "SCAFFOLD-DRAFT" in proposal_text:
         errors.append("proposal.md still contains the SCAFFOLD-DRAFT marker")
@@ -75,24 +103,25 @@ def main() -> int:
                 f"proposal.md must declare translation_file: {expected_translation} for the required bilingual package"
             )
 
-    def changed(rel: str) -> bool:
-        path = root / rel
-        return path.is_file() and rel in declared and digest(path) != declared[rel]
+    if not refresh_mode:
+        def changed(rel: str) -> bool:
+            path = root / rel
+            return path.is_file() and rel in declared and digest(path) != declared[rel]
 
-    for rel in READABLE_OUTPUTS:
-        if not changed(rel):
-            errors.append(f"{rel} is unchanged from the generated scaffold")
-    unchanged_figures = [rel for rel in FIGURES if not changed(rel)]
-    if unchanged_figures:
-        errors.append("all five proposal figures must be regenerated: " + ", ".join(unchanged_figures))
-    if not any(changed(rel) for rel in DESIGN_GEOMETRY):
-        errors.append("at least one participant-controlled design geometry layer must change")
-    for rel in DRAWINGS:
-        path = root / rel
-        if not changed(rel):
-            errors.append(f"{rel} is unchanged from the placeholder drawing")
-        elif is_empty_pdf(path.read_bytes()):
-            errors.append(f"{rel} has no pages")
+        for rel in READABLE_OUTPUTS:
+            if not changed(rel):
+                errors.append(f"{rel} is unchanged from the generated scaffold")
+        unchanged_figures = [rel for rel in FIGURES if not changed(rel)]
+        if unchanged_figures:
+            errors.append("all five proposal figures must be regenerated: " + ", ".join(unchanged_figures))
+        if not any(changed(rel) for rel in DESIGN_GEOMETRY):
+            errors.append("at least one participant-controlled design geometry layer must change")
+        for rel in DRAWINGS:
+            path = root / rel
+            if not changed(rel):
+                errors.append(f"{rel} is unchanged from the placeholder drawing")
+            elif is_empty_pdf(path.read_bytes()):
+                errors.append(f"{rel} has no pages")
 
     if translation_language and strict_bilingual:
         listed_items = {
@@ -123,7 +152,8 @@ def main() -> int:
                     errors.append(f"{translated_proposal.name} must declare translation_of: proposal.md")
 
     if errors:
-        print("Submission is still a scaffold:")
+        heading = "Submission refresh blocked:" if refresh_mode else "Submission is still a scaffold:"
+        print(heading)
         for error in errors:
             print(f"- {error}")
         return 1
@@ -173,7 +203,10 @@ def main() -> int:
         if rel and rel != "manifest.json" and (root / rel).is_file():
             item["sha256"] = digest(root / rel)
     manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    print(f"Review-ready package: {root}")
+    if refresh_mode:
+        print(f"Review-ready package refreshed: {root}")
+    else:
+        print(f"Review-ready package: {root}")
     print("Run self_check_submission.py now. Any later file edit requires refreshed manifest hashes and another full validation.")
     return 0
 

--- a/skills/urban-design-ai-submission/SKILL.md
+++ b/skills/urban-design-ai-submission/SKILL.md
@@ -61,7 +61,7 @@ Use $urban-design-ai-submission to create a lightweight sparse workspace and par
 
 `package_type=professional_design_package` describes the artifact. `review_status` is derived by self-check and maintainer review. The legacy `submission_stage=formal` field remains for compatibility and is not a review decision. Missing organizer-supplied official polygons do not block content scoring or reduce the participant's score; provisional geometry must still be clearly labeled and recalculated when official data becomes available.
 
-The scaffold starts with `package_state=scaffold` and a `SCAFFOLD-DRAFT` marker. It is intentionally invalid for review. Replace the generated narrative, design geometry, all five figures, offline visual, rendered report, and both drawing PDFs, then run `finalize_submission.py`. Finalization refuses unchanged template artifacts, zero-page PDFs, and an unchanged design layer before setting `package_state=ready_for_review` and refreshing manifest hashes.
+The scaffold starts with `package_state=scaffold` and a `SCAFFOLD-DRAFT` marker. It is intentionally invalid for review. Replace the generated narrative, design geometry, all five figures, offline visual, rendered report, and both drawing PDFs, then run `finalize_submission.py`. Finalization refuses unchanged template artifacts, zero-page PDFs, and an unchanged design layer before setting `package_state=ready_for_review` and refreshing manifest hashes. For a later revision of an existing ready package, run `finalize_submission.py --refresh`; it keeps the anti-placeholder checks, refreshes listed-file hashes, and resets the self-check claim.
 
 ## Required Inputs
 
@@ -292,7 +292,7 @@ Do not solve machine completeness by appending a paragraph of identifiers. The v
 5. Replace scaffold text, diagrams, metrics, design layers, offline visual, and placeholder PDFs with the actual proposal content; remove the `SCAFFOLD-DRAFT` marker.
 6. Generate A3/A0 PDFs and offline `visual/index.html`.
 7. Run `python3 scripts/render_proposal_html.py submissions/<agent-id>/<proposal-slug>`.
-8. Run `python3 scripts/finalize_submission.py submissions/<agent-id>/<proposal-slug>`.
+8. Run `python3 scripts/finalize_submission.py submissions/<agent-id>/<proposal-slug>` for first finalization; use `--refresh` after revising an existing `ready_for_review` package.
 9. Run `python3 scripts/self_check_submission.py submissions/<agent-id>/<proposal-slug> --pr-author <agent-id>`.
 10. Run `python3 scripts/participant_preflight.py submissions/<agent-id>/<proposal-slug> --pr-author <agent-id> --check-push`.
 11. Repair until deterministic validation, bilingual packaging, spatial review, visual packaging check, professional evidence review, PR scope, file-size, and push-access checks all PASS.

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -298,6 +298,71 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
             self.assertEqual("proposal.md", items["proposal.en.md"]["translation_of"])
             self.assertEqual("report/proposal.html", items["report/proposal.en.html"]["translation_of"])
 
+    def test_finalize_refreshes_ready_package_after_revision(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_official_site_package(root)
+            submission_dir = root / "submissions" / "alice" / "refresh-pass"
+            scaffold = run_scaffold(submission_dir, cwd=root)
+            self.assertEqual(0, scaffold.returncode, scaffold.stdout + scaffold.stderr)
+            finalized = complete_scaffold(submission_dir)
+            self.assertEqual(0, finalized.returncode, finalized.stdout + finalized.stderr)
+
+            manifest_path = submission_dir / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["validation_claim"]["self_checked"] = True
+            before = next(item["sha256"] for item in manifest["files"] if item["path"] == "visual/index.html")
+            manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+            visual_path = submission_dir / "visual" / "index.html"
+            visual_path.write_text(visual_path.read_text(encoding="utf-8") + "\n<!-- presentation revision -->\n", encoding="utf-8")
+
+            refreshed = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "finalize_submission.py"),
+                    str(submission_dir),
+                    "--refresh",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(0, refreshed.returncode, refreshed.stdout + refreshed.stderr)
+            updated = json.loads(manifest_path.read_text(encoding="utf-8"))
+            after = next(item["sha256"] for item in updated["files"] if item["path"] == "visual/index.html")
+            self.assertEqual("ready_for_review", updated["package_state"])
+            self.assertNotEqual(before, after)
+            self.assertEqual(hashlib.sha256(visual_path.read_bytes()).hexdigest(), after)
+            self.assertFalse(updated["validation_claim"]["self_checked"])
+            self.assertIn("Review-ready package refreshed", refreshed.stdout)
+
+    def test_finalize_refresh_blocks_zero_page_drawing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_official_site_package(root)
+            submission_dir = root / "submissions" / "alice" / "refresh-pdf"
+            scaffold = run_scaffold(submission_dir, cwd=root)
+            self.assertEqual(0, scaffold.returncode, scaffold.stdout + scaffold.stderr)
+            finalized = complete_scaffold(submission_dir)
+            self.assertEqual(0, finalized.returncode, finalized.stdout + finalized.stderr)
+            (submission_dir / "drawings" / "a0-boards.pdf").write_bytes(
+                b"%PDF-1.4\n/Type /Pages /Count 0\n"
+            )
+
+            refreshed = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "finalize_submission.py"),
+                    str(submission_dir),
+                    "--refresh",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(0, refreshed.returncode)
+            self.assertIn("drawings/a0-boards.pdf has no pages", refreshed.stdout)
+
     def test_finalize_preserves_localized_figure_language_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             output_dir = Path(tmp) / "submissions" / "alice" / "bilingual-figures"


### PR DESCRIPTION
## What changed

Fixes #953 by adding an explicit revision path to `scripts/finalize_submission.py`:

- first finalization remains the existing scaffold-only command;
- `--refresh` is accepted only when `manifest.json` already has `package_state=ready_for_review`;
- refresh mode checks the scaffold marker, required readable/figure files, and non-empty drawing PDFs;
- all listed existing files receive fresh SHA-256 values;
- `validation_claim.self_checked` is reset to `false`, so the participant must rerun the full self-check;
- the participant skill, README, formal guide, and PR template document the two-state workflow.

## Why

The documented continuous-participation loop tells contributors to rerun finalization after a revision, but the script rejected every `ready_for_review` manifest with `package_state must be scaffold before finalization`. Setting the state back to `scaffold` is unsafe because the normal path then compares the package against scaffold hashes and requires replacing every artifact again.

## Validation

- `python3 -m unittest tests.test_agent_scaffold_and_self_check -q` — 21 passed.
- `python3 -m unittest tests.test_agent_scaffold_and_self_check tests.test_submission_workflow -q` — 125 passed.
- `python3 -m py_compile scripts/finalize_submission.py` — PASS.
- `git diff --check` — PASS.
- Added regression coverage for refreshing a ready package and for rejecting a zero-page PDF during refresh.

The broader `tests.test_prelaunch_check` baseline still reports the existing stale `submissions-data.js` generated-data failure on current `upstream/main`; this PR does not modify the maintainer-controlled gallery index.
