### PR TITLE
fix: report malformed public source enum fields

### DIFF
--- a/scripts/validate_sources.py
+++ b/scripts/validate_sources.py
@@ -130,12 +130,12 @@ def validate_source_item(
         seen_ids.add(source_id)
 
     source_type = source.get("type")
-    if source_type and source_type not in ALLOWED_TYPES:
+    if isinstance(source_type, str) and source_type and source_type not in ALLOWED_TYPES:
         allowed = ", ".join(sorted(ALLOWED_TYPES))
         report.add_error(f"{prefix}: type must be one of {allowed}")
 
     public_status = source.get("public_status")
-    if public_status and public_status not in ALLOWED_PUBLIC_STATUSES:
+    if isinstance(public_status, str) and public_status and public_status not in ALLOWED_PUBLIC_STATUSES:
         allowed = ", ".join(sorted(ALLOWED_PUBLIC_STATUSES))
         report.add_error(f"{prefix}: public_status must be one of {allowed}")
 

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -136,6 +136,23 @@ class PublicSourcesTests(unittest.TestCase):
             report = validate_source_index(root)
             self.assertTrue(report.ok, report.errors)
 
+    def test_non_string_enum_fields_report_errors_without_crashing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "brief").mkdir()
+            (root / "brief" / "public-brief.md").write_text("# brief", encoding="utf-8")
+            bad_index = copy.deepcopy(VALID_INDEX)
+            bad_index["sources"][0]["type"] = {"unexpected": "object"}
+            bad_index["sources"][0]["public_status"] = ["public-draft"]
+            self.write_json(root, "sources/public-sources.json", bad_index)
+
+            report = validate_source_index(root)
+
+            self.assertFalse(report.ok)
+            joined = "\n".join(report.errors)
+            self.assertIn("missing required string field `type`", joined)
+            self.assertIn("missing required string field `public_status`", joined)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`validate_sources.py` correctly records a required-field error when `type` or `public_status` is not a string, but then performs set membership on that malformed value. JSON objects and arrays therefore raise `TypeError` instead of producing a validation report.

## Change

- only perform enum membership checks after confirming the value is a non-empty string
- add a regression fixture with an object `type` and array `public_status`
- assert both fields produce structured validation errors without crashing

## Verification

- `python3 -m unittest tests.test_public_sources -v` (6 passed)
- `python3 scripts/validate_sources.py --json` (current index passes)
- `python3 -m py_compile scripts/validate_sources.py tests/test_public_sources.py`
- `git diff --check`