### PR TITLE
fix: support safe ready-package revisions

### DIFF
--- a/scripts/finalize_submission.py
+++ b/scripts/finalize_submission.py
@@ -11,8 +11,10 @@ from pathlib import Path
 from validate_submission import (
     DISPLAY_BASE_FILES,
     PERSISTED_READINESS_CONTRACT,
+    first_symbolic_link,
     is_empty_pdf,
     localized_path,
+    normalize_changed_path,
     parse_front_matter,
     primary_path_from_localized,
     requires_bilingual_contract,
@@ -41,6 +43,58 @@ REFRESH_PLACEHOLDER_MARKERS = ("SCAFFOLD-DRAFT", "PARTICIPANT-DESIGN: replace")
 
 def digest(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def safe_manifest_path(root: Path, raw_path: object) -> tuple[str | None, Path | None, str | None]:
+    """Normalize a manifest path and prove that it stays inside the package."""
+    if not isinstance(raw_path, str):
+        return None, None, "manifest.json contains a non-string file path"
+    try:
+        rel = normalize_changed_path(raw_path)
+    except ValueError as exc:
+        return None, None, f"manifest.json contains an unsafe file path {raw_path!r}: {exc}"
+    linked = first_symbolic_link(root, rel)
+    if linked is not None:
+        linked_rel = linked.relative_to(root).as_posix()
+        return None, None, f"manifest.json path traverses symbolic link: {rel} (via {linked_rel})"
+    path = root / rel
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return None, None, f"manifest.json path resolves outside the package: {rel}"
+    return rel, path, None
+
+
+def invalidate_self_check(root: Path) -> None:
+    """Make a persisted self-check fail closed after any package refresh."""
+    path = root / "self_check.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        data = {}
+    if not isinstance(data, dict):
+        data = {}
+    data["ok"] = False
+    data["can_enter_formal_review"] = False
+    data["review_status"] = "revision-requested"
+    checks = data.get("checks")
+    if not isinstance(checks, list):
+        checks = []
+    checks = [
+        item
+        for item in checks
+        if not (isinstance(item, dict) and item.get("check_id") == "REFRESH_INVALIDATED")
+    ]
+    checks.append(
+        {
+            "check_id": "REFRESH_INVALIDATED",
+            "result": "fail",
+            "severity": "blocking",
+            "message": "Package files changed; rerun scripts/self_check_submission.py before formal review.",
+        }
+    )
+    data["checks"] = checks
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
 def refresh_ready_package(root: Path, manifest_path: Path, manifest: dict) -> int:
@@ -97,6 +151,7 @@ def refresh_ready_package(root: Path, manifest_path: Path, manifest: dict) -> in
                     errors.append(f"{expected_translation} must declare translation_of: proposal.md")
 
     files = manifest.get("files")
+    listed_items: dict[str, dict] = {}
     if not isinstance(files, list) or not files:
         errors.append("manifest.json files must be a non-empty array")
     else:
@@ -104,11 +159,45 @@ def refresh_ready_package(root: Path, manifest_path: Path, manifest: dict) -> in
             if not isinstance(item, dict) or not item.get("path"):
                 errors.append("manifest.json contains a file entry without a path")
                 continue
-            rel = str(item["path"])
+            rel, path, path_error = safe_manifest_path(root, item["path"])
+            if path_error:
+                errors.append(path_error)
+                continue
+            assert rel is not None and path is not None
+            item["path"] = rel
+            if rel in listed_items:
+                errors.append(f"manifest.json contains duplicate file entries: {rel}")
+                continue
+            listed_items[rel] = item
             if rel == "manifest.json":
                 continue
-            if not (root / rel).is_file():
+            if not path.is_file():
                 errors.append(f"manifest.json lists a missing file: {rel}")
+
+    if translation_language and strict_bilingual:
+        bilingual_primary_files = [*sorted(DISPLAY_BASE_FILES), *sorted(FIGURES)]
+        for rel in bilingual_primary_files:
+            primary_item = listed_items.get(rel)
+            if primary_item is None:
+                errors.append(f"manifest.json must list the required display file: {rel}")
+                continue
+            if rel.startswith("assets/figures/") and primary_item.get("language") == "neutral":
+                continue
+            translated_rel = localized_path(rel, translation_language)
+            translated_path = root / translated_rel
+            if not translated_path.is_file():
+                errors.append(f"required bilingual counterpart is missing: {translated_rel}")
+                continue
+            translated_item = listed_items.get(translated_rel)
+            if translated_item is None:
+                errors.append(f"manifest.json must list the required bilingual counterpart: {translated_rel}")
+                continue
+            if translated_item.get("language") != translation_language:
+                errors.append(f"{translated_rel} must declare language: {translation_language}")
+            if translated_item.get("translation_of") != rel:
+                errors.append(f"{translated_rel} must declare translation_of: {rel}")
+            if translated_rel.endswith(".pdf") and is_empty_pdf(translated_path.read_bytes()):
+                errors.append(f"{translated_rel} has no pages or is still a placeholder drawing")
 
     if errors:
         print("Ready package was not refreshed:")
@@ -116,6 +205,7 @@ def refresh_ready_package(root: Path, manifest_path: Path, manifest: dict) -> in
             print(f"- {error}")
         return 1
 
+    invalidate_self_check(root)
     for item in manifest["files"]:
         if not isinstance(item, dict):
             continue

--- a/scripts/finalize_submission.py
+++ b/scripts/finalize_submission.py
@@ -81,8 +81,8 @@ def safe_fixed_package_path(root: Path, relative_path: str) -> Path:
     return path
 
 
-def invalidate_self_check(root: Path) -> None:
-    """Make a persisted self-check fail closed after any package refresh."""
+def invalidated_self_check_bytes(root: Path) -> bytes:
+    """Build the fail-closed self-check payload for a package refresh."""
     path = safe_fixed_package_path(root, "self_check.json")
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
@@ -111,7 +111,7 @@ def invalidate_self_check(root: Path) -> None:
         }
     )
     data["checks"] = checks
