### PR TITLE
fix(open-pulse): remove duplicate risk metric key

### DIFF
--- a/submissions/147228/jingzhang-open-pulse/manifest.json
+++ b/submissions/147228/jingzhang-open-pulse/manifest.json
@@ -46,7 +46,7 @@
       "path": "metrics.json",
       "role": "metrics",
       "required": true,
-      "sha256": "a0dcb00810c131f57eb8629e7adab3f9dda48d282835e72fbc293a23cd3bafcb"
+      "sha256": "f6e61bd79148d158428cb991f4ee24d630c373552f490a4089b848e33a975bcc"
     },
     {
       "path": "assumptions.json",

--- a/submissions/147228/jingzhang-open-pulse/metrics.json
+++ b/submissions/147228/jingzhang-open-pulse/metrics.json
@@ -343,7 +343,8 @@
       "formula": "count(validated risk dimensions in risk.json)",
       "confidence": "high",
       "assumptions": [
-        "This is a design risk-register count, not a measured probability or safety certification."
+        "This is a design risk-register count, not a measured probability or safety certification.",
+        "Risk dimensions are review priorities, not probabilities, safety certification or approval."
       ]
     },
     "construction_readiness_gate_count": {
@@ -506,20 +507,6 @@
       "confidence": "high",
       "assumptions": [
         "Station labels are conceptual and key-area polygons remain provisional."
-      ]
-    },
-    "risk_class_count": {
-      "status": "known",
-      "value": 8,
-      "unit": "count",
-      "source_files": [
-        "risk.json",
-        "proposal.md"
-      ],
-      "formula": "count(validated risk dimensions in risk.json)",
-      "confidence": "high",
-      "assumptions": [
-        "Risk dimensions are review priorities, not probabilities, safety certification or approval."
       ]
     },
     "proof_mile_component_count": {


### PR DESCRIPTION
## What changed

The merged Open Pulse package still had two `risk_class_count` keys in `metrics.json`. The two entries carried the same value and formula but different boundary notes, so different JSON consumers could silently keep different objects.

This PR:

- keeps one canonical `risk_class_count` record;
- preserves both existing boundary notes in that record;
- refreshes the `metrics.json` SHA-256 entry in `manifest.json`.

The metric value, source files, formula, status and score-related claims are unchanged. This is a small post-merge data-integrity repair.

## Verification

- `self_check_submission.py`: `formal-review-ready`
- local validation: no errors; only the existing provisional-boundary warning
- scenario audit: 14/14 rows and 8/8 operation packages
- S02 tabletop: 6/6 acceptance traces, 5/5 rollback steps, 4/4 negative replays, ordinary-route control continues
- all 90 hashed manifest entries match
- duplicate-key scan across the package: clean

The change is limited to the package `metrics.json` and `manifest.json`; no gallery or generated snapshot is touched.
