### PR TITLE
fix(review): invalidate stale advisory cache identities

### DIFF
--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -235,6 +235,8 @@ python3 scripts/ai_review_submission.py \
 - `pr-comment.md`：可复制到 PR 的最终意见。
 - `review-input.json`、`review-prompt.md`、`request-metadata.json`：本地审计材料。
 
+队列 worker 还会在维护者主机的 `.maintainer-review/queue/review-observations.jsonl` 追加一行最小观察记录。记录包含 PR/head、各维度分数、加权分、`repair_count`、下一步数量、评审身份摘要、发布建议和是否复用了缓存；不包含评语正文、模型原始输出或视觉材料。该文件属于本地维护审计，不提交到仓库，也不作为公开评分表。
+
 发布建议分为 `do-not-publish`、`publish-qualified` 和 `featured-candidate`。它只由 schema 合规输出、本地 gate 和加权分共同派生；`featured-candidate` 仍需通过维护者发布脚本写入 `gallery-publication.json`，AI 脚本本身不修改发布清单、不提交、不评论 PR、不 merge。
 
 AI 无法仅凭文件内容证明现实世界中的版权归属或资料公开性。缺少授权、来源或权属证据时，prompt 要求返回 `request-changes` 和具体补证清单，而不是臆测“已合规”。

--- a/scripts/ai_review_submission.py
+++ b/scripts/ai_review_submission.py
@@ -358,42 +358,60 @@ def stable_json_sha256(value: Any) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
+TRUSTED_REVIEW_SCRIPT_NAMES = (
+    "ai_review_submission.py",
+    "auto_review_queue.py",
+    "generate_submissions_data.py",
+    "review_submission.py",
+    "source_registry_utils.py",
+    "validate_local_submission.py",
+    "validate_submission.py",
+    "self_check_submission.py",
+    "spatial_review.py",
+    "visual_review.py",
+    "professional_review.py",
+)
+
+# These are the repository-controlled inputs read by the trusted review
+# scripts.  Glob entries are intentional: adding/removing an enum or scenario
+# must invalidate an advisory cache even when the current package does not use
+# that new value yet.
+TRUSTED_REVIEW_POLICY_PATHS = (
+    ADVISORY_REVIEW_SCHEMA_PATH,
+    "brief/site-package/agent_taskbook.json",
+    "brief/site-package/enums/*.json",
+    "brief/site-package/schemas/geojson_feature.schema.json",
+    "brief/site-package/standards/standards.json",
+    "data/source_registry.json",
+    "tracks.json",
+    "scenarios/*.json",
+)
+
+
 def review_policy_sha256(repo_root: Path) -> str:
-    """Fingerprint the trusted review code and current package policy inputs."""
-    script_names = [
-        "ai_review_submission.py",
-        "auto_review_queue.py",
-        "generate_submissions_data.py",
-        "review_submission.py",
-        "source_registry_utils.py",
-        "validate_submission.py",
-        "self_check_submission.py",
-        "spatial_review.py",
-        "visual_review.py",
-        "professional_review.py",
-    ]
-    policy_paths = [
-        ADVISORY_REVIEW_SCHEMA_PATH,
-        "brief/site-package/agent_taskbook.json",
-        "data/source_registry.json",
-    ]
+    """Fingerprint every trusted code and input that can affect review output."""
     digest = hashlib.sha256()
     script_root = Path(__file__).resolve().parent
-    for script_name in script_names:
+    for script_name in TRUSTED_REVIEW_SCRIPT_NAMES:
         path = script_root / script_name
         digest.update(f"trusted-scripts/{script_name}".encode("utf-8"))
         digest.update(b"\0")
         digest.update(path.read_bytes() if path.is_file() else b"<missing>")
         digest.update(b"\0")
-    for relative_path in policy_paths:
-        path = repo_root / relative_path
-        digest.update(f"package-policy/{relative_path}".encode("utf-8"))
-        digest.update(b"\0")
-        if path.is_file():
+    for pattern in TRUSTED_REVIEW_POLICY_PATHS:
+        matches = sorted(
+            path for path in repo_root.glob(pattern) if path.is_file()
+        )
+        if not matches:
+            digest.update(f"package-policy/{pattern}".encode("utf-8"))
+            digest.update(b"\0<missing>\0")
+            continue
+        for path in matches:
+            relative_path = path.relative_to(repo_root).as_posix()
+            digest.update(f"package-policy/{relative_path}".encode("utf-8"))
+            digest.update(b"\0")
             digest.update(path.read_bytes())
-        else:
-            digest.update(b"<missing>")
-        digest.update(b"\0")
+            digest.update(b"\0")
     return digest.hexdigest()
 
 

