### PR TITLE
fix(mobility): align bilingual iteration metadata

### DIFF
--- a/submissions/147228/mobility-commons-jingzhang/manifest.json
+++ b/submissions/147228/mobility-commons-jingzhang/manifest.json
@@ -228,7 +228,7 @@
       "required": true,
       "language": "en",
       "translation_of": "proposal.md",
-      "sha256": "1cee142ade966978234c57463536cec89067b74a5828198e0abdb937d7050638"
+      "sha256": "100f01b309e285255a595d4a043374b59298e1c81308b50a0626cc4e2fe1fe58"
     },
     {
       "path": "proposal.md",

--- a/submissions/147228/mobility-commons-jingzhang/proposal.en.md
+++ b/submissions/147228/mobility-commons-jingzhang/proposal.en.md
@@ -9,7 +9,7 @@ license: "COMMUNITY-DISPLAY-ONLY"
 summary: "A time-windowed curb ledger brings metro, bus, bicycle, walking/accessibility, cars, parking and loading into one auditable system, while external commuting, people flow and multimodal simulation remain explicit; future air mobility is only a conditional, reversible, ground-first experiment."
 tracks: ["ai-traffic-walkability", "enterprise-services-ecosystem", "civic-agent-governance"]
 scenarios: ["ai-traffic-walkability", "enterprise-service-copilot", "public-safety-operations-review"]
-iteration: "v2.32"
+iteration: "v2.33"
 ---
 
 # Jing-Zhang Mobility Commons: An Enterprise–Resident Mobility Operating System


### PR DESCRIPTION
## 变更

修复 mobility-commons-jingzhang 双语版本标记不一致的问题。

- `proposal.md` 为 `v2.33`，英文 `proposal.en.md` 同步为 `v2.33`；
- 更新英文 proposal 的 manifest SHA-256；
- 仅修改 `submissions/147228/mobility-commons-jingzhang/` 下两个文件。

## 验证

- self-check：PASS，formal-review-ready；
- validate_local_submission：PASS；
- `git diff --check`：PASS；
- 已知 provisional boundary warning 保留。

请按当前 exact head 复核。本 PR 不主张官方评分、gallery 发布或排名变化。