### PR TITLE
fix(spatial): audit declared absolute metric areas

### DIFF
--- a/scripts/spatial_review.py
+++ b/scripts/spatial_review.py
@@ -38,6 +38,10 @@ except ImportError:  # pragma: no cover
 
 AREA_TOLERANCE_SQM = 1.0
 RELATIVE_AREA_TOLERANCE = 0.01
+# Keep the existing compatibility envelope for legacy packages, but surface a
+# non-blocking finding when a declared absolute area drifts beyond ordinary
+# three-decimal reporting precision.
+AREA_REPORTING_COMPARISON_EPSILON = 1e-9
 TOPOLOGY_RELATIVE_AREA_TOLERANCE = 0.0001
 KEY_AREA_RELATIVE_TOLERANCE = 0.03
 OFFICIAL_KEY_AREA_AREAS = {
@@ -401,6 +405,22 @@ def check_metric_close(
                 actual=round(actual, 6),
             )
         )
+    elif unit == "sqm" and delta > AREA_TOLERANCE_SQM and not math.isclose(
+        delta,
+        AREA_TOLERANCE_SQM,
+        rel_tol=0.0,
+        abs_tol=AREA_REPORTING_COMPARISON_EPSILON,
+    ):
+        report.add(
+            SpatialIssue(
+                "METRIC_RECALC_DRIFT",
+                "minor",
+                "metrics.json",
+                f"{name} is within the legacy tolerance but drifts beyond ordinary reporting precision; reconcile before publication.",
+                expected=round(expected, 6),
+                actual=round(actual, 6),
+            )
+        )
 
 
 def load_metrics(submission_dir: Path) -> dict:
@@ -473,6 +493,9 @@ def review_submission(submission_dir: Path, repo_root: Path, stage: str) -> Spat
 
     metrics = load_metrics(submission_dir)
     check_metric_close(report, metrics, "site_area_sqm", site_area, "sqm")
+    check_metric_close(report, metrics, "green_space_area_sqm", green_area, "sqm")
+    check_metric_close(report, metrics, "public_space_area_sqm", public_area, "sqm")
+    check_metric_close(report, metrics, "building_footprint_area_sqm", building_area, "sqm")
     check_metric_close(report, metrics, "green_ratio", green_area / site_area if site_area else 0, "ratio")
     check_metric_close(
         report, metrics, "public_space_ratio", public_area / site_area if site_area else 0, "ratio"

--- a/tests/test_spatial_review.py
+++ b/tests/test_spatial_review.py
@@ -15,7 +15,7 @@ HAS_SPATIAL_DEPS = all(
 )
 
 if HAS_SPATIAL_DEPS:
-    from spatial_review import review_submission  # noqa: E402
+    from spatial_review import AREA_TOLERANCE_SQM, review_submission  # noqa: E402
     from pyproj import Transformer  # noqa: E402
     from shapely.geometry import shape  # noqa: E402
     from shapely.ops import transform  # noqa: E402
@@ -171,6 +171,58 @@ class SpatialReviewTests(unittest.TestCase):
             report = review_submission(root / base, REPO_ROOT, "formal")
             self.assertFalse(report.ok)
             self.assertIn("KEY_AREA_AREA_MISMATCH", {issue.check_id for issue in report.issues})
+
+    def test_absolute_metric_drift_is_reported_without_blocking_legacy_package(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/spatial-absolute-metric-drift"
+            write_valid_spatial_package(root, base)
+            green = projected_area(polygon(116.305, 39.905, 116.307, 39.907))
+            metrics = {
+                "schema_version": "0.1.0",
+                "units": {"length": "m", "area": "sqm"},
+                "metrics": {
+                    "green_space_area_sqm": {
+                        "status": "known",
+                        "value": round(green + AREA_TOLERANCE_SQM * 2, 3),
+                        "unit": "sqm",
+                        "source_files": ["geometry/green_space.geojson"],
+                        "formula": "sum(non-overlapping concept green-space polygons)",
+                    }
+                },
+            }
+            write_json(root, f"{base}/metrics.json", metrics)
+
+            report = review_submission(root / base, REPO_ROOT, "formal")
+
+            self.assertTrue(report.ok, [issue.__dict__ for issue in report.issues])
+            self.assertIn("METRIC_RECALC_DRIFT", {issue.check_id for issue in report.issues})
+
+    def test_absolute_metric_mismatch_remains_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/spatial-absolute-metric-mismatch"
+            write_valid_spatial_package(root, base)
+            green = projected_area(polygon(116.305, 39.905, 116.307, 39.907))
+            metrics = {
+                "schema_version": "0.1.0",
+                "units": {"length": "m", "area": "sqm"},
+                "metrics": {
+                    "green_space_area_sqm": {
+                        "status": "known",
+                        "value": round(green * 1.02, 3),
+                        "unit": "sqm",
+                        "source_files": ["geometry/green_space.geojson"],
+                        "formula": "sum(non-overlapping concept green-space polygons)",
+                    }
+                },
+            }
+            write_json(root, f"{base}/metrics.json", metrics)
+
+            report = review_submission(root / base, REPO_ROOT, "formal")
+
+            self.assertFalse(report.ok)
+            self.assertIn("METRIC_RECALC_MISMATCH", {issue.check_id for issue in report.issues})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- validate declared `green_space_area_sqm`, `public_space_area_sqm`, and `building_footprint_area_sqm` against the canonical EPSG:4548 geometry union
- preserve the existing 1% legacy compatibility envelope
- surface a non-blocking `METRIC_RECALC_DRIFT` when an absolute area differs by more than 1 sqm but remains within that legacy envelope
- keep genuine mismatches above the existing envelope blocking

This closes a gate gap exposed by PR #1106: its metrics.json absolute areas differ from the same-head GeoJSON recomputation while the existing spatial review reports PASS.

## Verification

- implementation checkout was based on main `7dc8e9ae50800d2171f9ad26b728f4b809aea692`; the live PR base may advance with main and must be validated by the trusted run
- implementation head: `aadc00f3d4c53a235dd554d47a480546ab41f28a`
- focused spatial tests: 8 passed
- submission workflow + visual review suite: 114 passed
- `py_compile` and `git diff --check`: passed
- replayed against #1106 exact head: three absolute-area drifts are surfaced as minor findings and the report remains `ok=true`

No submission package, gallery asset, scoring rule, or maintainer-controlled publication file is changed.