--- a/scripts/ai_review_submission.py
+++ b/scripts/ai_review_submission.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import base64
 from datetime import datetime, timezone
+import hashlib
 import json
 import mimetypes
 import os
@@ -350,6 +351,70 @@ def compact_review_input(review_input: dict[str, Any]) -> dict[str, Any]:
     result = dict(review_input)
     result.pop("advisory_review_schema", None)
     return result
+
+
+def stable_json_sha256(value: Any) -> str:
+    payload = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def review_policy_sha256(repo_root: Path) -> str:
+    """Fingerprint the trusted review code and current package policy inputs."""
+    script_names = [
+        "ai_review_submission.py",
+        "auto_review_queue.py",
+        "review_submission.py",
+        "validate_submission.py",
+        "self_check_submission.py",
+        "spatial_review.py",
+        "visual_review.py",
+        "professional_review.py",
+    ]
+    policy_paths = [
+        ADVISORY_REVIEW_SCHEMA_PATH,
+        "brief/site-package/agent_taskbook.json",
+        "data/source_registry.json",
+    ]
+    digest = hashlib.sha256()
+    script_root = Path(__file__).resolve().parent
+    for script_name in script_names:
+        path = script_root / script_name
+        digest.update(f"trusted-scripts/{script_name}".encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes() if path.is_file() else b"<missing>")
+        digest.update(b"\0")
+    for relative_path in policy_paths:
+        path = repo_root / relative_path
+        digest.update(f"package-policy/{relative_path}".encode("utf-8"))
+        digest.update(b"\0")
+        if path.is_file():
+            digest.update(path.read_bytes())
+        else:
+            digest.update(b"<missing>")
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def review_identity(
+    repo_root: Path,
+    submission_dir: Path,
+    review_input: dict[str, Any],
+    schema: dict[str, Any],
+    model: str,
+    base_url: str,
+    reasoning_effort: str,
+) -> dict[str, str]:
+    prompt = system_instructions() + "\n\n" + build_prompt(review_input)
+    return {
+        "reviewed_package_sha256": package_sha256(submission_dir),
+        "review_input_sha256": stable_json_sha256(compact_review_input(review_input)),
+        "prompt_sha256": hashlib.sha256(prompt.encode("utf-8")).hexdigest(),
+        "review_schema_sha256": stable_json_sha256(schema),
+        "review_policy_sha256": review_policy_sha256(repo_root),
+        "model": model,
+        "base_url": base_url,
+        "reasoning_effort": reasoning_effort,
+    }
 
 
 def api_response_schema(schema: dict[str, Any]) -> dict[str, Any]:
@@ -781,13 +846,12 @@ def run_ai_review(
             "preflight_issues": visual_preflight_issues,
         }
         review_input["ai_content_preflight_issues"] = content_preflight_issues
