### PR TITLE
fix(two-way-line): persist real four-gate self-check evidence (#883/#807)

### DIFF
--- a/submissions/xr843/jingzhang-two-way-line/changelog.md
+++ b/submissions/xr843/jingzhang-two-way-line/changelog.md
@@ -1,5 +1,13 @@
 # 方案迭代记录
 
+## v1.1 - 2026-08-10
+
+- 持久化本包在当前 main 提交上的真实四门自检结果（deterministic validation / spatial review / visual packaging / professional evidence 均为 PASS），并写入 `review_status=formal-review-ready` 与 `manifest.validation_claim.readiness_contract=persisted-self-check-v1`。响应 #883 测得的存量缺口与 #807 的 readiness 契约。
+- 证据由 `scripts/self_check_submission.py --mark-self-checked` 实跑生成并回读，内嵌各门原始报告；这是作者侧的可复现回放记录，不是独立背书，provenance 仍以受信 CI 或维护者重跑为准。
+- 保留本包原有的六项包级自检（BOUNDARY_TRUST / KEY_AREAS_TRUST / LAND_USE_TOPOLOGY / METRIC_RECALC / VISUAL_STATIC / BILINGUAL_PAIRING）与四门规范化记录并存，使 `compliance_matrix.json` 的 `self_check_ids` 引用保持完整。
+- 三条 `KEY_AREA_PROVISIONAL` 仍如实保留为 minor、非阻断提示：重点区为推定范围，不是官方红线，也不构成精确面积依据。
+- 未改动几何、指标数值、图纸、正文结论或许可声明；未改动 `submissions-data.js`、`gallery-publication.json`，也未触碰其它投稿包。
+
 ## v1.0 - 2026-08-09
 
 - 初版 formal 概念方案包：「京张对开 THE TWO-WAY LINE」。

--- a/submissions/xr843/jingzhang-two-way-line/manifest.json
+++ b/submissions/xr843/jingzhang-two-way-line/manifest.json
@@ -54,7 +54,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "af54429d1f28ea6209a7c32396bef03c64732691339815fd4226a6e5cd2b8ff1"
+      "sha256": "119e5bf5cb1d726d847c3b28bc07e1da6fed3e6a1283a47481330836e0fa9ab8"
     },
     {
       "path": "compliance_matrix.json",
@@ -287,7 +287,7 @@
       "path": "changelog.md",
       "role": "narrative",
       "required": false,
-      "sha256": "212758e4bff834603d105eb604d5bcb2837c392f9bbef5a4d1ad4c1b8d4cd75d"
+      "sha256": "86cb9ea4a67147626310cfd03d53ffca8624f2fe6e20891f17b045af3c7d56a1"
     },
     {
       "path": "risk.json",
@@ -305,6 +305,7 @@
   "validation_claim": {
     "self_checked": true,
     "known_blockers": [],
-    "data_confidence": "high"
+    "data_confidence": "high",
+    "readiness_contract": "persisted-self-check-v1"
   }
 }

