### PR TITLE
fix(validate): explain the CRLF/LF cause behind manifest sha256 mismatch

### DIFF
--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -784,6 +784,33 @@ def validate_agent_disclosure(
         )
 
 
+def describe_line_ending_digest_mismatch(raw: bytes, declared_digest: str) -> str:
+    """Explain a manifest sha256 mismatch that is only a line-ending difference.
+
+    A manifest generated on a CRLF working copy records digests of CRLF bytes,
+    but git normalises the committed bytes to LF (the reverse happens when CRLF
+    files are committed verbatim). Either way every text file mismatches while
+    binary files still match, which is hard to read from the digest alone.
+    Returning a hint keeps the error actionable instead of merely factual.
+    """
+
+    lf_bytes = raw.replace(b"\r\n", b"\n")
+    crlf_bytes = lf_bytes.replace(b"\n", b"\r\n")
+    if crlf_bytes != raw and hashlib.sha256(crlf_bytes).hexdigest() == declared_digest:
+        return (
+            "; the declared digest matches this file's CRLF form. The manifest was"
+            " generated on a CRLF working copy and git normalised the committed bytes"
+            " to LF. Set core.autocrlf=false, restore the working tree, then regenerate"
+            " the manifest"
+        )
+    if lf_bytes != raw and hashlib.sha256(lf_bytes).hexdigest() == declared_digest:
+        return (
+            "; the declared digest matches this file's LF form, but the committed bytes"
+            " contain CRLF. Normalise the file to LF before regenerating the manifest"
+        )
+    return ""
+
+
 def policy_file(repo_root: Path, relative_path: str) -> Path:
     candidate = repo_root / relative_path
     if candidate.exists():
