### PR TITLE
fix(review): surface ratio metric drift without breaking legacy packages

### DIFF
--- a/scripts/spatial_review.py
+++ b/scripts/spatial_review.py
@@ -42,6 +42,14 @@ RELATIVE_AREA_TOLERANCE = 0.01
 # non-blocking finding when a declared absolute area drifts beyond ordinary
 # three-decimal reporting precision.
 AREA_REPORTING_COMPARISON_EPSILON = 1e-9
+# Ratio values in metrics.json are published to six decimal places.  Keep the
+# existing 1% compatibility envelope for legacy packages, but surface a
+# non-blocking audit finding when a declared ratio drifts beyond ordinary
+# six-decimal reporting/rounding precision.
+RATIO_REPORTING_TOLERANCE = 0.00001
+# Only absorbs binary floating-point noise at the decimal boundary; it is not
+# an additional reporting tolerance.
+RATIO_REPORTING_COMPARISON_EPSILON = 1e-12
 TOPOLOGY_RELATIVE_AREA_TOLERANCE = 0.0001
 KEY_AREA_RELATIVE_TOLERANCE = 0.03
 OFFICIAL_KEY_AREA_AREAS = {
@@ -401,6 +409,26 @@ def check_metric_close(
                 "major",
                 "metrics.json",
                 f"{name} does not match spatial recomputation.",
+                expected=round(expected, 6),
+                actual=round(actual, 6),
+            )
+        )
+    elif (
+        unit == "ratio"
+        and delta > RATIO_REPORTING_TOLERANCE
+        and not math.isclose(
+            delta,
+            RATIO_REPORTING_TOLERANCE,
+            rel_tol=0.0,
+            abs_tol=RATIO_REPORTING_COMPARISON_EPSILON,
+        )
+    ):
+        report.add(
+            SpatialIssue(
+                "METRIC_RECALC_DRIFT",
+                "minor",
+                "metrics.json",
+                f"{name} is within the legacy tolerance but drifts beyond six-decimal reporting precision; reconcile before publication.",
                 expected=round(expected, 6),
                 actual=round(actual, 6),
             )

--- a/tests/test_spatial_review.py
+++ b/tests/test_spatial_review.py
@@ -15,7 +15,13 @@ HAS_SPATIAL_DEPS = all(
 )
 
 if HAS_SPATIAL_DEPS:
-    from spatial_review import AREA_TOLERANCE_SQM, review_submission  # noqa: E402
+    from spatial_review import (  # noqa: E402
+        AREA_TOLERANCE_SQM,
+        RATIO_REPORTING_TOLERANCE,
+        SpatialReport,
+        check_metric_close,
+        review_submission,
+    )
     from pyproj import Transformer  # noqa: E402
     from shapely.geometry import shape  # noqa: E402
     from shapely.ops import transform  # noqa: E402
@@ -198,6 +204,36 @@ class SpatialReviewTests(unittest.TestCase):
             self.assertTrue(report.ok, [issue.__dict__ for issue in report.issues])
             self.assertIn("METRIC_RECALC_DRIFT", {issue.check_id for issue in report.issues})
 
+    def test_ratio_drift_is_reported_without_blocking_legacy_package(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/spatial-ratio-drift"
+            write_valid_spatial_package(root, base)
+            public = projected_area(polygon(116.307, 39.907, 116.309, 39.909))
+            site = projected_area(polygon(116.300, 39.900, 116.310, 39.910))
+            metrics = {
+                "schema_version": "0.1.0",
+                "units": {"length": "m", "area": "sqm"},
+                "metrics": {
+                    "public_space_ratio": {
+                        "status": "known",
+                        "value": round(public / site + 0.0001, 6),
+                        "unit": "ratio",
+                        "source_files": [
+                            "geometry/public_space.geojson",
+                            "geometry/site_boundary.geojson",
+                        ],
+                        "formula": "public_space_area_sqm / site_area_sqm",
+                    }
+                },
+            }
+            write_json(root, f"{base}/metrics.json", metrics)
+
+            report = review_submission(root / base, REPO_ROOT, "formal")
+
+            self.assertTrue(report.ok, [issue.__dict__ for issue in report.issues])
+            self.assertIn("METRIC_RECALC_DRIFT", {issue.check_id for issue in report.issues})
+
     def test_absolute_metric_mismatch_remains_blocking(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -224,6 +260,37 @@ class SpatialReviewTests(unittest.TestCase):
             self.assertFalse(report.ok)
             self.assertIn("METRIC_RECALC_MISMATCH", {issue.check_id for issue in report.issues})
 
+    def test_ratio_reporting_boundary_ignores_binary_float_noise(self) -> None:
+        report = SpatialReport(stage="formal")
+        expected = 0.25
+        actual = expected + RATIO_REPORTING_TOLERANCE
+
+        check_metric_close(
+            report,
+            {"ratio": {"value": actual}},
+            "ratio",
+            expected,
+            "ratio",
+        )
+
+        self.assertTrue(report.ok, [issue.__dict__ for issue in report.issues])
+        self.assertNotIn("METRIC_RECALC_DRIFT", {issue.check_id for issue in report.issues})
+
+    def test_ratio_reporting_drift_above_boundary_is_visible(self) -> None:
+        report = SpatialReport(stage="formal")
+        expected = 0.25
+        actual = expected + RATIO_REPORTING_TOLERANCE * 2
+
+        check_metric_close(
+            report,
+            {"ratio": {"value": actual}},
+            "ratio",
+            expected,
+            "ratio",
+        )
+
+        self.assertTrue(report.ok, [issue.__dict__ for issue in report.issues])
+        self.assertIn("METRIC_RECALC_DRIFT", {issue.check_id for issue in report.issues})
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- surface a non-blocking `METRIC_RECALC_DRIFT` finding when a declared ratio is within the legacy 1% compatibility envelope but exceeds six-decimal reporting precision;
- keep existing major mismatch behavior unchanged, so this does not retroactively fail legacy packages;
- add a regression proving the drift is visible while the spatial review remains `ok=true`.

## Why

At exact PR #1100 head `71d874d`, `spatial_review.py` recomputes `public_space_ratio=0.145582` while `metrics.json` declares `0.145697`. The existing 1% tolerance correctly avoided a false hard failure, but it also gave no machine-readable signal that the published ratio should be reconciled before publication. This patch makes that boundary visible to reviewers without changing the acceptance status.

## Verification

- `python3 -m unittest tests.test_spatial_review -v` — 7 passed
- `python3 -m unittest tests.test_submission_workflow tests.test_visual_review -v` — 114 passed
- `python3 -m py_compile scripts/spatial_review.py`
- `git diff --check`
- exact #1100 package with the patched reviewer: `ok=true`, existing provisional notices retained, plus `METRIC_RECALC_DRIFT` with expected `0.145582` and actual `0.145697`

This changes only the spatial review script and its tests. It does not modify contributor packages, `submissions-data.js`, scoring, publication, or ranking behavior.
