### PR TITLE
fix: make skill installation checks authoritative

### DIFF
--- a/scripts/install_submission_skill.py
+++ b/scripts/install_submission_skill.py
@@ -59,9 +59,24 @@ def copy_skill(source: Path, target: Path) -> None:
     )
 
 
-def build_report(source: Path, target: Path, installed: bool, action: str) -> dict[str, Any]:
+def target_within_codex_home(codex_home: Path, target: Path) -> bool:
+    try:
+        target.resolve().relative_to(codex_home.resolve())
+    except (OSError, RuntimeError, ValueError):
+        return False
+    return True
+
+
+def build_report(
+    source: Path,
+    target: Path,
+    installed: bool,
+    action: str,
+    *,
+    target_safe: bool = True,
+) -> dict[str, Any]:
     source_exists = (source / "SKILL.md").exists()
-    target_exists = (target / "SKILL.md").exists()
+    target_exists = target_safe and (target / "SKILL.md").exists()
     report: dict[str, Any] = {
         "action": action,
         "skill_name": SKILL_NAME,
@@ -70,6 +85,7 @@ def build_report(source: Path, target: Path, installed: bool, action: str) -> di
         "installed": installed,
         "source_exists": source_exists,
         "target_exists": target_exists,
+        "target_safe": target_safe,
         "starter_prompt": STARTER_PROMPT,
     }
     if source_exists:
@@ -80,7 +96,7 @@ def build_report(source: Path, target: Path, installed: bool, action: str) -> di
         report["up_to_date"] = report.get("source_sha256") == report.get("target_sha256")
     else:
         report["up_to_date"] = False
-    report["ok"] = source_exists and target_exists and report["up_to_date"]
+    report["ok"] = source_exists and target_exists and target_safe and report["up_to_date"]
     return report
 
 
@@ -110,7 +126,23 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     source = repo_root() / "skills" / SKILL_NAME
-    target = Path(args.codex_home).expanduser() / "skills" / SKILL_NAME
+    codex_home = Path(args.codex_home).expanduser()
+    target = codex_home / "skills" / SKILL_NAME
+
+    if not target_within_codex_home(codex_home, target):
+        report = build_report(
+            source,
+            target,
+            installed=False,
+            action="unsafe-target",
+            target_safe=False,
+        )
+        report["error"] = "Target resolves outside the configured Codex home."
+        if args.json:
+            print(json.dumps(report, ensure_ascii=False, indent=2))
+        else:
+            print(render_text(report), file=sys.stderr)
+        return 1
 
     if not (source / "SKILL.md").exists():
         report = build_report(source, target, installed=False, action="missing-source")

--- a/scripts/install_submission_skill.py
+++ b/scripts/install_submission_skill.py
@@ -45,11 +45,16 @@ def tree_digest(path: Path) -> str:
 
 
 def copy_skill(source: Path, target: Path) -> None:
+    if source.resolve() == target.resolve():
+        return
     target.parent.mkdir(parents=True, exist_ok=True)
+    if target.is_symlink() or target.is_file():
+        target.unlink()
+    elif target.exists():
+        shutil.rmtree(target)
     shutil.copytree(
         source,
         target,
-        dirs_exist_ok=True,
         ignore=shutil.ignore_patterns("__pycache__", "*.pyc", ".DS_Store"),
     )
 
