### PR TITLE
ci(gallery): fail closed when maintenance branch is absent

### DIFF
--- a/.github/workflows/gallery-snapshot-maintenance.yml
+++ b/.github/workflows/gallery-snapshot-maintenance.yml
@@ -40,9 +40,27 @@ jobs:
 
           # This workflow runs only for the canonical repository's trusted main
           # push. It never checks out or executes a contributor PR head.
-          if git ls-remote --exit-code origin "refs/heads/${branch}" >/dev/null 2>&1; then
-            git fetch origin "refs/heads/${branch}:refs/remotes/origin/${branch}"
+          # The repository ruleset requires an administrator to bootstrap this
+          # maintenance ref once. Do not attempt a create-only push with the
+          # GITHUB_TOKEN: it cannot satisfy the admin-only branch-creation rule.
+          if ! git ls-remote --exit-code origin "refs/heads/${branch}" >/dev/null 2>&1; then
+            message="${branch} does not exist. An administrator must create it from trusted main before this workflow can publish a review PR."
+            {
+              echo "### Gallery snapshot maintenance blocked"
+              echo
+              echo "${message}"
+              echo
+              echo "One-time bootstrap (run with administrator bypass):"
+              echo 'git fetch origin main'
+              echo "git push origin origin/main:refs/heads/${branch}"
+              echo
+              echo "Then re-run this workflow with workflow_dispatch."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            echo "::error title=Maintenance branch bootstrap required::${message}"
+            echo "bootstrap-required=true" >> "${GITHUB_OUTPUT}"
+            exit 1
           fi
+          git fetch origin "refs/heads/${branch}:refs/remotes/origin/${branch}"
           git switch --create "${branch}" "${GITHUB_SHA}"
           python3 scripts/generate_submissions_data.py
           python3 scripts/generate_submissions_data.py --check
@@ -64,13 +82,9 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "chore: refresh generated gallery snapshot"
 
-          if expected="$(git rev-parse --verify "refs/remotes/origin/${branch}" 2>/dev/null)"; then
-            git push --force-with-lease="refs/heads/${branch}:${expected}" \
-              origin "HEAD:refs/heads/${branch}"
-          else
-            git push --force-with-lease="refs/heads/${branch}:0000000000000000000000000000000000000000" \
-              origin "HEAD:refs/heads/${branch}"
-          fi
+          expected="$(git rev-parse --verify "refs/remotes/origin/${branch}")"
+          git push --force-with-lease="refs/heads/${branch}:${expected}" \
+            origin "HEAD:refs/heads/${branch}"
           echo "changed=true" >> "${GITHUB_OUTPUT}"
 
       - name: Open or update snapshot maintenance PR

--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -141,6 +141,18 @@ python3 scripts/generate_submissions_data.py --check
 
 提交展示索引时，只提交 `submissions-data.js` 等展示页必要变更，不提交 `.maintainer-review/`、`docs/reviews/` 或任何 review packet。
 
+### Gallery snapshot maintenance 分支首次引导
+
+`.github/workflows/gallery-snapshot-maintenance.yml` 只在可信 `main` 或手动触发时生成 `submissions-data.js`，然后把变更推到 `automation/gallery-snapshot`，由维护者 PR 审查后合并。仓库的 `admin-only branch creation` ruleset 不允许 `GITHUB_TOKEN` 创建这个分支，因此首次启用前需要管理员一次性从可信 `main` 建立维护分支：
+
+```bash
+git fetch origin main
+git push origin origin/main:refs/heads/automation/gallery-snapshot
+git ls-remote --heads origin automation/gallery-snapshot
+```
+
+如果分支不存在，workflow 会在生成前 fail-closed，并把上述引导写入 Actions step summary；它不会尝试创建分支、借用参赛者分支，也不会直接写入 `main`。分支建立后用 `workflow_dispatch` 重新运行，后续更新继续使用带预期 SHA 的 `--force-with-lease`，并只打开或更新维护者草稿 PR。
+
 ### 策展 portal 展示卡片
 
 进入 portal 的方案由维护者策展。投稿包本身不包含 `exhibit.json`，deterministic 校验也会拒绝参赛者提交的 `exhibit.json`。为入选方案生成 exhibit 卡片并渲染 portal：

--- a/tests/test_gallery_snapshot_maintenance_workflow.py
+++ b/tests/test_gallery_snapshot_maintenance_workflow.py
@@ -35,8 +35,17 @@ class GallerySnapshotMaintenanceWorkflowTests(unittest.TestCase):
 
     def test_uses_stable_branch_and_safe_force_lease(self) -> None:
         self.assertIn("MAINTENANCE_BRANCH: automation/gallery-snapshot", self.workflow)
+        self.assertIn('git ls-remote --exit-code origin "refs/heads/${branch}"', self.workflow)
         self.assertIn("git push --force-with-lease=", self.workflow)
+        self.assertNotIn("0000000000000000000000000000000000000000", self.workflow)
         self.assertNotIn("HEAD:refs/heads/main", self.workflow)
+
+    def test_missing_maintenance_branch_fails_with_bootstrap_instructions(self) -> None:
+        self.assertIn("bootstrap-required=true", self.workflow)
+        self.assertIn("GITHUB_STEP_SUMMARY", self.workflow)
+        self.assertIn("One-time bootstrap", self.workflow)
+        self.assertIn("administrator must create it", self.workflow)
+        self.assertIn("git push origin origin/main:refs/heads/${branch}", self.workflow)
 
     def test_only_opens_draft_pr_when_snapshot_changed(self) -> None:
         self.assertIn('echo "changed=false"', self.workflow)


### PR DESCRIPTION
## What changed

The gallery snapshot workflow generated `submissions-data.js` successfully on run `31344964281`, but failed before opening its maintenance PR because the repository ruleset disallows `GITHUB_TOKEN` from creating the missing `automation/gallery-snapshot` branch.

This PR keeps the existing publication boundary and makes the failure recoverable:

- check that the maintenance branch exists before generating and committing a snapshot;
- fail closed with an Actions step summary and an explicit one-time administrator bootstrap command when it does not;
- remove the all-zero lease create-only push, while retaining the expected-SHA `--force-with-lease` update for an existing branch;
- document the bootstrap and re-run path for maintainers;
- add regression assertions for the missing-branch path and the no-direct-main invariant.

The workflow still runs only from trusted `main` or `workflow_dispatch`, never executes contributor PR code, never borrows a participant branch, and never writes directly to `main`.

## Verification

- `tests.test_gallery_snapshot_maintenance_workflow`: 6/6 passed
- `py_compile`: passed
- `git diff --check`: clean
- The broader gallery/prelaunch tests still report the already-known stale `submissions-data.js` snapshot; this PR does not modify generated publication artifacts or bypass the maintainer PR gate.
