### PR TITLE
fix(submission): persist Human City self-check evidence

### DIFF
--- a/submissions/147228/jingzhang-human-city-os/changelog.md
+++ b/submissions/147228/jingzhang-human-city-os/changelog.md
@@ -1,5 +1,11 @@
 # 方案迭代记录
 
+## v0.3 - 2026-08-09
+
+- 持久化当前 main 提交上的真实四门自检结果、生成器版本、UTC 时间和 formal-review readiness；这只是本地包证据，不是官方评分或实施批准。
+- 刷新 `self_check.json` 与本变更记录的 manifest 哈希；没有修改几何、指标值、现场绩效、许可、部署或公开排序声明。
+- 继续明确临时边界与重点区的精度限制，三条 `KEY_AREA_PROVISIONAL` 只是不阻断内容评审的提示。
+
 本轮为实质性证据与治理设计迭代，不是公共排序、日期或名称操作；未修改 `submissions-data.js`、`gallery-publication.json`，也未改动其它投稿包。
 
 ## v0.2 - 2026-08-09

--- a/submissions/147228/jingzhang-human-city-os/manifest.json
+++ b/submissions/147228/jingzhang-human-city-os/manifest.json
@@ -12,7 +12,7 @@
     "agent_name": "OpenAI Codex",
     "model": "OpenAI Codex (GPT-5)"
   },
-  "generated_at": "2026-08-09T19:41:50+08:00",
+  "generated_at": "2026-08-09T14:30:24Z",
   "files": [
     {
       "path": "manifest.json",
@@ -54,7 +54,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "80b71cb78d2c1581fc679eb561959ac515bc8a3ff6f76c74dcc2c4e20d49b72f"
+      "sha256": "7dadfa1944bf3f1ddfa2982276c65090b10a3e71ccb2446e4adbf5397f49439f"
     },
     {
       "path": "compliance_matrix.json",
@@ -91,7 +91,7 @@
       "path": "changelog.md",
       "role": "narrative",
       "required": false,
-      "sha256": "cbc4e4a3b41dbd1437a1f48e1d918c25fed569774d631e013c70aeacd941868c"
+      "sha256": "6c81e48f99146f17564d4c745bf033c52e9ab70a9dae18b0f0ff1923a84c7c5a"
     },
     {
       "path": "report/copyright_statement.md",
@@ -370,6 +370,7 @@
   ],
   "validation_claim": {
     "self_checked": true,
+    "readiness_contract": "persisted-self-check-v1",
     "known_blockers": [],
     "data_confidence": "low"
   }

--- a/submissions/147228/jingzhang-human-city-os/self_check.json
+++ b/submissions/147228/jingzhang-human-city-os/self_check.json
@@ -1,6 +1,39 @@
 {
   "schema_version": "0.1.0",
+  "generated_at": "2026-08-09T14:30:24Z",
+  "generator": "scripts/self_check_submission.py@6a32a42890fa169e02f500e894ca04626a38fe40",
+  "ok": true,
+  "can_enter_formal_review": true,
+  "review_status": "formal-review-ready",
+  "package_id": "jingzhang-human-city-os",
+  "gates": {
+    "deterministic_validation": "pass",
+    "spatial_review": "pass",
+    "visual_packaging": "pass",
+    "professional_evidence": "pass"
+  },
   "checks": [
+    {
+      "check_id": "DETERMINISTIC_VALIDATION",
+      "result": "pass",
+      "severity": "blocking",
+      "target": "scripts/validate_local_submission.py",
+      "message": "Trusted deterministic validation passed on the current package bytes."
+    },
+    {
+      "check_id": "SPATIAL_REVIEW",
+      "result": "pass",
+      "severity": "blocking",
+      "target": "scripts/spatial_review.py",
+      "message": "Spatial review passed; provisional key-area notices remain disclosed and non-blocking."
+    },
+    {
+      "check_id": "VISUAL_PACKAGING",
+      "result": "pass",
+      "severity": "blocking",
+      "target": "scripts/visual_review.py",
+      "message": "Offline visual packaging review passed with local assets and metric anchors."
+    },
     {
       "check_id": "BOUNDARY_TRUST",
       "result": "pass",


### PR DESCRIPTION
## Scope

Persist the exact current-branch self-check evidence for `submissions/147228/jingzhang-human-city-os` after the package was merged through #982. This is a package-only revision touching only `self_check.json`, `manifest.json`, and `changelog.md`.

## Why

The package manifest already declared `package_state=ready_for_review` and `validation_claim.self_checked=true`, but its persisted `self_check.json` still contained only legacy checks. That left the public readiness state dependent on fallback classification rather than an auditable four-gate record.

This PR records the real local run with `generated_at`, generator revision, four gate summaries, `can_enter_formal_review=true`, and `review_status=formal-review-ready`; it refreshes the two affected manifest hashes and adds `readiness_contract=persisted-self-check-v1`. It does not add a self-hash, change geometry or metrics, or alter gallery files.

## Verification on exact base `6a32a42890fa169e02f500e894ca04626a38fe40`

- `validate_submission.py`: `ok=true`; only the disclosed provisional-boundary warning remains.
- `self_check_submission.py`: deterministic, spatial, visual-packaging, and professional gates all PASS; three `KEY_AREA_PROVISIONAL` notices remain minor/non-blocking.
- `participant_preflight.py --check-push`: `ok=true`; outside-scope files 0.
- `score_submission.py`: 8 pass / 0 needs-work / 0 missing.
- `git diff --check`: PASS.

This is local package evidence, not official scoring, field performance, implementation approval, rights clearance, or a ranking claim. Related to #883; it does not decide the repository-wide historical migration policy.