+        identity = review_identity(repo_root, submission_dir, review_input, schema, model, base_url, reasoning_effort)
         payload = build_request_payload(review_input, schema, model, visual_content, reasoning_effort)
         metadata = {
             "schema_version": "1.0.0",
             "submission_dir": review_input["submission_dir"],
-            "reviewed_package_sha256": package_sha256(submission_dir),
-            "model": model,
-            "base_url": base_url,
+            **identity,
             "generated_at": datetime.now(timezone.utc).isoformat(),
             "visual_inputs": visual_inputs,
             "visual_warnings": visual_warnings,

--- a/scripts/ai_review_submission.py
+++ b/scripts/ai_review_submission.py
@@ -363,7 +363,9 @@ def review_policy_sha256(repo_root: Path) -> str:
     script_names = [
         "ai_review_submission.py",
         "auto_review_queue.py",
+        "generate_submissions_data.py",
         "review_submission.py",
+        "source_registry_utils.py",
         "validate_submission.py",
         "self_check_submission.py",
         "spatial_review.py",

--- a/scripts/ai_review_submission.py
+++ b/scripts/ai_review_submission.py
@@ -398,16 +398,36 @@ def review_policy_sha256(repo_root: Path) -> str:
         digest.update(b"\0")
         digest.update(path.read_bytes() if path.is_file() else b"<missing>")
         digest.update(b"\0")
+    trusted_policy_root = script_root.parent
     for pattern in TRUSTED_REVIEW_POLICY_PATHS:
-        matches = sorted(
-            path for path in repo_root.glob(pattern) if path.is_file()
-        )
+        # Some deterministic validators intentionally fall back to the
+        # maintainer checkout when a PR checkout is missing a policy file.
+        # Hash the effective file for every relative match so a change to that
+        # trusted fallback cannot reuse an older advisory review.
+        repo_matches = {
+            path.relative_to(repo_root).as_posix(): path
+            for path in repo_root.glob(pattern)
+            if path.is_file()
+        }
+        trusted_matches = {
+            path.relative_to(trusted_policy_root).as_posix(): path
+            for path in trusted_policy_root.glob(pattern)
+            if path.is_file()
+        }
+        matches = [
+            (
+                relative_path,
+                repo_matches[relative_path]
+                if relative_path in repo_matches
+                else trusted_matches[relative_path],
+            )
+            for relative_path in sorted(set(repo_matches) | set(trusted_matches))
+        ]
         if not matches:
             digest.update(f"package-policy/{pattern}".encode("utf-8"))
             digest.update(b"\0<missing>\0")
             continue
-        for path in matches:
-            relative_path = path.relative_to(repo_root).as_posix()
+        for relative_path, path in matches:
             digest.update(f"package-policy/{relative_path}".encode("utf-8"))
             digest.update(b"\0")
             digest.update(path.read_bytes())

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -21,8 +21,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from ai_review_submission import DEFAULT_BASE_URL, review_policy_sha256
+from ai_review_submission import DEFAULT_BASE_URL, review_identity
 from generate_submissions_data import package_sha256
+from review_submission import ADVISORY_REVIEW_SCHEMA_PATH, build_review_input
 
 
 REVIEW_MARKER = "<!-- haidian-auto-review:{head_sha} -->"
@@ -255,6 +256,8 @@ def load_cached_review(
         decision = json.loads((audit_dir / "ai-decision.json").read_text(encoding="utf-8"))
         comment = (audit_dir / "pr-comment.md").read_text(encoding="utf-8")
         metadata = json.loads((audit_dir / "request-metadata.json").read_text(encoding="utf-8"))
+        cached_input = json.loads((audit_dir / "review-input.json").read_text(encoding="utf-8"))
+        schema = json.loads((checkout_root / ADVISORY_REVIEW_SCHEMA_PATH).read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
     if not comment.strip():
@@ -262,6 +265,8 @@ def load_cached_review(
     if review.get("submission_dir") != submission_dir or decision.get("submission_dir") != submission_dir:
         return None
     if decision.get("dry_run") is not False or decision.get("model_output_schema_valid") is not True:
+        return None
+    if not isinstance(cached_input, dict) or not isinstance(schema, dict):
         return None
     try:
         expected_hash = package_sha256(checkout_root / submission_dir)
@@ -294,7 +299,56 @@ def load_cached_review(
         return None
     if metadata["reasoning_effort"] != reasoning_effort:
         return None
-    if metadata["review_policy_sha256"] != review_policy_sha256(checkout_root):
+    visual_inputs = metadata.get("visual_inputs")
+    visual_warnings = metadata.get("visual_warnings")
+    visual_preflight_issues = metadata.get("visual_preflight_issues")
+    content_preflight_issues = metadata.get("content_preflight_issues")
+    if not all(
+        isinstance(value, list)
+        for value in [visual_inputs, visual_warnings, visual_preflight_issues, content_preflight_issues]
+    ):
+        return None
+
+    try:
+        current_input = build_review_input(checkout_root, checkout_root / submission_dir)
+        current_input["ai_visual_input_summary"] = {
+            "included": visual_inputs,
+            "warnings": visual_warnings,
+            "preflight_issues": visual_preflight_issues,
+        }
+        current_input["ai_content_preflight_issues"] = content_preflight_issues
+        cached_identity = review_identity(
+            checkout_root,
+            checkout_root / submission_dir,
+            cached_input,
+            schema,
+            model,
+            base_url,
+            reasoning_effort,
+        )
+        current_identity = review_identity(
+            checkout_root,
+            checkout_root / submission_dir,
+            current_input,
+            schema,
+            model,
+            base_url,
+            reasoning_effort,
+        )
+    except Exception:
+        return None
+
+    if cached_input.get("submission_dir") != submission_dir or current_input.get("submission_dir") != submission_dir:
+        return None
+    if any(
+        any(record.get(field) != expected.get(field) for field in identity_fields)
+        for record, expected in [
+            (metadata, cached_identity),
+            (decision, cached_identity),
+            (metadata, current_identity),
+            (decision, current_identity),
+        ]
+    ):
         return None
     try:
         outcome = decide(review, decision, threshold)

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
 import fcntl
 import json
 import os
@@ -29,6 +30,8 @@ CONFLICT_MARKER = "<!-- haidian-auto-review-conflict:{head_sha} -->"
 PASS = "SUCCESS"
 WORKTREE_LOCK = threading.Lock()
 GITHUB_WRITE_LOCK = threading.Lock()
+OBSERVATION_LOCK = threading.Lock()
+OBSERVATION_SCHEMA_VERSION = "1.0.0"
 
 
 class WorkerError(RuntimeError):
@@ -40,6 +43,63 @@ class Decision:
     action: str
     score: float | None
     reason: str
+
+
+def build_review_observation(
+    *,
+    number: int,
+    head_sha: str,
+    submission_dir: str,
+    review: dict[str, Any],
+    decision: dict[str, Any],
+    outcome: Decision,
+    reused_audit: bool,
+) -> dict[str, Any]:
+    """Return a minimal local observation without persisting review prose."""
+    rubric_scores = {
+        str(item["dimension_id"]): item["score"]
+        for item in review.get("rubric_scores", [])
+        if isinstance(item, dict) and "dimension_id" in item and "score" in item
+    }
+    repair_count = sum(
+        len(item.get("required_repairs_zh", []))
+        for item in review.get("rubric_scores", [])
+        if isinstance(item, dict) and isinstance(item.get("required_repairs_zh", []), list)
+    )
+    next_actions = review.get("required_next_actions_zh", [])
+    return {
+        "schema_version": OBSERVATION_SCHEMA_VERSION,
+        "recorded_at": datetime.now(timezone.utc).isoformat(),
+        "pr_number": number,
+        "head_sha": head_sha,
+        "submission_dir": submission_dir,
+        "reviewed_package_sha256": decision.get("reviewed_package_sha256"),
+        "review_input_sha256": decision.get("review_input_sha256"),
+        "prompt_sha256": decision.get("prompt_sha256"),
+        "review_schema_sha256": decision.get("review_schema_sha256"),
+        "review_policy_sha256": decision.get("review_policy_sha256"),
+        "model": decision.get("model"),
+        "base_url": decision.get("base_url"),
+        "reasoning_effort": decision.get("reasoning_effort"),
+        "weighted_score_100": decision.get("weighted_score_100"),
+        "rubric_scores": rubric_scores,
+        "repair_count": repair_count,
+        "required_next_actions_count": len(next_actions) if isinstance(next_actions, list) else None,
+        "publication_recommendation": decision.get("publication_recommendation"),
+        "action": outcome.action,
+        "cache_reused": reused_audit,
+    }
+
+
+def append_review_observation(ledger_path: Path, observation: dict[str, Any]) -> None:
+    """Append one JSON observation atomically for same-process queue workers."""
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(observation, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+    with OBSERVATION_LOCK:
+        with ledger_path.open("a", encoding="utf-8") as handle:
+            handle.write(line)
+            handle.flush()
+            os.fsync(handle.fileno())
 
 
 def run(command: list[str], *, cwd: Path, capture: bool = True) -> subprocess.CompletedProcess[str]:
@@ -371,6 +431,18 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
             "package_sha256": ai_decision.get("reviewed_package_sha256"),
             "reused_audit": reused_audit,
         }
+        append_review_observation(
+            args.audit_root / "review-observations.jsonl",
+            build_review_observation(
+                number=number,
+                head_sha=head_sha,
+                submission_dir=submission_dir,
+                review=review,
+                decision=ai_decision,
+                outcome=outcome,
+                reused_audit=reused_audit,
+            ),
+        )
         if args.apply:
             with GITHUB_WRITE_LOCK:
                 apply_review(

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from ai_review_submission import DEFAULT_BASE_URL, review_policy_sha256
 from generate_submissions_data import package_sha256
 
 
@@ -184,11 +185,16 @@ def load_cached_review(
     submission_dir: str,
     checkout_root: Path,
     threshold: float,
+    *,
+    model: str,
+    base_url: str,
+    reasoning_effort: str,
 ) -> tuple[dict[str, Any], dict[str, Any], Decision] | None:
     try:
         review = json.loads((audit_dir / "ai-review.json").read_text(encoding="utf-8"))
         decision = json.loads((audit_dir / "ai-decision.json").read_text(encoding="utf-8"))
         comment = (audit_dir / "pr-comment.md").read_text(encoding="utf-8")
+        metadata = json.loads((audit_dir / "request-metadata.json").read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
     if not comment.strip():
@@ -202,6 +208,33 @@ def load_cached_review(
     except SystemExit:
         return None
     if decision.get("reviewed_package_sha256") != expected_hash:
+        return None
+    identity_fields = [
+        "reviewed_package_sha256",
+        "review_input_sha256",
+        "prompt_sha256",
+        "review_schema_sha256",
+        "review_policy_sha256",
+        "model",
+        "base_url",
+        "reasoning_effort",
+    ]
+    if any(
+        not isinstance(metadata.get(field), str)
+        or metadata.get(field) != decision.get(field)
+        for field in identity_fields
+    ):
+        return None
+    expected_base_url = os.getenv("OPENAI_BASE_URL", DEFAULT_BASE_URL)
+    if (
+        metadata["model"] != model
+        or metadata["base_url"] != base_url
+        or metadata["base_url"] != expected_base_url
+    ):
+        return None
+    if metadata["reasoning_effort"] != reasoning_effort:
+        return None
+    if metadata["review_policy_sha256"] != review_policy_sha256(checkout_root):
         return None
     try:
         outcome = decide(review, decision, threshold)
@@ -287,7 +320,15 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
         checked = run(["git", "rev-parse", "HEAD"], cwd=worktree).stdout.strip()
         if checked != head_sha:
             raise WorkerError("fetched worktree SHA does not match live PR head")
-        cached = load_cached_review(audit_dir, submission_dir, worktree, args.threshold)
+        cached = load_cached_review(
+            audit_dir,
+            submission_dir,
+            worktree,
+            args.threshold,
+            model=args.model,
+            base_url=os.getenv("OPENAI_BASE_URL", DEFAULT_BASE_URL),
+            reasoning_effort=args.reasoning_effort,
+        )
         if cached is None:
             command = [
                 sys.executable,

--- a/tests/test_ai_review_submission.py
+++ b/tests/test_ai_review_submission.py
@@ -201,6 +201,15 @@ class AIReviewSubmissionTests(unittest.TestCase):
             self.assertTrue((out / "ai-decision.json").is_file())
             self.assertTrue((out / "ai-review-report.md").is_file())
             self.assertTrue((out / "pr-comment.md").is_file())
+            metadata = json.loads((out / "request-metadata.json").read_text(encoding="utf-8"))
+            for field in [
+                "review_input_sha256",
+                "prompt_sha256",
+                "review_schema_sha256",
+                "review_policy_sha256",
+            ]:
+                self.assertRegex(metadata[field], r"^[0-9a-f]{64}$")
+            self.assertEqual("high", metadata["reasoning_effort"])
             self.assertEqual("json_schema", client.payload["text"]["format"]["type"])
             self.assertNotIn("$schema", client.payload["text"]["format"]["schema"])
             self.assertNotIn("$id", client.payload["text"]["format"]["schema"])

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -10,7 +10,10 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
 from auto_review_queue import (  # noqa: E402
+    Decision,
     WorkerError,
+    append_review_observation,
+    build_review_observation,
     ci_state,
     decide,
     load_cached_review,
@@ -26,6 +29,51 @@ class AutoReviewQueueTests(unittest.TestCase):
         with patch.object(sys, "argv", ["auto_review_queue"]):
             args = parse_args()
         self.assertEqual(18, args.max_images)
+
+    def test_review_observation_is_minimal_and_append_only(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            ledger = Path(temp_dir) / "queue" / "review-observations.jsonl"
+            review = {
+                "rubric_scores": [
+                    {"dimension_id": "brief_alignment", "score": 4, "required_repairs_zh": ["clarify scope"]},
+                    {"dimension_id": "originality", "score": 3, "required_repairs_zh": []},
+                ],
+                "required_next_actions_zh": ["clarify scope"],
+            }
+            decision = {
+                "reviewed_package_sha256": "a" * 64,
+                "review_input_sha256": "b" * 64,
+                "prompt_sha256": "c" * 64,
+                "review_schema_sha256": "d" * 64,
+                "review_policy_sha256": "e" * 64,
+                "model": "gpt-test",
+                "base_url": DEFAULT_BASE_URL,
+                "reasoning_effort": "high",
+                "weighted_score_100": 72.5,
+                "publication_recommendation": "publish-qualified",
+            }
+            first = build_review_observation(
+                number=1190,
+                head_sha="f" * 40,
+                submission_dir="submissions/alice/plan",
+                review=review,
+                decision=decision,
+                outcome=Decision("accept", 72.5, "threshold and all gates passed"),
+                reused_audit=False,
+            )
+            second = dict(first, recorded_at="later", cache_reused=True)
+            append_review_observation(ledger, first)
+            append_review_observation(ledger, second)
+
+            rows = [json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines()]
+            self.assertEqual(2, len(rows))
+            self.assertEqual({"brief_alignment": 4, "originality": 3}, rows[0]["rubric_scores"])
+            self.assertEqual(1, rows[0]["repair_count"])
+            self.assertEqual(1, rows[0]["required_next_actions_count"])
+            self.assertFalse(rows[0]["cache_reused"])
+            self.assertTrue(rows[1]["cache_reused"])
+            self.assertNotIn("required_repairs_zh", rows[0])
+            self.assertNotIn("comment_zh", rows[0])
 
     def test_accepts_score_at_threshold_when_all_gates_pass(self) -> None:
         review = {

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -41,6 +41,7 @@ class AutoReviewQueueTests(unittest.TestCase):
                 "generate_submissions_data.py",
                 "review_submission.py",
                 "source_registry_utils.py",
+                "validate_local_submission.py",
                 "validate_submission.py",
                 "self_check_submission.py",
                 "spatial_review.py",
@@ -61,6 +62,32 @@ class AutoReviewQueueTests(unittest.TestCase):
                 ai_review_submission.__file__ = str(scripts / "ai_review_submission.py")
                 before = review_policy_sha256(repo)
                 (scripts / "source_registry_utils.py").write_text("dependency changed", encoding="utf-8")
+                after = review_policy_sha256(repo)
+            finally:
+                ai_review_submission.__file__ = original_file
+
+            self.assertNotEqual(before, after)
+
+    def test_policy_hash_changes_for_transitive_policy_inputs(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir) / "checkout"
+            scripts = repo / "scripts"
+            scripts.mkdir(parents=True)
+            for name in ai_review_submission.TRUSTED_REVIEW_SCRIPT_NAMES:
+                (scripts / name).write_text(name, encoding="utf-8")
+            schema = repo / "brief" / "site-package" / "schemas" / "advisory_review.schema.json"
+            schema.parent.mkdir(parents=True)
+            schema.write_text("{}", encoding="utf-8")
+            enums = repo / "brief" / "site-package" / "enums"
+            enums.mkdir(parents=True)
+            layers = enums / "layers.json"
+            layers.write_text('{"layers": []}', encoding="utf-8")
+
+            original_file = ai_review_submission.__file__
+            try:
+                ai_review_submission.__file__ = str(scripts / "ai_review_submission.py")
+                before = review_policy_sha256(repo)
+                layers.write_text('{"layers": [{"code": "new-layer"}]}', encoding="utf-8")
                 after = review_policy_sha256(repo)
             finally:
                 ai_review_submission.__file__ = original_file

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -94,6 +94,39 @@ class AutoReviewQueueTests(unittest.TestCase):
 
             self.assertNotEqual(before, after)
 
+    def test_policy_hash_changes_for_trusted_fallback_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            trusted_root = root / "trusted"
+            checkout = root / "checkout"
+            scripts = trusted_root / "scripts"
+            scripts.mkdir(parents=True)
+            for name in ai_review_submission.TRUSTED_REVIEW_SCRIPT_NAMES:
+                (scripts / name).write_text(name, encoding="utf-8")
+
+            schema = checkout / "brief" / "site-package" / "schemas" / "advisory_review.schema.json"
+            schema.parent.mkdir(parents=True)
+            schema.write_text("{}", encoding="utf-8")
+            (checkout / "brief" / "site-package").mkdir(exist_ok=True)
+            (checkout / "brief" / "site-package" / "agent_taskbook.json").write_text("{}", encoding="utf-8")
+            (checkout / "data").mkdir()
+            (checkout / "data" / "source_registry.json").write_text("{}", encoding="utf-8")
+
+            fallback_layers = trusted_root / "brief" / "site-package" / "enums" / "layers.json"
+            fallback_layers.parent.mkdir(parents=True)
+            fallback_layers.write_text('{"layers": []}', encoding="utf-8")
+
+            original_file = ai_review_submission.__file__
+            try:
+                ai_review_submission.__file__ = str(scripts / "ai_review_submission.py")
+                before = review_policy_sha256(checkout)
+                fallback_layers.write_text('{"layers": [{"code": "fallback-layer"}]}', encoding="utf-8")
+                after = review_policy_sha256(checkout)
+            finally:
+                ai_review_submission.__file__ = original_file
+
+            self.assertNotEqual(before, after)
+
     def test_review_observation_is_minimal_and_append_only(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             ledger = Path(temp_dir) / "queue" / "review-observations.jsonl"

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -20,8 +20,8 @@ from auto_review_queue import (  # noqa: E402
     parse_args,
     submission_dir_from_files,
 )
-from ai_review_submission import DEFAULT_BASE_URL, review_policy_sha256  # noqa: E402
-from generate_submissions_data import package_sha256  # noqa: E402
+import ai_review_submission  # noqa: E402
+from ai_review_submission import DEFAULT_BASE_URL, review_identity, review_policy_sha256  # noqa: E402
 
 
 class AutoReviewQueueTests(unittest.TestCase):
@@ -29,6 +29,43 @@ class AutoReviewQueueTests(unittest.TestCase):
         with patch.object(sys, "argv", ["auto_review_queue"]):
             args = parse_args()
         self.assertEqual(18, args.max_images)
+
+    def test_policy_hash_changes_for_transitive_review_dependencies(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir) / "checkout"
+            scripts = repo / "scripts"
+            scripts.mkdir(parents=True)
+            for name in [
+                "ai_review_submission.py",
+                "auto_review_queue.py",
+                "generate_submissions_data.py",
+                "review_submission.py",
+                "source_registry_utils.py",
+                "validate_submission.py",
+                "self_check_submission.py",
+                "spatial_review.py",
+                "visual_review.py",
+                "professional_review.py",
+            ]:
+                (scripts / name).write_text(name, encoding="utf-8")
+            schema = repo / "brief" / "site-package" / "schemas" / "advisory_review.schema.json"
+            schema.parent.mkdir(parents=True)
+            schema.write_text("{}", encoding="utf-8")
+            (repo / "brief" / "site-package").mkdir(exist_ok=True)
+            (repo / "brief" / "site-package" / "agent_taskbook.json").write_text("{}", encoding="utf-8")
+            (repo / "data").mkdir()
+            (repo / "data" / "source_registry.json").write_text("{}", encoding="utf-8")
+
+            original_file = ai_review_submission.__file__
+            try:
+                ai_review_submission.__file__ = str(scripts / "ai_review_submission.py")
+                before = review_policy_sha256(repo)
+                (scripts / "source_registry_utils.py").write_text("dependency changed", encoding="utf-8")
+                after = review_policy_sha256(repo)
+            finally:
+                ai_review_submission.__file__ = original_file
+
+            self.assertNotEqual(before, after)
 
     def test_review_observation_is_minimal_and_append_only(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -214,9 +251,18 @@ class AutoReviewQueueTests(unittest.TestCase):
             submission.mkdir(parents=True)
             (submission / "proposal.md").write_text("proposal", encoding="utf-8")
             (submission / "manifest.json").write_text('{"files": []}', encoding="utf-8")
-            digest = package_sha256(submission)
             audit = Path(temp_dir) / "audit"
             audit.mkdir()
+            schema_path = checkout / "brief" / "site-package" / "schemas" / "advisory_review.schema.json"
+            schema_path.parent.mkdir(parents=True)
+            schema_path.write_text("{}", encoding="utf-8")
+            review_input = {
+                "submission_dir": "submissions/alice/plan",
+                "author": "alice",
+                "input_revision": "v1",
+                "ai_visual_input_summary": {"included": [], "warnings": [], "preflight_issues": []},
+                "ai_content_preflight_issues": [],
+            }
             review = {
                 "submission_dir": "submissions/alice/plan",
                 "mandatory_rejection": {"result": "pass"},
@@ -230,13 +276,18 @@ class AutoReviewQueueTests(unittest.TestCase):
                     ]
                 },
             }
+            identity = review_identity(
+                checkout,
+                submission,
+                review_input,
+                {},
+                "gpt-test",
+                DEFAULT_BASE_URL,
+                "high",
+            )
             decision = {
                 "submission_dir": "submissions/alice/plan",
-                "reviewed_package_sha256": digest,
-                "review_input_sha256": "b" * 64,
-                "prompt_sha256": "c" * 64,
-                "review_schema_sha256": "d" * 64,
-                "review_policy_sha256": review_policy_sha256(checkout),
+                **identity,
                 "model": "gpt-test",
                 "base_url": DEFAULT_BASE_URL,
                 "reasoning_effort": "high",
@@ -246,18 +297,31 @@ class AutoReviewQueueTests(unittest.TestCase):
             }
             (audit / "ai-review.json").write_text(json.dumps(review), encoding="utf-8")
             (audit / "ai-decision.json").write_text(json.dumps(decision), encoding="utf-8")
-            (audit / "request-metadata.json").write_text(json.dumps(decision), encoding="utf-8")
+            (audit / "review-input.json").write_text(json.dumps(review_input), encoding="utf-8")
+            (audit / "request-metadata.json").write_text(
+                json.dumps(
+                    {
+                        **decision,
+                        "visual_inputs": [],
+                        "visual_warnings": [],
+                        "visual_preflight_issues": [],
+                        "content_preflight_issues": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
             (audit / "pr-comment.md").write_text("review", encoding="utf-8")
 
-            cached = load_cached_review(
-                audit,
-                "submissions/alice/plan",
-                checkout,
-                60,
-                model="gpt-test",
-                base_url=DEFAULT_BASE_URL,
-                reasoning_effort="high",
-            )
+            with patch("auto_review_queue.build_review_input", return_value=review_input):
+                cached = load_cached_review(
+                    audit,
+                    "submissions/alice/plan",
+                    checkout,
+                    60,
+                    model="gpt-test",
+                    base_url=DEFAULT_BASE_URL,
+                    reasoning_effort="high",
+                )
             self.assertIsNotNone(cached)
             assert cached is not None
             self.assertEqual("accept", cached[2].action)
@@ -274,18 +338,19 @@ class AutoReviewQueueTests(unittest.TestCase):
                 )
             )
 
-            (submission / "proposal.md").write_text("updated", encoding="utf-8")
-            self.assertIsNone(
-                load_cached_review(
-                    audit,
-                    "submissions/alice/plan",
-                    checkout,
-                    60,
-                    model="gpt-test",
-                    base_url=DEFAULT_BASE_URL,
-                    reasoning_effort="high",
+            changed_input = dict(review_input, input_revision="v2")
+            with patch("auto_review_queue.build_review_input", return_value=changed_input):
+                self.assertIsNone(
+                    load_cached_review(
+                        audit,
+                        "submissions/alice/plan",
+                        checkout,
+                        60,
+                        model="gpt-test",
+                        base_url=DEFAULT_BASE_URL,
+                        reasoning_effort="high",
+                    )
                 )
-            )
 
 
 if __name__ == "__main__":

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -17,6 +17,7 @@ from auto_review_queue import (  # noqa: E402
     parse_args,
     submission_dir_from_files,
 )
+from ai_review_submission import DEFAULT_BASE_URL, review_policy_sha256  # noqa: E402
 from generate_submissions_data import package_sha256  # noqa: E402
 
 
@@ -184,21 +185,59 @@ class AutoReviewQueueTests(unittest.TestCase):
             decision = {
                 "submission_dir": "submissions/alice/plan",
                 "reviewed_package_sha256": digest,
+                "review_input_sha256": "b" * 64,
+                "prompt_sha256": "c" * 64,
+                "review_schema_sha256": "d" * 64,
+                "review_policy_sha256": review_policy_sha256(checkout),
+                "model": "gpt-test",
+                "base_url": DEFAULT_BASE_URL,
+                "reasoning_effort": "high",
                 "weighted_score_100": 61,
                 "dry_run": False,
                 "model_output_schema_valid": True,
             }
             (audit / "ai-review.json").write_text(json.dumps(review), encoding="utf-8")
             (audit / "ai-decision.json").write_text(json.dumps(decision), encoding="utf-8")
+            (audit / "request-metadata.json").write_text(json.dumps(decision), encoding="utf-8")
             (audit / "pr-comment.md").write_text("review", encoding="utf-8")
 
-            cached = load_cached_review(audit, "submissions/alice/plan", checkout, 60)
+            cached = load_cached_review(
+                audit,
+                "submissions/alice/plan",
+                checkout,
+                60,
+                model="gpt-test",
+                base_url=DEFAULT_BASE_URL,
+                reasoning_effort="high",
+            )
             self.assertIsNotNone(cached)
             assert cached is not None
             self.assertEqual("accept", cached[2].action)
 
+            self.assertIsNone(
+                load_cached_review(
+                    audit,
+                    "submissions/alice/plan",
+                    checkout,
+                    60,
+                    model="gpt-new",
+                    base_url=DEFAULT_BASE_URL,
+                    reasoning_effort="high",
+                )
+            )
+
             (submission / "proposal.md").write_text("updated", encoding="utf-8")
-            self.assertIsNone(load_cached_review(audit, "submissions/alice/plan", checkout, 60))
+            self.assertIsNone(
+                load_cached_review(
+                    audit,
+                    "submissions/alice/plan",
+                    checkout,
+                    60,
+                    model="gpt-test",
+                    base_url=DEFAULT_BASE_URL,
+                    reasoning_effort="high",
+                )
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

Fixes the advisory-review cache identity raised in #950.

auto_review_queue.py previously reused a local verdict when the submission path and package SHA matched. It did not verify the model, endpoint, reasoning effort, prompt/input, schema, or review-policy revision. A same-head rerun after a review-policy or model change could therefore silently reuse an old verdict.

This patch:

- records package, review-input, prompt, schema, and policy SHA-256 identities;
- records model, endpoint, and reasoning effort;
- fingerprints the trusted review scripts plus the package-side taskbook/schema/source registry;
- requires request-metadata.json and exact identity agreement before cache reuse;
- makes legacy/incomplete caches fail closed;
- leaves score thresholds and publication policy unchanged.

## Verification

- test_ai_review_submission.py: 14 passed
- test_auto_review_queue.py: 8 passed
- test_review_submission.py: 2 passed
- test_maintainer_review.py: 5 passed
- test_trusted_review_scripts.py: 2 passed
- py_compile and git diff --check: passed

This is an observability/cache-correctness fix; it does not claim any score, merge, publication, or ranking change.