### PR TITLE
fix(validation): block cross-author submission changes

### DIFF
--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -148,6 +148,30 @@ class GitHubClient:
             url = next_link(headers.get("Link", ""))
         return results
 
+    def tree_blob_map(self, sha: str) -> dict[str, str]:
+        """Return the recursive blob map for a trusted base or head commit."""
+        encoded_sha = urllib.parse.quote(sha, safe="")
+        data, _ = self.request(
+            "GET",
+            f"/repos/{self.repository}/git/trees/{encoded_sha}?recursive=1",
+        )
+        if not isinstance(data, dict) or data.get("truncated"):
+            raise RuntimeError(
+                f"GitHub tree response for `{sha}` was missing or truncated"
+            )
+        entries = data.get("tree")
+        if not isinstance(entries, list):
+            raise RuntimeError(f"GitHub tree response for `{sha}` was malformed")
+        blobs: dict[str, str] = {}
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            path = entry.get("path")
+            blob_sha = entry.get("sha")
+            if entry.get("type") == "blob" and isinstance(path, str) and isinstance(blob_sha, str):
+                blobs[path] = blob_sha
+        return blobs
+
     def download_content(
         self,
         repo: str,
@@ -281,6 +305,67 @@ def validation_paths_for(files: list[dict], maintainer_bypass: bool) -> list[str
         for item in files
         if item.get("status") != "removed"
     ]
+
+
+def submission_scope_violations(
+    files: list[dict], pr_author: str, maintainer_bypass: bool
+) -> list[str]:
+    """Return participant-submission paths outside the PR author's directory.
+
+    GitHub reports the current path in ``filename`` and the old path in
+    ``previous_filename`` for renames.  Both paths matter: otherwise a
+    participant can rename or delete another author's submission while the
+    validator only hydrates and validates the new, participant-owned files.
+    Maintainer-authorized PRs retain an explicit bypass for repository-wide
+    maintenance.
+    """
+    if maintainer_bypass:
+        return []
+
+    author = pr_author.casefold()
+    violations: set[str] = set()
+    for item in files:
+        for key in ("filename", "previous_filename"):
+            path = item.get(key)
+            if not isinstance(path, str):
+                continue
+            parts = path.split("/")
+            if not parts or parts[0] != "submissions":
+                continue
+            if len(parts) < 2 or parts[1].casefold() != author:
+                violations.add(path)
+    return sorted(violations)
+
+
+def submission_tree_scope_violations(
+    base_tree: dict[str, str],
+    head_tree: dict[str, str],
+    pr_author: str,
+    maintainer_bypass: bool,
+) -> list[str]:
+    """Return changed submission paths outside the participant's own scope.
+
+    This catches deletions hidden by a pull request's merge-base calculation,
+    including a branch based on the first parent of a merge commit.
+    """
+    if maintainer_bypass:
+        return []
+
+    author = pr_author.casefold()
+    changed_paths = {
+        path
+        for path in base_tree.keys() | head_tree.keys()
+        if base_tree.get(path) != head_tree.get(path)
+    }
+    violations = {
+        path
+        for path in changed_paths
+        if (
+            path.split("/")[0] == "submissions"
+            and (len(path.split("/")) < 2 or path.split("/")[1].casefold() != author)
+        )
+    }
+    return sorted(violations)
 
 
 def is_review_queue_candidate(changed_files: list[str], pr_author: str) -> bool:
@@ -421,6 +506,7 @@ def main() -> int:
     maintainer_bypass = pr_author.lower() in {item.lower() for item in bypass}
     validation_files = validation_paths_for(files, maintainer_bypass)
     queue_candidate = is_review_queue_candidate(changed_files, pr_author)
+    scope_violations = submission_scope_violations(files, pr_author, maintainer_bypass)
 
     # Code/docs/test PRs do not need participant-package hydration.  Decide
     # this immediately after the file listing so a non-submission change
@@ -447,6 +533,78 @@ def main() -> int:
         write_step_summary(comment)
         client.upsert_comment(pr_number, comment)
         return 0
+
+    scope_verification_error = None
+    base_sha = pull_request.get("base", {}).get("sha")
+    if not maintainer_bypass and isinstance(base_sha, str) and base_sha:
+        try:
+            base_tree = client.tree_blob_map(base_sha)
+            head_tree = client.tree_blob_map(head_sha)
+            scope_violations.extend(
+                submission_tree_scope_violations(
+                    base_tree,
+                    head_tree,
+                    pr_author,
+                    maintainer_bypass,
+                )
+            )
+            scope_violations = sorted(set(scope_violations))
+        except RuntimeError as exc:
+            scope_verification_error = str(exc)
+
+    if scope_verification_error:
+        validation = ValidationReport(
+            changed_files=changed_files,
+            maintainer_bypass=maintainer_bypass,
+        )
+        validation.add_error(
+            "submission path ownership could not be verified: "
+            f"{scope_verification_error}"
+        )
+        validation_markdown = format_report(validation)
+        if not is_current_pull_request_head(client, pr_number, head_sha):
+            print(
+                f"Skipping stale validation side effects for PR #{pr_number}: "
+                f"the PR head changed before the submission-scope verification failure was reported."
+            )
+            return 0
+        comment = (
+            f"{COMMENT_MARKER}\n"
+            "# Haidian Submission Validation\n\n"
+            f"{validation_markdown}\n\n"
+            "> This CI check is deterministic. It does not call AI models and does not make content-quality judgments."
+        )
+        write_step_summary(comment)
+        client.upsert_comment(pr_number, comment)
+        return 1
+
+    if scope_violations:
+        validation = ValidationReport(
+            changed_files=changed_files,
+            maintainer_bypass=maintainer_bypass,
+        )
+        for path in scope_violations:
+            validation.add_error(
+                f"{path}: participant PR by `{pr_author}` may only modify paths "
+                f"under `submissions/{pr_author}/`; cross-author submission "
+                "changes require maintainer authorization"
+            )
+        validation_markdown = format_report(validation)
+        if not is_current_pull_request_head(client, pr_number, head_sha):
+            print(
+                f"Skipping stale validation side effects for PR #{pr_number}: "
+                f"the PR head changed before the submission-scope failure was reported."
+            )
+            return 0
+        comment = (
+            f"{COMMENT_MARKER}\n"
+            "# Haidian Submission Validation\n\n"
+            f"{validation_markdown}\n\n"
+            "> This CI check is deterministic. It does not call AI models and does not make content-quality judgments."
+        )
+        write_step_summary(comment)
+        client.upsert_comment(pr_number, comment)
+        return 1
 
     worktree = Path(tempfile.mkdtemp(prefix="haidian-pr-"))
     try:

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -38,6 +38,8 @@ from github_pr_validation import (  # noqa: E402
     is_review_queue_candidate,
     main,
     safe_manifest_paths,
+    submission_scope_violations,
+    submission_tree_scope_violations,
     validation_paths_for,
 )
 from validate_local_submission import discover_submission_files  # noqa: E402
@@ -122,6 +124,47 @@ class GitHubApiResilienceTests(unittest.TestCase):
                 client.request("POST", "/test", {"body": "comment"})
         self.assertEqual(1, urlopen.call_count)
         sleep.assert_not_called()
+
+    def test_tree_blob_map_extracts_blobs_and_rejects_truncation(self) -> None:
+        client = GitHubClient("token", "open-city-ai/haidian")
+        with patch.object(
+            client,
+            "request",
+            return_value=(
+                {
+                    "truncated": False,
+                    "tree": [
+                        {
+                            "path": "submissions/alice/proposal.md",
+                            "type": "blob",
+                            "sha": "blob-sha",
+                        },
+                        {
+                            "path": "submissions/alice",
+                            "type": "tree",
+                            "sha": "tree-sha",
+                        },
+                    ],
+                },
+                {},
+            ),
+        ) as request:
+            self.assertEqual(
+                {"submissions/alice/proposal.md": "blob-sha"},
+                client.tree_blob_map("head-sha"),
+            )
+        request.assert_called_once_with(
+            "GET",
+            "/repos/open-city-ai/haidian/git/trees/head-sha?recursive=1",
+        )
+
+        with patch.object(
+            client,
+            "request",
+            return_value=({"truncated": True, "tree": []}, {}),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "missing or truncated"):
+                client.tree_blob_map("large-sha")
 
     def test_download_404_retries_then_succeeds(self) -> None:
         client = GitHubClient("token", "open-city-ai/haidian")
@@ -424,6 +467,121 @@ class ManifestHydrationTests(unittest.TestCase):
     def test_removed_paths_are_excluded_from_validation_scope(self) -> None:
         files = [{"filename": "submissions/alice/design/proposal.md", "status": "removed"}]
         self.assertEqual([], validation_paths_for(files, False))
+
+    def test_participant_scope_catches_cross_author_delete_and_rename(self) -> None:
+        files = [
+            {"filename": "submissions/bob/old-design/proposal.md", "status": "removed"},
+            {
+                "filename": "submissions/alice/new-design/proposal.md",
+                "previous_filename": "submissions/bob/old-design/proposal.md",
+                "status": "renamed",
+            },
+            {"filename": "submissions/alice/new-design/manifest.json", "status": "added"},
+        ]
+        self.assertEqual(
+            [
+                "submissions/bob/old-design/proposal.md",
+            ],
+            submission_scope_violations(files, "alice", False),
+        )
+        self.assertEqual([], submission_scope_violations(files, "alice", True))
+
+    def test_tree_scope_catches_hidden_cross_author_deletion(self) -> None:
+        base_tree = {
+            "submissions/bob/old-design/proposal.md": "old-blob",
+            "submissions/alice/old-design/manifest.json": "unchanged-blob",
+        }
+        head_tree = {
+            "submissions/alice/new-design/proposal.md": "new-blob",
+            "submissions/alice/old-design/manifest.json": "unchanged-blob",
+        }
+        self.assertEqual(
+            ["submissions/bob/old-design/proposal.md"],
+            submission_tree_scope_violations(base_tree, head_tree, "alice", False),
+        )
+        self.assertEqual(
+            [],
+            submission_tree_scope_violations(base_tree, head_tree, "alice", True),
+        )
+
+    def test_cross_author_submission_change_fails_before_download(self) -> None:
+        event = {
+            "pull_request": {
+                "number": 909,
+                "user": {"login": "alice"},
+                "head": {"repo": {"full_name": "alice/haidian"}, "sha": "head-sha"},
+            }
+        }
+        files = [
+            {"filename": "submissions/bob/old-design/proposal.md", "status": "removed"},
+            {"filename": "submissions/alice/new-design/proposal.md", "status": "added"},
+        ]
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
+            json.dump(event, event_file)
+            event_file.flush()
+            client = MagicMock()
+            client.repository = "open-city-ai/haidian"
+            client.request.return_value = ({"head": {"sha": "head-sha"}}, {})
+            client.paginate.return_value = files
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "token",
+                    "GITHUB_REPOSITORY": "open-city-ai/haidian",
+                    "GITHUB_EVENT_PATH": event_file.name,
+                },
+                clear=False,
+            ), patch("github_pr_validation.GitHubClient", return_value=client):
+                self.assertEqual(1, main())
+        client.download_content.assert_not_called()
+        client.fetch_content.assert_not_called()
+        comment = client.upsert_comment.call_args.args[1]
+        self.assertIn("cross-author submission changes require maintainer authorization", comment)
+
+    def test_tree_guard_catches_deletion_hidden_by_pr_file_listing(self) -> None:
+        event = {
+            "pull_request": {
+                "number": 909,
+                "user": {"login": "alice"},
+                "base": {"sha": "base-sha"},
+                "head": {"repo": {"full_name": "alice/haidian"}, "sha": "head-sha"},
+            }
+        }
+        files = [
+            {"filename": "submissions/alice/new-design/proposal.md", "status": "added"},
+        ]
+        base_tree = {
+            "submissions/bob/old-design/proposal.md": "old-blob",
+        }
+        head_tree = {
+            "submissions/alice/new-design/proposal.md": "new-blob",
+        }
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
+            json.dump(event, event_file)
+            event_file.flush()
+            client = MagicMock()
+            client.repository = "open-city-ai/haidian"
+            client.request.side_effect = [
+                ({"head": {"sha": "head-sha"}}, {}),
+                ({"head": {"sha": "head-sha"}}, {}),
+                ({"head": {"sha": "head-sha"}}, {}),
+            ]
+            client.tree_blob_map.side_effect = [base_tree, head_tree]
+            client.paginate.return_value = files
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "token",
+                    "GITHUB_REPOSITORY": "open-city-ai/haidian",
+                    "GITHUB_EVENT_PATH": event_file.name,
+                },
+                clear=False,
+            ), patch("github_pr_validation.GitHubClient", return_value=client):
+                self.assertEqual(1, main())
+        client.download_content.assert_not_called()
+        client.fetch_content.assert_not_called()
+        comment = client.upsert_comment.call_args.args[1]
+        self.assertIn("submissions/bob/old-design/proposal.md", comment)
 
     def test_participant_deletion_only_pr_is_warning_not_missing_file_failure(self) -> None:
         event = {


### PR DESCRIPTION
## Summary

Closes the participant-scope gap exposed by [#909](https://github.com/open-city-ai/haidian/pull/909). The validator previously used author scope only to decide whether a PR entered the review queue; a mixed-author submission PR could still receive deterministic PASS after the non-author files were excluded from content validation.

## Root cause

- `validation_paths_for()` intentionally omits removed files.
- `is_review_queue_candidate()` returned false for cross-author paths but did not make validation fail.
- GitHub's PR-files endpoint can also hide deletions when a branch is based on the first parent of a merge commit. The exact #909 head showed only 40 added files there, while a base/head Git-tree comparison revealed 40 removed `Waterfak3r` paths.

## Fix

- Add deterministic participant-scope errors for `filename` and `previous_filename`.
- Compare trusted base/head recursive Git trees so hidden deletions and content changes under another participant's directory are detected.
- Preserve maintainer bypass for authorized repository-wide maintenance.
- Fail before downloading or hydrating contributor content when ownership scope is invalid or the tree response is truncated/malformed.

## Evidence

- Live #909 base/head tree replay reports 40 cross-author paths; the prior PR-files list reported none.
- `python3 -m unittest tests.test_submission_workflow tests.test_trusted_review_scripts tests.test_auto_review_queue tests.test_participant_preflight -q` — 123 passed.
- `python3 -m py_compile scripts/github_pr_validation.py` — passed.
- `git diff --check` — passed.

This PR changes only validator code and tests; it does not modify submissions, gallery data, or review decisions.