-    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return (json.dumps(data, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
 
 
 def refresh_ready_package(root: Path, manifest_path: Path, manifest: dict) -> int:
@@ -125,12 +125,21 @@ def refresh_ready_package(root: Path, manifest_path: Path, manifest: dict) -> in
     persisted validation claim stale until self-check is run again.
     """
     errors: list[str] = []
+
+    def fixed_path(relative_path: str) -> Path | None:
+        try:
+            return safe_fixed_package_path(root, relative_path)
+        except ValueError as exc:
+            errors.append(str(exc))
+            return None
+
     try:
-        safe_fixed_package_path(root, "self_check.json")
+        self_check_path = safe_fixed_package_path(root, "self_check.json")
     except ValueError as exc:
         errors.append(str(exc))
-    proposal_path = root / "proposal.md"
-    if not proposal_path.is_file():
+        self_check_path = root / "self_check.json"
+    proposal_path = fixed_path("proposal.md")
+    if proposal_path is None or not proposal_path.is_file():
         errors.append("proposal.md is required for refresh")
         proposal_text = ""
     else:
@@ -139,8 +148,8 @@ def refresh_ready_package(root: Path, manifest_path: Path, manifest: dict) -> in
         if marker in proposal_text:
             errors.append(f"proposal.md still contains the generated placeholder marker: {marker}")
     for rel in [*FIGURES, *DRAWINGS, *READABLE_OUTPUTS]:
-        path = root / rel
-        if not path.is_file():
+        path = fixed_path(rel)
+        if path is None or not path.is_file():
             errors.append(f"required review artifact is missing: {rel}")
         elif rel in DRAWINGS and is_empty_pdf(path.read_bytes()):
             errors.append(f"{rel} has no pages or is still a placeholder drawing")
@@ -155,8 +164,8 @@ def refresh_ready_package(root: Path, manifest_path: Path, manifest: dict) -> in
             errors.append(
                 f"proposal.md must declare translation_file: {expected_translation} for the required bilingual package"
             )
-        translated_path = root / expected_translation
-        if not translated_path.is_file():
+        translated_path = fixed_path(expected_translation)
+        if translated_path is None or not translated_path.is_file():
             errors.append(f"required bilingual counterpart is missing: {expected_translation}")
         else:
             try:
@@ -205,8 +214,8 @@ def refresh_ready_package(root: Path, manifest_path: Path, manifest: dict) -> in
             if rel.startswith("assets/figures/") and primary_item.get("language") == "neutral":
                 continue
             translated_rel = localized_path(rel, translation_language)
-            translated_path = root / translated_rel
-            if not translated_path.is_file():
+            translated_path = fixed_path(translated_rel)
+            if translated_path is None or not translated_path.is_file():
                 errors.append(f"required bilingual counterpart is missing: {translated_rel}")
                 continue
             translated_item = listed_items.get(translated_rel)
@@ -226,19 +235,47 @@ def refresh_ready_package(root: Path, manifest_path: Path, manifest: dict) -> in
             print(f"- {error}")
         return 1
 
-    invalidate_self_check(root)
+    try:
+        original_manifest = manifest_path.read_bytes()
+        original_self_check = self_check_path.read_bytes()
+        refreshed_self_check = invalidated_self_check_bytes(root)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        print(f"Ready package was not refreshed: cannot prepare transactional update: {exc}")
+        return 1
+
     for item in manifest["files"]:
         if not isinstance(item, dict):
             continue
         rel = item.get("path")
-        if rel and rel != "manifest.json" and (root / rel).is_file():
-            item["sha256"] = digest(root / rel)
+        if not rel or rel == "manifest.json":
+            continue
+        if rel == "self_check.json":
+            item["sha256"] = hashlib.sha256(refreshed_self_check).hexdigest()
+            continue
+        _, path, path_error = safe_manifest_path(root, rel)
+        if path_error is None and path is not None and path.is_file():
+            item["sha256"] = digest(path)
     claim = manifest.get("validation_claim")
     if not isinstance(claim, dict):
         claim = {}
         manifest["validation_claim"] = claim
     claim["self_checked"] = False
-    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    refreshed_manifest = (json.dumps(manifest, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+    try:
+        self_check_path.write_bytes(refreshed_self_check)
+        manifest_path.write_bytes(refreshed_manifest)
+    except OSError as exc:
+        try:
+            self_check_path.write_bytes(original_self_check)
+            manifest_path.write_bytes(original_manifest)
+        except OSError as rollback_exc:
+            print(
+                "Ready package refresh failed and rollback was incomplete: "
+                f"{exc}; rollback error: {rollback_exc}"
+            )
+            return 1
+        print(f"Ready package was not refreshed; transactional update rolled back: {exc}")
+        return 1
     print(f"Refreshed review-ready package: {root}")
     print(
         "Run self_check_submission.py --mark-self-checked now; the persisted validation "

--- a/scripts/finalize_submission.py
+++ b/scripts/finalize_submission.py
@@ -65,9 +65,25 @@ def safe_manifest_path(root: Path, raw_path: object) -> tuple[str | None, Path |
     return rel, path, None
 
 
+def safe_fixed_package_path(root: Path, relative_path: str) -> Path:
+    """Resolve a fixed package file without following a contributor symlink."""
+    linked = first_symbolic_link(root, relative_path)
+    if linked is not None:
+        linked_rel = linked.relative_to(root).as_posix()
+        raise ValueError(
+            f"fixed package path traverses symbolic link: {relative_path} (via {linked_rel})"
+        )
+    path = root / relative_path
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError as exc:
+        raise ValueError(f"fixed package path resolves outside the package: {relative_path}") from exc
+    return path
+
+
 def invalidate_self_check(root: Path) -> None:
     """Make a persisted self-check fail closed after any package refresh."""
-    path = root / "self_check.json"
+    path = safe_fixed_package_path(root, "self_check.json")
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
@@ -90,6 +106,7 @@ def invalidate_self_check(root: Path) -> None:
             "check_id": "REFRESH_INVALIDATED",
             "result": "fail",
             "severity": "blocking",
+            "target": "self_check.json",
             "message": "Package files changed; rerun scripts/self_check_submission.py before formal review.",
         }
     )
@@ -108,6 +125,10 @@ def refresh_ready_package(root: Path, manifest_path: Path, manifest: dict) -> in
     persisted validation claim stale until self-check is run again.
     """
     errors: list[str] = []
+    try:
+        safe_fixed_package_path(root, "self_check.json")
+    except ValueError as exc:
+        errors.append(str(exc))
     proposal_path = root / "proposal.md"
     if not proposal_path.is_file():
         errors.append("proposal.md is required for refresh")
@@ -219,7 +240,10 @@ def refresh_ready_package(root: Path, manifest_path: Path, manifest: dict) -> in
     claim["self_checked"] = False
     manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     print(f"Refreshed review-ready package: {root}")
-    print("Run self_check_submission.py now; the persisted validation claim is stale until it passes again.")
+    print(
+        "Run self_check_submission.py --mark-self-checked now; the persisted validation "
+        "claim remains pending until the passing four-gate report is persisted."
+    )
     return 0
 
 
@@ -233,7 +257,10 @@ def main() -> int:
     )
     args = parser.parse_args()
     root = Path(args.submission_dir).resolve()
-    manifest_path = root / "manifest.json"
+    try:
+        manifest_path = safe_fixed_package_path(root, "manifest.json")
+    except ValueError as exc:
+        parser.error(str(exc))
     if not manifest_path.is_file():
         parser.error(f"manifest.json not found under {root}")
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))

