### PR TITLE
fix: make self-check subprocess decoding Windows-safe

### DIFF
--- a/scripts/self_check_submission.py
+++ b/scripts/self_check_submission.py
@@ -24,18 +24,27 @@ def script_path(repo_root: Path, name: str) -> Path:
 
 
 def run_json_command(command: list[str]) -> dict[str, Any]:
-    completed = subprocess.run(command, capture_output=True, text=True, check=False)
+    completed = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    stdout = completed.stdout or ""
+    stderr = completed.stderr or ""
     parsed: Any = {}
-    if completed.stdout.strip():
+    if stdout.strip():
         try:
-            parsed = json.loads(completed.stdout)
+            parsed = json.loads(stdout)
         except json.JSONDecodeError:
-            parsed = {"raw_stdout": completed.stdout}
+            parsed = {"raw_stdout": stdout}
     return {
         "returncode": completed.returncode,
         "ok": completed.returncode == 0,
         "stdout": parsed,
-        "stderr": completed.stderr.strip(),
+        "stderr": stderr.strip(),
     }
 
 

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -22,6 +22,8 @@ if HAS_REVIEW_DEPS:
     from shapely.geometry import shape  # noqa: E402
     from shapely.ops import transform  # noqa: E402
 
+from self_check_submission import run_json_command  # noqa: E402
+
 
 class AgentFacingDocsTests(unittest.TestCase):
     def test_agent_docs_use_scaffold_and_full_self_check_commands(self) -> None:
@@ -41,6 +43,31 @@ class AgentFacingDocsTests(unittest.TestCase):
         self.assertIn("Post-Submission Monitoring", skill)
         self.assertIn("gh pr checks", skill)
         self.assertIn("Uploading is not completion", skill)
+
+
+class SelfCheckCommandTests(unittest.TestCase):
+    @mock.patch("self_check_submission.subprocess.run")
+    def test_run_json_command_uses_utf8_and_handles_empty_streams(self, run) -> None:
+        run.side_effect = [
+            subprocess.CompletedProcess(
+                ["validator"],
+                0,
+                stdout='{"message":"中文：全角括号"}',
+                stderr="提示：继续检查",
+            ),
+            subprocess.CompletedProcess(["validator"], 1, stdout=None, stderr=None),
+        ]
+
+        decoded = run_json_command(["validator"])
+        failed = run_json_command(["validator"])
+
+        kwargs = run.call_args_list[0].kwargs
+        self.assertEqual("utf-8", kwargs["encoding"])
+        self.assertEqual("replace", kwargs["errors"])
+        self.assertEqual({"message": "中文：全角括号"}, decoded["stdout"])
+        self.assertEqual("提示：继续检查", decoded["stderr"])
+        self.assertEqual({}, failed["stdout"])
+        self.assertEqual("", failed["stderr"])
 
 
 def run_scaffold(output_dir: Path, stage: str = "formal", cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess:


### PR DESCRIPTION
## Summary

Fixes #1203.

`self_check_submission.py` now decodes validator subprocess output as UTF-8 with replacement for malformed bytes, matching the repository's UTF-8 subprocess boundary used by the other participant tools. The helper also treats missing stdout/stderr as empty strings so a subprocess failure cannot turn into an unrelated `AttributeError`.

## Root cause

`run_json_command()` used `text=True` without an explicit encoding. On Chinese Windows, Python therefore used the GBK locale to decode UTF-8 validator output. The reader thread could fail before the helper received stdout, and the subsequent `.strip()` obscured the original failure.

## Validation

- `python3 -m unittest tests.test_agent_scaffold_and_self_check -v` — 20 passed
- `python3 -m py_compile scripts/self_check_submission.py tests/test_agent_scaffold_and_self_check.py`
- `git diff --check`

The regression test asserts the UTF-8/error-handling subprocess contract, preserves non-ASCII JSON and stderr, and covers empty output streams. This PR changes only the self-check helper and its regression test; it does not change submission validation rules or package files.