@@ -58,7 +63,6 @@ def build_report(source: Path, target: Path, installed: bool, action: str) -> di
     source_exists = (source / "SKILL.md").exists()
     target_exists = (target / "SKILL.md").exists()
     report: dict[str, Any] = {
-        "ok": source_exists and target_exists,
         "action": action,
         "skill_name": SKILL_NAME,
         "source": str(source),
@@ -76,6 +80,7 @@ def build_report(source: Path, target: Path, installed: bool, action: str) -> di
         report["up_to_date"] = report.get("source_sha256") == report.get("target_sha256")
     else:
         report["up_to_date"] = False
+    report["ok"] = source_exists and target_exists and report["up_to_date"]
     return report
 
 

--- a/tests/test_install_submission_skill.py
+++ b/tests/test_install_submission_skill.py
@@ -45,6 +45,44 @@ class InstallSubmissionSkillTests(unittest.TestCase):
             self.assertTrue(reinstall_report["up_to_date"])
             self.assertFalse(stale.exists())
 
+    def test_symlinked_skills_parent_outside_codex_home_is_rejected(self) -> None:
+        for args in [(), ("--check",)]:
+            with self.subTest(args=args), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                codex_home = root / "home"
+                outside = root / "outside"
+                codex_home.mkdir()
+                outside.mkdir()
+                (codex_home / "skills").symlink_to(outside, target_is_directory=True)
+
+                target = outside / "urban-design-ai-submission"
+                target.mkdir()
+                (target / "SKILL.md").write_text("external skill\n", encoding="utf-8")
+                sentinel = target / "sentinel.txt"
+                sentinel.write_text("DO NOT DELETE\n", encoding="utf-8")
+
+                completed = self.run_installer(codex_home, *args)
+
+                self.assertNotEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+                report = json.loads(completed.stdout)
+                self.assertEqual(report["action"], "unsafe-target")
+                self.assertFalse(report["target_safe"])
+                self.assertFalse(report["installed"])
+                self.assertEqual(sentinel.read_text(encoding="utf-8"), "DO NOT DELETE\n")
+
+    def test_install_is_noop_when_source_and_target_are_the_same(self) -> None:
+        skill_file = REPO_ROOT / "skills" / "urban-design-ai-submission" / "SKILL.md"
+        original = skill_file.read_bytes()
+
+        completed = self.run_installer(REPO_ROOT)
+
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        report = json.loads(completed.stdout)
+        self.assertTrue(report["ok"])
+        self.assertTrue(report["up_to_date"])
+        self.assertEqual(report["source_sha256"], report["target_sha256"])
+        self.assertEqual(skill_file.read_bytes(), original)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_install_submission_skill.py
+++ b/tests/test_install_submission_skill.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = REPO_ROOT / "scripts" / "install_submission_skill.py"
+
+
+class InstallSubmissionSkillTests(unittest.TestCase):
+    def run_installer(self, codex_home: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(INSTALLER), "--codex-home", str(codex_home), *args, "--json"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_check_detects_stale_file_and_reinstall_removes_it(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            codex_home = Path(tmp)
+            installed = self.run_installer(codex_home)
+            self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+
+            target = codex_home / "skills" / "urban-design-ai-submission"
+            stale = target / "stale.md"
+            stale.write_text("obsolete\n", encoding="utf-8")
+
+            checked = self.run_installer(codex_home, "--check")
+            self.assertNotEqual(checked.returncode, 0, checked.stdout + checked.stderr)
+            check_report = json.loads(checked.stdout)
+            self.assertFalse(check_report["ok"])
+            self.assertFalse(check_report["up_to_date"])
+
+            reinstalled = self.run_installer(codex_home)
+            self.assertEqual(reinstalled.returncode, 0, reinstalled.stdout + reinstalled.stderr)
+            reinstall_report = json.loads(reinstalled.stdout)
+            self.assertTrue(reinstall_report["ok"])
+            self.assertTrue(reinstall_report["up_to_date"])
+            self.assertFalse(stale.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The skill installer reported `ok: true` whenever both `SKILL.md` files existed, even when their tree digests differed. It also copied over an existing directory without removing files deleted from the repository, so stale files survived every reinstall.

## Change

- make report success require matching source and target tree digests
- replace the managed target skill directory during installation so removed files do not linger
- preserve the no-op case when source and target resolve to the same directory
- add a regression test that creates a stale target file, verifies `--check` exits nonzero, reinstalls, and verifies the stale file is removed

## Verification

- `python3 -m unittest tests.test_install_submission_skill tests.test_site_package_contract.SitePackageContractTests.test_submission_skill_installer_copies_skill -v` (2 passed)
- `python3 -m py_compile scripts/install_submission_skill.py tests/test_install_submission_skill.py`
- `git diff --check`