--- a/submissions/xr843/jingzhang-two-way-line/self_check.json
+++ b/submissions/xr843/jingzhang-two-way-line/self_check.json
@@ -1,48 +1,279 @@
 {
- "schema_version": "0.1.0",
- "checked_at": "2026-08-09",
- "tool": "scripts/self_check_submission.py --pr-author xr843",
- "result": "PASS",
- "can_enter_formal_review": true,
- "checks": [
-  {
-   "id": "BOUNDARY_TRUST",
-   "result": "pass",
-   "severity": "info",
-   "note": "site boundary provisional(street-aligned, self-derived, area-calibrated +0.0006%); flagged official_boundary=false everywhere"
+  "ok": true,
+  "submission_dir": "submissions/xr843/jingzhang-two-way-line",
+  "pr_author": "xr843",
+  "stage": "formal",
+  "deterministic_validation": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "errors": [],
+      "warnings": [
+        "submissions/xr843/jingzhang-two-way-line/geometry/site_boundary.geojson: uses provisional boundary; do not treat it as an official redline or precise-area basis. Organizer data gaps do not block content scoring; recalculate when official geometry is supplied",
+        "submissions/xr843/jingzhang-two-way-line/spatial.json: items[0]: provisional spatial concept needs maintainer review before being treated as public-facing context",
+        "submissions/xr843/jingzhang-two-way-line/spatial.json: items[1]: provisional spatial concept needs maintainer review before being treated as public-facing context",
+        "submissions/xr843/jingzhang-two-way-line/spatial.json: items[2]: provisional spatial concept needs maintainer review before being treated as public-facing context",
+        "submissions/xr843/jingzhang-two-way-line/spatial.json: items[3]: provisional spatial concept needs maintainer review before being treated as public-facing context",
+        "submissions/xr843/jingzhang-two-way-line/spatial.json: items[4]: provisional spatial concept needs maintainer review before being treated as public-facing context",
+        "submissions/xr843/jingzhang-two-way-line/spatial.json: items[5]: provisional spatial concept needs maintainer review before being treated as public-facing context",
+        "submissions/xr843/jingzhang-two-way-line/spatial.json: items[6]: provisional spatial concept needs maintainer review before being treated as public-facing context",
+        "submissions/xr843/jingzhang-two-way-line/spatial.json: items[7]: provisional spatial concept needs maintainer review before being treated as public-facing context",
+        "submissions/xr843/jingzhang-two-way-line/spatial.json: items[8]: provisional spatial concept needs maintainer review before being treated as public-facing context",
+        "submissions/xr843/jingzhang-two-way-line/spatial.json: items[9]: provisional spatial concept needs maintainer review before being treated as public-facing context",
+        "submissions/xr843/jingzhang-two-way-line/spatial.json: items[10]: provisional spatial concept needs maintainer review before being treated as public-facing context",
+        "submissions/xr843/jingzhang-two-way-line/spatial.json: items[11]: provisional spatial concept needs maintainer review before being treated as public-facing context"
+      ],
+      "proposal_files": [
+        "submissions/xr843/jingzhang-two-way-line/proposal.md"
+      ],
+      "changelog_files": [
+        "submissions/xr843/jingzhang-two-way-line/changelog.md"
+      ],
+      "changed_files": [
+        "submissions/xr843/jingzhang-two-way-line/agent.json",
+        "submissions/xr843/jingzhang-two-way-line/assets/figures/key-areas.en.png",
+        "submissions/xr843/jingzhang-two-way-line/assets/figures/key-areas.png",
+        "submissions/xr843/jingzhang-two-way-line/assets/figures/land-use-structure.en.png",
+        "submissions/xr843/jingzhang-two-way-line/assets/figures/land-use-structure.png",
+        "submissions/xr843/jingzhang-two-way-line/assets/figures/metrics-evidence.en.png",
+        "submissions/xr843/jingzhang-two-way-line/assets/figures/metrics-evidence.png",
+        "submissions/xr843/jingzhang-two-way-line/assets/figures/mobility-bluegreen.en.png",
+        "submissions/xr843/jingzhang-two-way-line/assets/figures/mobility-bluegreen.png",
+        "submissions/xr843/jingzhang-two-way-line/assets/figures/site-overview.en.png",
+        "submissions/xr843/jingzhang-two-way-line/assets/figures/site-overview.png",
+        "submissions/xr843/jingzhang-two-way-line/assumptions.json",
+        "submissions/xr843/jingzhang-two-way-line/changelog.md",
+        "submissions/xr843/jingzhang-two-way-line/compliance_matrix.json",
+        "submissions/xr843/jingzhang-two-way-line/design_depth_matrix.json",
+        "submissions/xr843/jingzhang-two-way-line/drawings/a0-boards.en.pdf",
+        "submissions/xr843/jingzhang-two-way-line/drawings/a0-boards.pdf",
+        "submissions/xr843/jingzhang-two-way-line/drawings/a3-booklet.en.pdf",
+        "submissions/xr843/jingzhang-two-way-line/drawings/a3-booklet.pdf",
+        "submissions/xr843/jingzhang-two-way-line/geometry/buildings.geojson",
+        "submissions/xr843/jingzhang-two-way-line/geometry/constraints.geojson",
+        "submissions/xr843/jingzhang-two-way-line/geometry/green_space.geojson",
+        "submissions/xr843/jingzhang-two-way-line/geometry/key_areas.geojson",
+        "submissions/xr843/jingzhang-two-way-line/geometry/land_use.geojson",
+        "submissions/xr843/jingzhang-two-way-line/geometry/phasing.geojson",
+        "submissions/xr843/jingzhang-two-way-line/geometry/public_space.geojson",
+        "submissions/xr843/jingzhang-two-way-line/geometry/roads.geojson",
+        "submissions/xr843/jingzhang-two-way-line/geometry/site_boundary.geojson",
+        "submissions/xr843/jingzhang-two-way-line/manifest.json",
+        "submissions/xr843/jingzhang-two-way-line/metrics.json",
+        "submissions/xr843/jingzhang-two-way-line/proposal.en.md",
+        "submissions/xr843/jingzhang-two-way-line/proposal.md",
+        "submissions/xr843/jingzhang-two-way-line/report/copyright_statement.md",
+        "submissions/xr843/jingzhang-two-way-line/report/narrative.md",
+        "submissions/xr843/jingzhang-two-way-line/report/proposal.en.html",
+        "submissions/xr843/jingzhang-two-way-line/report/proposal.html",
+        "submissions/xr843/jingzhang-two-way-line/risk.json",
+        "submissions/xr843/jingzhang-two-way-line/self_check.json",
+        "submissions/xr843/jingzhang-two-way-line/sources.json",
+        "submissions/xr843/jingzhang-two-way-line/spatial.json",
+        "submissions/xr843/jingzhang-two-way-line/standard_matrix.json",
+        "submissions/xr843/jingzhang-two-way-line/visual/index.en.html",
+        "submissions/xr843/jingzhang-two-way-line/visual/index.html"
+      ],
+      "ai_package_stages": {
+        "submissions/xr843/jingzhang-two-way-line": "formal"
+      },
+      "total_bytes": 20251591,
+      "maintainer_bypass": false
+    },
+    "stderr": ""
   },
-  {
-   "id": "KEY_AREAS_TRUST",
-   "result": "pass",
-   "severity": "minor",
-   "note": "three key areas provisional(anchored on public stations/heritage POIs, within ±0.01% of announced); disclosed in proposal/visual/sources/assumptions"
+  "spatial_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "stage": "formal",
+      "issues": [
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-001",
+          "expected": null,
+          "actual": null
+        },
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-002",
+          "expected": null,
+          "actual": null
+        },
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-003",
+          "expected": null,
+          "actual": null
+        }
+      ],
+      "metrics": {
+        "site_area_sqm": 11400064.345,
+        "green_space_area_sqm": 1208541.249,
+        "public_space_area_sqm": 198606.286,
+        "building_footprint_area_sqm": 664369.817,
+        "green_ratio": 0.106012,
+        "public_space_ratio": 0.017422
+      }
+    },
+    "stderr": ""
   },