--- a/scripts/finalize_submission.py
+++ b/scripts/finalize_submission.py
@@ -36,23 +36,126 @@ DESIGN_GEOMETRY = [
 ]
 DRAWINGS = ["drawings/a3-booklet.pdf", "drawings/a0-boards.pdf"]
 READABLE_OUTPUTS = ["proposal.md", "report/proposal.html", "visual/index.html"]
+REFRESH_PLACEHOLDER_MARKERS = ("SCAFFOLD-DRAFT", "PARTICIPANT-DESIGN: replace")
 
 
 def digest(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def refresh_ready_package(root: Path, manifest_path: Path, manifest: dict) -> int:
+    """Refresh hashes for a ready package after a participant revision.
+
+    A ready package has already passed the scaffold-to-submission promotion
+    checks.  Re-running those checks would reject a legitimate presentation-
+    only edit because the files are no longer unchanged from the scaffold.
+    Refresh therefore keeps the package state, verifies the anti-placeholder
+    and bilingual metadata boundaries, rewrites declared hashes, and marks the
+    persisted validation claim stale until self-check is run again.
+    """
+    errors: list[str] = []
+    proposal_path = root / "proposal.md"
+    if not proposal_path.is_file():
+        errors.append("proposal.md is required for refresh")
+        proposal_text = ""
+    else:
+        proposal_text = proposal_path.read_text(encoding="utf-8")
+    for marker in REFRESH_PLACEHOLDER_MARKERS:
+        if marker in proposal_text:
+            errors.append(f"proposal.md still contains the generated placeholder marker: {marker}")
+    for rel in [*FIGURES, *DRAWINGS, *READABLE_OUTPUTS]:
+        path = root / rel
+        if not path.is_file():
+            errors.append(f"required review artifact is missing: {rel}")
+        elif rel in DRAWINGS and is_empty_pdf(path.read_bytes()):
+            errors.append(f"{rel} has no pages or is still a placeholder drawing")
+
+    proposal_metadata, _ = parse_front_matter(proposal_text) if proposal_text else ({}, "")
+    primary_language = proposal_metadata.get("language")
+    translation_language = "en" if primary_language == "zh" else "zh" if primary_language == "en" else None
+    strict_bilingual = requires_bilingual_contract(proposal_metadata)
+    if translation_language and strict_bilingual:
+        expected_translation = localized_path("proposal.md", translation_language)
+        if proposal_metadata.get("translation_file") != expected_translation:
+            errors.append(
+                f"proposal.md must declare translation_file: {expected_translation} for the required bilingual package"
+            )
+        translated_path = root / expected_translation
+        if not translated_path.is_file():
+            errors.append(f"required bilingual counterpart is missing: {expected_translation}")
+        else:
+            try:
+                translated_metadata, _ = parse_front_matter(
+                    translated_path.read_text(encoding="utf-8")
+                )
+            except UnicodeDecodeError:
+                errors.append(f"{expected_translation} must be UTF-8 text")
+            else:
+                if translated_metadata.get("language") != translation_language:
+                    errors.append(f"{expected_translation} must declare language: {translation_language}")
+                if translated_metadata.get("translation_of") != "proposal.md":
+                    errors.append(f"{expected_translation} must declare translation_of: proposal.md")
+
+    files = manifest.get("files")
+    if not isinstance(files, list) or not files:
+        errors.append("manifest.json files must be a non-empty array")
+    else:
+        for item in files:
+            if not isinstance(item, dict) or not item.get("path"):
+                errors.append("manifest.json contains a file entry without a path")
+                continue
+            rel = str(item["path"])
+            if rel == "manifest.json":
+                continue
+            if not (root / rel).is_file():
+                errors.append(f"manifest.json lists a missing file: {rel}")
+
+    if errors:
+        print("Ready package was not refreshed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    for item in manifest["files"]:
+        if not isinstance(item, dict):
+            continue
+        rel = item.get("path")
+        if rel and rel != "manifest.json" and (root / rel).is_file():
+            item["sha256"] = digest(root / rel)
+    claim = manifest.get("validation_claim")
+    if not isinstance(claim, dict):
+        claim = {}
+        manifest["validation_claim"] = claim
+    claim["self_checked"] = False
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"Refreshed review-ready package: {root}")
+    print("Run self_check_submission.py now; the persisted validation claim is stale until it passes again.")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("submission_dir")
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="refresh hashes for an existing ready_for_review package after a revision",
+    )
     args = parser.parse_args()
     root = Path(args.submission_dir).resolve()
     manifest_path = root / "manifest.json"
     if not manifest_path.is_file():
         parser.error(f"manifest.json not found under {root}")
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    if manifest.get("package_state") != "scaffold":
+    package_state = manifest.get("package_state")
+    if package_state == "ready_for_review":
+        if not args.refresh:
+            parser.error("package_state is ready_for_review; use --refresh to refresh a revised package")
+        return refresh_ready_package(root, manifest_path, manifest)
+    if package_state != "scaffold":
         parser.error("package_state must be scaffold before finalization")
