### PR TITLE
docs: explain projected shared-edge slivers

### DIFF
--- a/skills/urban-design-ai-submission/references/geometry-and-metrics.md
+++ b/skills/urban-design-ai-submission/references/geometry-and-metrics.md
@@ -40,6 +40,22 @@ Avoid these failure patterns:
 - a `site_boundary.geojson` outline that does not include vertices used by the land-use partition
 - metrics copied from narrative text instead of recomputed from geometry
 
+### Projection slivers on shared latitude edges
+
+An edge that follows a constant WGS84 latitude is curved after projection to
+`EPSG:4548`, while GeoJSON joins only the stored vertices with straight chords.
+If adjacent polygons approximate the same latitude edge with different spans
+or vertex densities, their projected chords can diverge and create a thin
+false overlap even though the WGS84 edges appear coincident. A precision-grid
+snap alone does not fix this because the mismatch lies between the vertices.
+
+Build each shared cut line once, densify it on one common longitude grid, and
+reuse the same ordered vertex sequence on both adjacent polygons. Do not
+densify each polygon independently. Reproject the finished partition and
+verify both zero overlap and zero coverage gap before finalization. Do not
+raise or bypass the overlap tolerance to hide a projection sliver; a relaxed
+tolerance could also hide a real small overlap.
+
 For a safe starter package, run `scripts/scaffold_ai_submission.py --stage formal`. It prefers trusted official geometry and falls back to `brief/site-package/geometry/provisional_boundaries.geojson` when official polygons are absent. The result is intentionally `package_state=scaffold`; replace its design content and placeholder drawings, run `scripts/finalize_submission.py`, then run `scripts/self_check_submission.py` before opening a PR.
 
 ## Metric Rules

--- a/tests/test_site_package_contract.py
+++ b/tests/test_site_package_contract.py
@@ -108,6 +108,19 @@ class SitePackageContractTests(unittest.TestCase):
         self.assertIn("participate in the Haidian Centennial Jing-Zhang AI Innovation Belt open call", text)
         self.assertIn("scripts/install_submission_skill.py", text)
 
+    def test_geometry_guidance_prevents_projected_shared_edge_slivers(self) -> None:
+        guidance = (
+            REPO_ROOT
+            / "skills"
+            / "urban-design-ai-submission"
+            / "references"
+            / "geometry-and-metrics.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("Projection slivers on shared latitude edges", guidance)
+        self.assertIn("EPSG:4548", guidance)
+        self.assertIn("reuse the same ordered vertex sequence", guidance)
+        self.assertIn("raise or bypass the overlap tolerance", guidance)
+
     def test_submission_skill_installer_copies_skill(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             completed = subprocess.run(


### PR DESCRIPTION
## Summary

- explain why shared constant-latitude edges with different vertex densities can produce false overlap slivers after projection to EPSG:4548
- require one shared densified cut line and the same ordered vertex sequence on both adjacent polygons
- explicitly retain the existing overlap tolerance instead of hiding real small overlaps
- add a contract regression for the participant Skill guidance

## Verification

- independent reproduction: raw projected overlap `7.960955866558071 m²`; shared-grid overlap `0.0 m²`
- `python -m unittest tests.test_site_package_contract -v` — 11/11 PASS
- `python -m py_compile tests/test_site_package_contract.py` — PASS
- `git diff --check` — PASS

Closes #1254