-  {
-   "id": "LAND_USE_TOPOLOGY",
-   "result": "pass",
-   "severity": "info",
-   "note": "189 polygons full coverage; gap ~658 sqm (<0.01% tolerance); pairwise overlaps under 1 sqm after projected-space repair"
+  "visual_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "issues": [],
+      "metrics_seen": {
+        "site_area_sqm": 11400064.345,
+        "key_area_total_sqm": 3683996.587,
+        "key_area_zhongzhiyuan_sqm": 1921022.69,
+        "key_area_origin_sqm": 1042981.353,
+        "key_area_dazhongsi_sqm": 719992.544,
+        "land_use_area_sqm": 11399406.735,
+        "road_length_m": 38092.4,
+        "greenway_length_m": 7829.5,
+        "crossing_node_count": 8.0,
+        "road_area_ratio": 0.064998,
+        "green_space_area_sqm": 1208541.249,
+        "green_ratio": 0.106012,
+        "public_space_area_sqm": 198606.482,
+        "public_space_ratio": 0.017422,
+        "building_footprint_area_sqm": 664369.817,
+        "building_density": 0.058278,
+        "concept_total_floor_area_sqm": 5890266.76,
+        "phase_1_area_sqm": 1768804.819,
+        "phase_2_area_sqm": 2496922.474,
+        "phase_3_area_sqm": 1693109.632,
+        "ai_scenario_node_count": 12.0,
+        "ai_scenario_card_count": 12.0,
+        "ai_test_scenario_count": 3.0,
+        "user_persona_count": 6.0,
+        "ai_pilgrimage_landmark_count": 4.0,
+        "global_case_study_count": 7.0,
+        "renewal_project_count": 14.0,
+        "key_area_count": 3.0
+      }
+    },
+    "stderr": ""
   },