@@ -1346,9 +1373,15 @@ def validate_manifest_file(report: ValidationReport, repo_root: Path, proposal_d
                 else:
                     report.add_warning(message + " (legacy package compatibility)")
             elif declared_digest:
-                actual_digest = hashlib.sha256(listed_file.read_bytes()).hexdigest()
+                listed_bytes = listed_file.read_bytes()
+                actual_digest = hashlib.sha256(listed_bytes).hexdigest()
                 if declared_digest != actual_digest:
                     message = f"{proposal_dir}/manifest.json: sha256 mismatch for `{safe_path}`"
+                    line_ending_hint = describe_line_ending_digest_mismatch(
+                        listed_bytes, declared_digest
+                    )
+                    if line_ending_hint:
+                        message += line_ending_hint
                     if translation_entry and not strict_bilingual:
                         report.add_warning(message + "; legacy bilingual metadata does not block review")
                     else:

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -2261,6 +2261,71 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertIn("visual/index.en.html", "\n".join(report.errors))
             self.assertIn("iframe", "\n".join(report.errors))
 
+    def test_crlf_manifest_digest_mismatch_explains_line_endings(self) -> None:
+        """A manifest generated on a CRLF working copy should say so, not just 'mismatch'."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            manifest_path = root / base / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            target = root / base / "metrics.json"
+            committed = target.read_bytes().replace(b"\r\n", b"\n")
+            target.write_bytes(committed)
+            crlf_digest = hashlib.sha256(committed.replace(b"\n", b"\r\n")).hexdigest()
+            for entry in manifest["files"]:
+                if entry.get("path") == "metrics.json":
+                    entry["sha256"] = crlf_digest
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+            )
+            report = validate_submission(root, "alice", changed)
+            joined = "\n".join(report.errors)
+            self.assertIn("sha256 mismatch for `metrics.json`", joined)
+            self.assertIn("matches this file's CRLF form", joined)
+            self.assertIn("core.autocrlf=false", joined)
+
+    def test_crlf_committed_bytes_digest_mismatch_explains_line_endings(self) -> None:
+        """The reverse case: committed bytes are CRLF while the manifest used LF."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            manifest_path = root / base / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            target = root / base / "metrics.json"
+            lf_bytes = target.read_bytes().replace(b"\r\n", b"\n")
+            target.write_bytes(lf_bytes.replace(b"\n", b"\r\n"))
+            for entry in manifest["files"]:
+                if entry.get("path") == "metrics.json":
+                    entry["sha256"] = hashlib.sha256(lf_bytes).hexdigest()
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+            )
+            report = validate_submission(root, "alice", changed)
+            joined = "\n".join(report.errors)
+            self.assertIn("matches this file's LF form", joined)
+
+    def test_unrelated_manifest_digest_mismatch_has_no_line_ending_hint(self) -> None:
+        """A genuinely stale digest must not be mislabelled as a line-ending problem."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            manifest_path = root / base / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            for entry in manifest["files"]:
+                if entry.get("path") == "metrics.json":
+                    entry["sha256"] = "0" * 64
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+            )
+            report = validate_submission(root, "alice", changed)
+            joined = "\n".join(report.errors)
+            self.assertIn("sha256 mismatch for `metrics.json`", joined)
+            self.assertNotIn("CRLF form", joined)
+            self.assertNotIn("LF form", joined)
+
     def test_stale_translation_manifest_hash_is_non_blocking(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
> 这是**工具改进 PR，不是投稿**，所以没有套用投稿模板的清单。改动只涉及 `scripts/` 与 `tests/`，不触碰任何 `submissions/`。

关联 issue：#1062

## 问题

`manifest.json: sha256 mismatch for X` 目前只陈述"对不上"，但在最常见的那种情况下——投稿者在 Windows 上生成 manifest、git 按 `core.autocrlf=true` 把提交字节归一成 LF——一个包会**同时冒出二三十条**这样的报错，而且**全是文本文件、二进制文件一条不错**。投稿者从报错本身看不出这是行尾问题，往往会以为是内容出了错。

我在做社区互审时统计了当前 47 个 CI 失败的 open PR：**25 个是这一个原因**，合计 538 条 `sha256 mismatch`。这些包的内容其实是完好的——只重算一次 manifest 哈希就能从 FAIL 直接变成 `formal-review-ready`（我在 #1028 #1026 #885 #549 #508 #425 #289 #265 #191 #93 #89 #66 #50 等包上实测过）。详细数据在 #1062。

## 改动

`scripts/validate_submission.py` 里加一个纯函数 `describe_line_ending_digest_mismatch()`，在报 mismatch 时多做一次判定：把文件字节按 CRLF（或 LF）归一后重算，若与 manifest 声明值相符，就把结论追加到报错里。

改动前后，同一个包（#1028 的 head）的输出：

```
- .../manifest.json: sha256 mismatch for `agent.json`
```
```
- .../manifest.json: sha256 mismatch for `agent.json`; the declared digest matches
  this file's CRLF form. The manifest was generated on a CRLF working copy and git
  normalised the committed bytes to LF. Set core.autocrlf=false, restore the working
  tree, then regenerate the manifest
```

两个方向都覆盖：
- 提交字节是 LF、声明值是 CRLF 的哈希 → 提示 `core.autocrlf`（最常见）
- 提交字节是 CRLF、声明值是 LF 的哈希 → 提示先归一为 LF（如 #505）

**不会误报**：只有重算后逐位相同才追加提示。真正陈旧的哈希（比如文件确实被重新生成过）维持原样输出。#505 是个天然的对照——24 条失配里 18 条被判定为行尾问题，其余 6 条（含两个 PDF）没有任何提示。

严重级别、警告/错误的归属、既有措辞全部不变，只在消息尾部追加。

## 验证

- 新增 3 个用例：CRLF 方向、LF 反向、以及"真·陈旧哈希不得被误标为行尾问题"的负例
- `python3 -m unittest discover -s tests -p test_submission_workflow.py` → **107 passed**
- 全量套件在打补丁前后的失败集合**逐条相同**（本地 8 条失败均为环境性：`submissions/` 未 checkout 导致的 gallery 类用例，与本改动无关）
- 用 #1028 与 #505 两个真实包的精确 head 字节做过端到端验证：#1028 的 23 条 mismatch 全部带上 CRLF 提示，#505 的 18/24 带上 LF 提示

## 说明

我是参赛者 @anselasimov-web。#1062 里还提了第二个建议（在根 `.gitattributes` 加 `* text=auto eol=lf` 从源头堵住），那个涉及全仓库行尾策略，我没有放进这个 PR，交给维护者判断。
