### PR TITLE
fix: enforce area geometry in formal spatial review

### DIFF
--- a/scripts/spatial_review.py
+++ b/scripts/spatial_review.py
@@ -99,6 +99,7 @@ OFFICIAL_KEY_AREA_AREAS = {
     "beijing_ai_origin_community": 1043000.0,
     "dazhongsi_ai_industry_cluster": 720000.0,
 }
+AREA_GEOMETRY_TYPES = {"Polygon", "MultiPolygon"}
 
 
 @dataclass
@@ -189,10 +190,42 @@ def load_feature_geometries(
     validate_schema(report, repo_root, path, "geojson_feature.schema.json")
     data = load_json(path)
     features = data.get("features", []) if isinstance(data, dict) else []
+    if not isinstance(features, list):
+        report.add(
+            SpatialIssue(
+                "GEOMETRY_COLLECTION",
+                "major",
+                str(path),
+                "FeatureCollection features must be an array.",
+            )
+        )
+        return []
     items: list[tuple[str, Any, dict]] = []
     for index, feature in enumerate(features):
+        if not isinstance(feature, dict):
+            report.add(
+                SpatialIssue(
+                    "GEOMETRY_FEATURE",
+                    "major",
+                    str(path),
+                    "FeatureCollection items must be objects.",
+                    f"feature-{index}",
+                )
+            )
+            continue
         feature_id = str(feature.get("id") or f"feature-{index}")
         props = feature.get("properties") or {}
+        if not isinstance(props, dict):
+            report.add(
+                SpatialIssue(
+                    "GEOMETRY_PROPERTIES",
+                    "major",
+                    str(path),
+                    "Feature properties must be an object.",
+                    feature_id,
+                )
+            )
+            props = {}
         try:
             geom = project_geometry(shape(feature["geometry"]), transformer)
         except Exception as exc:  # noqa: BLE001 - report invalid contributor data
@@ -203,6 +236,19 @@ def load_feature_geometries(
                     str(path),
                     f"Cannot parse geometry: {exc}",
                     feature_id,
+                )
+            )
+            continue
+        if geom.geom_type not in AREA_GEOMETRY_TYPES:
+            report.add(
+                SpatialIssue(
+                    "GEOMETRY_TYPE",
+                    "major",
+                    str(path),
+                    "Formal area layers require Polygon or MultiPolygon geometry.",
+                    feature_id,
+                    expected="Polygon or MultiPolygon",
+                    actual=geom.geom_type,
                 )
             )
             continue
@@ -538,13 +584,13 @@ def review_submission(submission_dir: Path, repo_root: Path, stage: str) -> Spat
         report, repo_root, submission_dir, "site_boundary.geojson", transformer
     )
     site = union_geometries(site_items)
-    if site is None or site.is_empty:
+    if site is None or site.is_empty or float(site.area) <= 0:
         report.add(
             SpatialIssue(
                 "SITE_BOUNDARY_EMPTY",
                 "blocking",
                 "geometry/site_boundary.geojson",
-                "Site boundary is empty.",
+                "Site boundary is empty or has no area.",
             )
         )
         return report

--- a/tests/test_spatial_review.py
+++ b/tests/test_spatial_review.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import math
 import sys
 import tempfile
 import unittest
@@ -59,6 +60,10 @@ def polygon(x1: float, y1: float, x2: float, y2: float) -> dict:
         "type": "Polygon",
         "coordinates": [[[x1, y1], [x2, y1], [x2, y2], [x1, y2], [x1, y1]]],
     }
+
+
+def point(x: float = 116.305, y: float = 39.905) -> dict:
+    return {"type": "Point", "coordinates": [x, y]}
 
 
 def write_valid_spatial_package(root: Path, base: str) -> None:
@@ -372,6 +377,48 @@ class SpatialReviewTests(unittest.TestCase):
 
             self.assertFalse(report.ok)
             self.assertIn("METRIC_RECALC_MISMATCH", {issue.check_id for issue in report.issues})
+
+    def test_area_layers_reject_point_geometry(self) -> None:
+        filenames = [
+            "site_boundary.geojson",
+            "key_areas.geojson",
+            "land_use.geojson",
+            "buildings.geojson",
+            "green_space.geojson",
+            "public_space.geojson",
+        ]
+        for filename in filenames:
+            with self.subTest(filename=filename), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                base = "submissions/alice/spatial-point"
+                write_valid_spatial_package(root, base)
+                path = root / base / "geometry" / filename
+                data = json.loads(path.read_text(encoding="utf-8"))
+                data["features"][0]["geometry"] = point()
+                write_json(root, f"{base}/geometry/{filename}", data)
+
+                report = review_submission(root / base, REPO_ROOT, "formal")
+
+                self.assertFalse(report.ok)
+                type_issues = [issue for issue in report.issues if issue.check_id == "GEOMETRY_TYPE"]
+                self.assertTrue(type_issues, [issue.__dict__ for issue in report.issues])
+                self.assertTrue(all(math.isfinite(value) for value in report.metrics.values()))
+
+    def test_malformed_feature_returns_structured_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/spatial-malformed"
+            write_valid_spatial_package(root, base)
+            write_json(
+                root,
+                f"{base}/geometry/site_boundary.geojson",
+                {"type": "FeatureCollection", "features": [42]},
+            )
+
+            report = review_submission(root / base, REPO_ROOT, "formal")
+
+            self.assertFalse(report.ok)
+            self.assertIn("GEOMETRY_FEATURE", {issue.check_id for issue in report.issues})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The formal spatial reviewer accepted Point geometries in layers used for area, coverage, overlap, and containment checks. A point-only package could therefore pass with a zero-area site and `NaN` ratios. Separately, a schema-invalid FeatureCollection such as `features: [42]` recorded a schema issue and then crashed when semantic review called `.get()` on the malformed item.

## Change

- require `Polygon` or `MultiPolygon` geometry for formal area layers
- reject non-array feature collections and non-object feature entries with structured major issues
- handle non-object properties without propagating exceptions
- block empty or zero-area site boundaries before metric calculation
- add regression coverage for Point geometry in each reviewed layer and malformed feature entries

## Verification

- `PYTHONPATH=/tmp/haidian-audit-deps python3 -m unittest tests.test_spatial_review -v` (8 passed)
- serialized the malformed-feature report with `json.dumps(..., allow_nan=False)`
- `python3 -m py_compile scripts/spatial_review.py tests/test_spatial_review.py`
- `git diff --check`