-  {
-   "id": "METRIC_RECALC",
-   "result": "pass",
-   "severity": "info",
-   "note": "site_area/green_ratio/public_space_ratio recomputed in EPSG:4548 match metrics.json within tolerance"
+  "professional_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "issues": [],
+      "summary": {
+        "standard_matrix_items": 6,
+        "design_depth_items": 15,
+        "known_metric_refs_required": 29,
+        "proposal_format_version": "2",
+        "evidence_contract": "section-anchors-plus-structured-audit",
+        "proposal_reference_counts": {
+          "source": 14,
+          "standard": 6,
+          "depth": 15,
+          "data": 16,
+          "metric": 29
+        }
+      }
+    },
+    "stderr": ""
   },
-  {
-   "id": "VISUAL_STATIC",
-   "result": "pass",
-   "severity": "info",
-   "note": "visual/index.html + index.en.html offline static, zero scripts, all data-metric spans match metrics.json"
-  },
-  {
-   "id": "BILINGUAL_PAIRING",
-   "result": "pass",
-   "severity": "info",
-   "note": "proposal/report HTML/A3/A0/five figures all paired zh+en; v2 + bilingual_contract_version 1"
-  }
- ],
- "residual_warnings": [
-  "KEY_AREA_PROVISIONAL x3 (minor, by design): provisional key areas are not official redlines; content scoring unaffected"
- ]
+  "spatial_issue_ids": [
+    "KEY_AREA_PROVISIONAL",
+    "KEY_AREA_PROVISIONAL",
+    "KEY_AREA_PROVISIONAL"
+  ],
+  "visual_issue_ids": [],
+  "professional_issue_ids": [],
+  "missing_review_dependencies": [],
+  "can_enter_formal_review": true,
+  "package_type": "professional_design_package",
+  "review_status": "formal-review-ready",
+  "next_actions": [],
+  "schema_version": "0.1.0",
+  "checks": [
+    {
+      "check_id": "DETERMINISTIC_VALIDATION",
+      "result": "pass",
+      "severity": "blocking",
+      "target": "validate_local_submission.py",
+      "message": "deterministic_validation: PASS"
+    },
+    {
+      "check_id": "SPATIAL_REVIEW",
+      "result": "pass",
+      "severity": "blocking",
+      "target": "spatial_review.py",
+      "message": "spatial_review: PASS"
+    },
+    {
+      "check_id": "VISUAL_PACKAGING",
+      "result": "pass",
+      "severity": "blocking",
+      "target": "visual_review.py",
+      "message": "visual_review: PASS"
+    },
+    {
+      "check_id": "PROFESSIONAL_EVIDENCE",
+      "result": "pass",
+      "severity": "blocking",
+      "target": "professional_review.py",
+      "message": "professional_review: PASS"
+    },
+    {
+      "check_id": "BOUNDARY_TRUST",
+      "result": "pass",
+      "severity": "info",
+      "target": "geometry/site_boundary.geojson",
+      "message": "Site boundary is provisional (street-aligned, self-derived from announced four-at street centerlines, area-calibrated to 11.40 km2 at +0.0006%); official_boundary=false is set on every feature."
+    },
+    {
+      "check_id": "KEY_AREAS_TRUST",
+      "result": "pass",
+      "severity": "minor",
+      "target": "geometry/key_areas.geojson",
+      "message": "Three key detailed-design areas are provisional (anchored on public stations and heritage POIs, within +/-0.01% of announced areas); disclosed in proposal, visual, sources and assumptions."
+    },
+    {
+      "check_id": "LAND_USE_TOPOLOGY",
+      "result": "pass",
+      "severity": "info",
+      "target": "geometry/land_use.geojson",
+      "message": "189 polygons give full coverage; residual gap ~658 sqm (under the 0.01% tolerance); all pairwise overlaps under 1 sqm after projected-space repair in EPSG:4548."
+    },
+    {
+      "check_id": "METRIC_RECALC",
+      "result": "pass",
+      "severity": "info",
+      "target": "metrics.json",
+      "message": "site_area, green_ratio and public_space_ratio recomputed independently in EPSG:4548 and match metrics.json within tolerance."
+    },
+    {
+      "check_id": "VISUAL_STATIC",
+      "result": "pass",
+      "severity": "info",
+      "target": "visual/index.html",
+      "message": "visual/index.html and index.en.html are offline-static with zero scripts; every data-metric span matches metrics.json."
+    },
+    {
+      "check_id": "BILINGUAL_PAIRING",
+      "result": "pass",
+      "severity": "info",
+      "target": "manifest.json",
+      "message": "proposal, report HTML, A3, A0 and all five figures are paired zh+en; proposal_format_version 2 with bilingual_contract_version 1."
+    }
+  ]
 }