+    if args.refresh:
+        parser.error("--refresh requires package_state=ready_for_review")
 
     declared = {
         str(item.get("path")): str(item.get("sha256"))

--- a/scripts/generate_submissions_data.py
+++ b/scripts/generate_submissions_data.py
@@ -176,6 +176,26 @@ def known_blockers(manifest: Any) -> list[str]:
     return []
 
 
+def has_stale_self_check_claim(submission_dir: Path, manifest: Any) -> bool:
+    """Treat an explicit refresh invalidation as stale for modern self-checks.
+
+    Older merged packages predate the machine-readable formal-readiness field
+    and commonly carry self_checked=false alongside a legacy self_check.json.
+    Preserve their historical gallery classification; a ready package with a
+    modern self-check result must be re-run after finalize --refresh marks the
+    claim stale.
+    """
+    if not isinstance(manifest, dict) or manifest.get("package_state") != "ready_for_review":
+        return False
+    claim = manifest.get("validation_claim")
+    if not isinstance(claim, dict) or claim.get("self_checked") is not False:
+        return False
+    self_check = read_json(submission_dir / "self_check.json")
+    return isinstance(self_check, dict) and isinstance(
+        self_check.get("can_enter_formal_review"), bool
+    )
+
+
 def feature_collection(path: Path) -> list[dict[str, Any]]:
     data = read_json(path)
     if isinstance(data, dict) and isinstance(data.get("features"), list):
@@ -228,6 +248,8 @@ def classify_submission(submission_dir: Path, manifest: Any) -> str:
     if stage != "formal":
         return "legacy_fixture"
     if not package_complete(submission_dir):
+        return "needs_revision"
+    if has_stale_self_check_claim(submission_dir, manifest):
         return "needs_revision"
     if stored_formal_readiness(submission_dir) is True:
         return "formal_review_ready"

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -30,6 +30,7 @@ from validate_submission import (
     PROTECTED_REVIEW_ARTIFACT_PREFIXES,
     ValidationReport,
     format_report,
+    normalize_changed_path,
     validate_submission,
 )
 
@@ -382,10 +383,10 @@ def safe_manifest_paths(manifest: object) -> set[str]:
         raw = item.get("path") if isinstance(item, dict) else None
         if not isinstance(raw, str):
             continue
-        candidate = PurePosixPath(raw)
-        if candidate.is_absolute() or not candidate.parts or ".." in candidate.parts:
+        try:
+            normalized = normalize_changed_path(raw.replace("\\", "/"))
+        except ValueError:
             continue
-        normalized = candidate.as_posix()
         if normalized in {".", ""}:
             continue
         paths.add(normalized)

--- a/scripts/self_check_submission.py
+++ b/scripts/self_check_submission.py
@@ -13,7 +13,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from validate_submission import PERSISTED_READINESS_CONTRACT
+from validate_submission import PERSISTED_READINESS_CONTRACT, first_symbolic_link
 
 
 REVIEW_DEPENDENCIES = ("shapely", "pyproj", "jsonschema")
@@ -25,6 +25,22 @@ def script_path(repo_root: Path, name: str) -> Path:
     # Keep every subprocess on the same trusted validator version as this
     # entrypoint.  repo_root may be an untrusted or older PR checkout.
     return SCRIPT_DIR / name
+
+
+def safe_package_file(submission_dir: Path, relative_path: str) -> Path:
+    """Resolve a fixed package file without following an unlisted symlink."""
+    linked = first_symbolic_link(submission_dir, relative_path)
+    if linked is not None:
+        linked_rel = linked.relative_to(submission_dir).as_posix()
+        raise ValueError(
+            f"fixed package path traverses symbolic link: {relative_path} (via {linked_rel})"
+        )
+    path = submission_dir / relative_path
+    try:
+        path.resolve().relative_to(submission_dir.resolve())
+    except ValueError as exc:
+        raise ValueError(f"fixed package path resolves outside the package: {relative_path}") from exc
+    return path
 
 
 def run_json_command(command: list[str]) -> dict[str, Any]:
@@ -355,12 +371,12 @@ def mark_self_checked(submission_dir: Path, report: dict[str, Any]) -> tuple[boo
     """Persist the passing four-gate report and its manifest claim atomically enough to retry safely."""
     if report.get("can_enter_formal_review") is not True:
         return False, "cannot mark self_checked unless can_enter_formal_review=true"
-    manifest_path = submission_dir / "manifest.json"
-    self_check_path = submission_dir / "self_check.json"
     try:
+        manifest_path = safe_package_file(submission_dir, "manifest.json")
+        self_check_path = safe_package_file(submission_dir, "self_check.json")
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         existing_self_check = json.loads(self_check_path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
         return False, f"cannot read manifest.json or self_check.json: {exc}"
     claim = manifest.get("validation_claim")
     if not isinstance(claim, dict):

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1668,6 +1668,19 @@ def validate_self_check_file(
     return data
 
 
+def self_check_claim_is_stale(manifest: dict | None, self_check: object) -> bool:
+    """Detect a modern self-check result invalidated by a later package refresh."""
+    if not isinstance(manifest, dict) or manifest.get("package_state") != "ready_for_review":
+        return False
+    claim = manifest.get("validation_claim")
+    return (
+        isinstance(claim, dict)
+        and claim.get("self_checked") is False
+        and isinstance(self_check, dict)
+        and isinstance(self_check.get("can_enter_formal_review"), bool)
+    )
+
+
 def collect_json_ids(data: object, list_key: str, id_key: str) -> set[str]:
     if not isinstance(data, dict):
         return set()
@@ -2064,6 +2077,11 @@ def validate_ai_package_dir(
             stage,
             allow_pending_self_check=allow_pending_self_check,
         )
+        if self_check_claim_is_stale(manifest, self_check) and not allow_pending_self_check:
+            report.add_error(
+                f"{proposal_dir}/manifest.json: validation_claim.self_checked=false; "
+                "rerun self_check_submission.py after the latest package refresh"
+            )
     validate_readiness_claim(
         report,
         proposal_dir,

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -386,6 +386,61 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
             self.assertEqual("proposal.md", items["proposal.en.md"]["translation_of"])
             self.assertEqual("report/proposal.html", items["report/proposal.en.html"]["translation_of"])
 
+    def test_refresh_updates_ready_package_hashes_and_stales_validation_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission_dir = root / "submissions" / "alice" / "refreshable"
+            write_official_site_package(root)
+            scaffold = run_scaffold(submission_dir, cwd=root)
+            self.assertEqual(0, scaffold.returncode, scaffold.stdout + scaffold.stderr)
+            finalized = complete_scaffold(submission_dir)
+            self.assertEqual(0, finalized.returncode, finalized.stdout + finalized.stderr)
+
+            proposal = submission_dir / "proposal.md"
+            proposal.write_text(
+                proposal.read_text(encoding="utf-8").replace(
+                    "PARTICIPANT-DESIGN: replace", "PARTICIPANT-DESIGN: refreshed"
+                ),
+                encoding="utf-8",
+            )
+
+            manifest_path = submission_dir / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["validation_claim"]["self_checked"] = True
+            manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+            before = json.loads(manifest_path.read_text(encoding="utf-8"))
+            old_digest = next(item["sha256"] for item in before["files"] if item["path"] == "visual/index.html")
+
+            visual = submission_dir / "visual" / "index.html"
+            visual.write_text(visual.read_text(encoding="utf-8") + "\n<!-- presentation refresh -->\n", encoding="utf-8")
+            rejected = subprocess.run(
+                [sys.executable, str(REPO_ROOT / "scripts" / "finalize_submission.py"), str(submission_dir)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(0, rejected.returncode)
+            self.assertIn("use --refresh", rejected.stderr)
+
+            refreshed = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "finalize_submission.py"),
+                    str(submission_dir),
+                    "--refresh",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(0, refreshed.returncode, refreshed.stdout + refreshed.stderr)
+            after = json.loads(manifest_path.read_text(encoding="utf-8"))
+            new_digest = next(item["sha256"] for item in after["files"] if item["path"] == "visual/index.html")
+            self.assertNotEqual(old_digest, new_digest)
+            self.assertEqual(new_digest, hashlib.sha256(visual.read_bytes()).hexdigest())
+            self.assertEqual("ready_for_review", after["package_state"])
+            self.assertFalse(after["validation_claim"]["self_checked"])
+
     def test_finalize_preserves_localized_figure_language_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             output_dir = Path(tmp) / "submissions" / "alice" / "bilingual-figures"

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -456,6 +456,54 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
 
             self.assertEqual("needs_revision", classify_submission(submission_dir, after))
 
+            marked = mark_self_checked(submission_dir)
+            self.assertEqual(0, marked.returncode, marked.stdout + marked.stderr)
+            refreshed_self_check = json.loads(
+                (submission_dir / "self_check.json").read_text(encoding="utf-8")
+            )
+            refreshed_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertTrue(refreshed_self_check["ok"])
+            self.assertTrue(refreshed_self_check["can_enter_formal_review"])
+            self.assertTrue(refreshed_manifest["validation_claim"]["self_checked"])
+            self.assertEqual(
+                "persisted-self-check-v1",
+                refreshed_manifest["validation_claim"]["readiness_contract"],
+            )
+            self.assertEqual(
+                "formal_review_ready",
+                classify_submission(submission_dir, refreshed_manifest),
+            )
+
+    def test_refresh_rejects_unlisted_self_check_symlink_before_write(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission_dir = root / "submissions" / "alice" / "unsafe-self-check"
+            write_official_site_package(root)
+            self.assertEqual(run_scaffold(submission_dir, cwd=root).returncode, 0)
+            self.assertEqual(complete_scaffold(submission_dir).returncode, 0)
+
+            outside = root / "outside-self-check.json"
+            sentinel = b'{"sentinel":"unchanged"}\n'
+            outside.write_bytes(sentinel)
+            self_check_path = submission_dir / "self_check.json"
+            self_check_path.unlink()
+            self_check_path.symlink_to(outside)
+
+            refreshed = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "finalize_submission.py"),
+                    str(submission_dir),
+                    "--refresh",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(0, refreshed.returncode)
+            self.assertIn("fixed package path traverses symbolic link", refreshed.stdout)
+            self.assertEqual(sentinel, outside.read_bytes())
+
     def test_refresh_rejects_missing_bilingual_companion_or_manifest_entry(self) -> None:
         for missing_manifest_entry in [True, False]:
             with self.subTest(missing_manifest_entry=missing_manifest_entry):

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -440,6 +440,109 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
             self.assertEqual(new_digest, hashlib.sha256(visual.read_bytes()).hexdigest())
             self.assertEqual("ready_for_review", after["package_state"])
             self.assertFalse(after["validation_claim"]["self_checked"])
+            self_check = json.loads((submission_dir / "self_check.json").read_text(encoding="utf-8"))
+            self.assertFalse(self_check["ok"])
+            self.assertFalse(self_check["can_enter_formal_review"])
+            self.assertEqual("revision-requested", self_check["review_status"])
+            self.assertTrue(
+                any(
+                    item.get("check_id") == "REFRESH_INVALIDATED"
+                    and item.get("severity") == "blocking"
+                    for item in self_check["checks"]
+                    if isinstance(item, dict)
+                )
+            )
+            from generate_submissions_data import classify_submission
+
+            self.assertEqual("needs_revision", classify_submission(submission_dir, after))
+
+    def test_refresh_rejects_missing_bilingual_companion_or_manifest_entry(self) -> None:
+        for missing_manifest_entry in [True, False]:
+            with self.subTest(missing_manifest_entry=missing_manifest_entry):
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = Path(tmp)
+                    submission_dir = root / "submissions" / "alice" / "bilingual-refresh"
+                    write_official_site_package(root)
+                    scaffold = run_scaffold(submission_dir, cwd=root)
+                    self.assertEqual(0, scaffold.returncode, scaffold.stdout + scaffold.stderr)
+                    finalized = complete_scaffold(submission_dir)
+                    self.assertEqual(0, finalized.returncode, finalized.stdout + finalized.stderr)
+
+                    manifest_path = submission_dir / "manifest.json"
+                    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+                    if missing_manifest_entry:
+                        manifest["files"] = [
+                            item
+                            for item in manifest["files"]
+                            if item.get("path") != "visual/index.en.html"
+                        ]
+                    else:
+                        (submission_dir / "visual" / "index.en.html").unlink()
+                    manifest_path.write_text(
+                        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+                    )
+
+                    refreshed = subprocess.run(
+                        [
+                            sys.executable,
+                            str(REPO_ROOT / "scripts" / "finalize_submission.py"),
+                            str(submission_dir),
+                            "--refresh",
+                        ],
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+                    self.assertNotEqual(0, refreshed.returncode)
+                    output = refreshed.stdout + refreshed.stderr
+                    if missing_manifest_entry:
+                        self.assertIn("manifest.json must list the required bilingual counterpart", output)
+                    else:
+                        self.assertIn("required bilingual counterpart is missing", output)
+
+    def test_refresh_rejects_manifest_traversal_and_symbolic_links(self) -> None:
+        for symbolic_link in [False, True]:
+            with self.subTest(symbolic_link=symbolic_link):
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = Path(tmp)
+                    submission_dir = root / "submissions" / "alice" / "unsafe-refresh"
+                    write_official_site_package(root)
+                    scaffold = run_scaffold(submission_dir, cwd=root)
+                    self.assertEqual(0, scaffold.returncode, scaffold.stdout + scaffold.stderr)
+                    finalized = complete_scaffold(submission_dir)
+                    self.assertEqual(0, finalized.returncode, finalized.stdout + finalized.stderr)
+
+                    manifest_path = submission_dir / "manifest.json"
+                    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+                    if symbolic_link:
+                        outside = root / "outside-visual.html"
+                        outside.write_text("outside package", encoding="utf-8")
+                        visual = submission_dir / "visual" / "index.html"
+                        visual.unlink()
+                        visual.symlink_to(outside)
+                    else:
+                        manifest["files"][0]["path"] = "../outside.txt"
+                    manifest_path.write_text(
+                        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+                    )
+
+                    refreshed = subprocess.run(
+                        [
+                            sys.executable,
+                            str(REPO_ROOT / "scripts" / "finalize_submission.py"),
+                            str(submission_dir),
+                            "--refresh",
+                        ],
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+                    self.assertNotEqual(0, refreshed.returncode)
+                    output = refreshed.stdout + refreshed.stderr
+                    if symbolic_link:
+                        self.assertIn("manifest.json path traverses symbolic link", output)
+                    else:
+                        self.assertIn("unsafe file path", output)
 
     def test_finalize_preserves_localized_figure_language_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -24,6 +24,7 @@ if HAS_REVIEW_DEPS:
     from shapely.ops import transform  # noqa: E402
 
 from self_check_submission import run_json_command  # noqa: E402
+from finalize_submission import refresh_ready_package  # noqa: E402
 
 
 class AgentFacingDocsTests(unittest.TestCase):
@@ -512,6 +513,45 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
             self.assertNotEqual(0, refreshed.returncode)
             self.assertIn("fixed package path traverses symbolic link", refreshed.stdout)
             self.assertEqual(sentinel, outside.read_bytes())
+
+    def test_refresh_rolls_back_when_manifest_write_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission_dir = root / "submissions" / "alice" / "transactional-refresh"
+            write_official_site_package(root)
+            self.assertEqual(run_scaffold(submission_dir, cwd=root).returncode, 0)
+            self.assertEqual(complete_scaffold(submission_dir).returncode, 0)
+            proposal_path = submission_dir / "proposal.md"
+            proposal_path.write_text(
+                proposal_path.read_text(encoding="utf-8").replace(
+                    "PARTICIPANT-DESIGN: replace", "PARTICIPANT-DESIGN: transactional refresh"
+                ),
+                encoding="utf-8",
+            )
+
+            manifest_path = submission_dir / "manifest.json"
+            self_check_path = submission_dir / "self_check.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            original_manifest = manifest_path.read_bytes()
+            original_self_check = self_check_path.read_bytes()
+            original_write_bytes = Path.write_bytes
+            write_count = 0
+
+            def fail_manifest_once(data: bytes) -> int:
+                nonlocal write_count
+                write_count += 1
+                if write_count == 2:
+                    raise OSError("simulated manifest write failure")
+                target = self_check_path if write_count in {1, 3} else manifest_path
+                return original_write_bytes(target, data)
+
+            with mock.patch.object(Path, "write_bytes", side_effect=fail_manifest_once):
+                result = refresh_ready_package(submission_dir, manifest_path, manifest)
+
+            self.assertEqual(1, result)
+            self.assertEqual(4, write_count)
+            self.assertEqual(original_manifest, manifest_path.read_bytes())
+            self.assertEqual(original_self_check, self_check_path.read_bytes())
 
     def test_refresh_rejects_missing_bilingual_companion_or_manifest_entry(self) -> None:
         for missing_manifest_entry in [True, False]:

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -544,6 +544,87 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
                     else:
                         self.assertIn("unsafe file path", output)
 
+    def test_refresh_rejects_manifest_path_escape_and_symbolic_link(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission_dir = root / "submissions" / "alice" / "unsafe-refresh"
+            write_official_site_package(root)
+            scaffold = run_scaffold(submission_dir, cwd=root)
+            self.assertEqual(0, scaffold.returncode, scaffold.stdout + scaffold.stderr)
+            finalized = complete_scaffold(submission_dir)
+            self.assertEqual(0, finalized.returncode, finalized.stdout + finalized.stderr)
+
+            manifest_path = submission_dir / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["files"].append({"path": "../outside.txt", "sha256": "0" * 64})
+            manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+            escaped = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "finalize_submission.py"),
+                    str(submission_dir),
+                    "--refresh",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(0, escaped.returncode)
+            self.assertIn("unsafe path", escaped.stdout)
+
+            manifest["files"] = [item for item in manifest["files"] if item.get("path") != "../outside.txt"]
+            outside = root / "outside.png"
+            outside.write_bytes(b"outside")
+            linked = submission_dir / "assets" / "figures" / "escape.png"
+            linked.symlink_to(outside)
+            manifest["files"].append({"path": "assets/figures/escape.png", "sha256": "0" * 64})
+            manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+            symlinked = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "finalize_submission.py"),
+                    str(submission_dir),
+                    "--refresh",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(0, symlinked.returncode)
+            self.assertIn("symbolic link", symlinked.stdout)
+
+    def test_refresh_rejects_removed_bilingual_display_counterpart(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission_dir = root / "submissions" / "alice" / "missing-counterpart"
+            write_official_site_package(root)
+            scaffold = run_scaffold(submission_dir, cwd=root)
+            self.assertEqual(0, scaffold.returncode, scaffold.stdout + scaffold.stderr)
+            finalized = complete_scaffold(submission_dir)
+            self.assertEqual(0, finalized.returncode, finalized.stdout + finalized.stderr)
+
+            translated_html = submission_dir / "report" / "proposal.en.html"
+            translated_html.unlink()
+            manifest_path = submission_dir / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["files"] = [
+                item for item in manifest["files"] if item.get("path") != "report/proposal.en.html"
+            ]
+            manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+            refreshed = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "finalize_submission.py"),
+                    str(submission_dir),
+                    "--refresh",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(0, refreshed.returncode)
+            self.assertIn("required bilingual counterpart is missing", refreshed.stdout)
+
     def test_finalize_preserves_localized_figure_language_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             output_dir = Path(tmp) / "submissions" / "alice" / "bilingual-figures"

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -482,6 +482,15 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
             self.assertEqual(run_scaffold(submission_dir, cwd=root).returncode, 0)
             self.assertEqual(complete_scaffold(submission_dir).returncode, 0)
 
+            manifest_path = submission_dir / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["files"] = [
+                item for item in manifest["files"] if item.get("path") != "self_check.json"
+            ]
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
             outside = root / "outside-self-check.json"
             sentinel = b'{"sentinel":"unchanged"}\n'
             outside.write_bytes(sentinel)

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -2149,6 +2149,29 @@ class SubmissionWorkflowTests(unittest.TestCase):
             report = validate_submission(root, "alice", [f"{base}/manifest.json"])
             self.assertTrue(report.ok, report.errors)
 
+    def test_refresh_invalidated_self_check_blocks_modern_formal_package(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            self.promote_package_to_formal(root, base)
+            manifest_path = root / base / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["package_state"] = "ready_for_review"
+            manifest["validation_claim"]["self_checked"] = False
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+            )
+            self_check_path = root / base / "self_check.json"
+            self_check = json.loads(self_check_path.read_text(encoding="utf-8"))
+            self_check["can_enter_formal_review"] = True
+            self_check_path.write_text(
+                json.dumps(self_check, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+            )
+            report = validate_submission(root, "alice", changed + [f"{base}/manifest.json"])
+            self.assertFalse(report.ok)
+            self.assertIn("self_checked=false", "\n".join(report.errors))
+
     def test_bilingual_contract_manifest_only_update_rechecks_full_package(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -2158,6 +2158,7 @@ class SubmissionWorkflowTests(unittest.TestCase):
             manifest_path = root / base / "manifest.json"
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
             manifest["package_state"] = "ready_for_review"
+            manifest["validation_claim"]["readiness_contract"] = "persisted-self-check-v1"
             manifest["validation_claim"]["self_checked"] = False
             manifest_path.write_text(
                 json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
@@ -2170,7 +2171,7 @@ class SubmissionWorkflowTests(unittest.TestCase):
             )
             report = validate_submission(root, "alice", changed + [f"{base}/manifest.json"])
             self.assertFalse(report.ok)
-            self.assertIn("self_checked=false", "\n".join(report.errors))
+            self.assertIn("must set validation_claim.self_checked=true", "\n".join(report.errors))
 
     def test_bilingual_contract_manifest_only_update_rechecks_full_package(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_submissions_gallery.py
+++ b/tests/test_submissions_gallery.py
@@ -6,6 +6,7 @@ import unittest
 import tempfile
 from pathlib import Path
 from urllib.parse import urlsplit
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -13,6 +14,7 @@ sys.path.insert(0, str(ROOT / "scripts"))
 from generate_submissions_data import (  # noqa: E402
     build_data,
     build_item,
+    classify_submission,
     discover_submissions,
     load_publication_registry,
     package_sha256,
@@ -81,6 +83,43 @@ class TestSubmissionsGallery(unittest.TestCase):
                 "proposal-view.html?proposal=submissions/alice/example",
                 items[0]["proposalUrl"],
             )
+
+    def test_refresh_invalidates_modern_self_check_until_rerun(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission = root / "submissions" / "alice" / "refreshable"
+            submission.mkdir(parents=True)
+            (submission / "self_check.json").write_text(
+                json.dumps({"can_enter_formal_review": True}), encoding="utf-8"
+            )
+            manifest = {
+                "submission_stage": "formal",
+                "package_state": "ready_for_review",
+                "validation_claim": {"self_checked": False, "known_blockers": []},
+            }
+            with patch("generate_submissions_data.package_complete", return_value=True), patch(
+                "generate_submissions_data.stored_formal_readiness", return_value=True
+            ):
+                self.assertEqual("needs_revision", classify_submission(submission, manifest))
+
+    def test_legacy_self_check_without_formal_readiness_keeps_compatibility(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission = root / "submissions" / "alice" / "legacy"
+            submission.mkdir(parents=True)
+            (submission / "self_check.json").write_text(
+                json.dumps({"checks": [{"result": "pass", "severity": "info"}]}),
+                encoding="utf-8",
+            )
+            manifest = {
+                "submission_stage": "formal",
+                "package_state": "ready_for_review",
+                "validation_claim": {"self_checked": False, "known_blockers": []},
+            }
+            with patch("generate_submissions_data.package_complete", return_value=True), patch(
+                "generate_submissions_data.stored_formal_readiness", return_value=None
+            ):
+                self.assertEqual("formal_review_ready", classify_submission(submission, manifest))
 
     def test_registry_can_explicitly_hold_a_merged_submission(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Problem\n\nAddresses #953. finalize_submission.py only accepted package_state=scaffold, so a legitimate presentation-only edit to an existing ready_for_review package could not refresh its manifest without hand-editing hashes.\n\n## Fix\n\n- Add an explicit --refresh mode for ready_for_review packages.\n- Preserve package_state, rerun anti-placeholder, required-artifact, bilingual metadata, and zero-page drawing checks.\n- Recompute declared SHA-256 entries from the current package contents.\n- Reset validation_claim.self_checked to false so the contributor must rerun self_check_submission.py.\n- Keep the original scaffold promotion path unchanged; --refresh cannot be used on a scaffold.\n\n## Verification\n\n- 124 focused workflow/self-check/prelaunch tests passed.\n- Touched Python compile and git diff --check passed.\n\nThis is fail-closed: refresh does not claim a package is trusted or formal-ready; it only creates a reproducible manifest state for the next self-check.