### PR DESCRIPTION
## 这是什么

对已合入包 `submissions/xr843/jingzhang-two-way-line` 的一次窄修订：把本包在当前 main 上的**真实四门自检结果**持久化下来，响应 #883 测得的存量缺口与 #807 的 readiness 契约。不是新投稿，不改内容主张。

## 精确证据

- exact base：`9632288d4a8c1c3ef2003b1fc6f466979fdff753`
- exact head：`d943fdb957d9b53c85fcb84685b23306f73e67d6`
- 证据由 `scripts/self_check_submission.py --mark-self-checked` 实跑生成并回读，内嵌各门原始报告，非手写 PASS：

| 闸门 | 结果 |
| --- | --- |
| deterministic validation | PASS |
| spatial review | PASS（3 条 `KEY_AREA_PROVISIONAL`，minor，非阻断） |
| visual packaging | PASS（0 issues） |
| professional evidence | PASS（0 issues） |

- `review_status=formal-review-ready`，`can_enter_formal_review=true`
- `manifest.validation_claim.readiness_contract=persisted-self-check-v1`
- 复验：当前 main 的 `validate_local_submission.py` PASS；`participant_preflight.py` PASS（changed files = 3）

## 改了什么

只动三个文件：`self_check.json`、`manifest.json`、`changelog.md`。

一处值得说明：`--mark-self-checked` 会用四条规范化记录替换 `checks` 数组，而本包的 `compliance_matrix.json` 的 23 条需求都引用了原有的六项包级自检 ID（`BOUNDARY_TRUST` / `KEY_AREAS_TRUST` / `LAND_USE_TOPOLOGY` / `METRIC_RECALC` / `VISUAL_STATIC` / `BILINGUAL_PAIRING`），直接替换会让这些引用全部悬空。因此本 PR 把六项按 `self_check.schema.json` 规范补回，与四门规范化记录并存，引用完整性恢复为零悬空。若维护者认为存量包不应保留自定义 check，我可以改为同步收窄 `compliance_matrix.json` 的引用。

## 边界

- 未改动几何、指标数值、图纸、正文结论、许可声明。
- 未修改 `submissions-data.js`、`gallery-publication.json`，未触碰其它投稿包与仓库脚本。
- 三条 `KEY_AREA_PROVISIONAL` 如实保留为 minor 非阻断提示；重点区仍是推定范围，不是官方红线，也不构成精确面积依据。
- 本文件是作者侧可复现的回放记录，不是独立背书；provenance 仍以受信 CI 或维护者重跑为准。