### PR TITLE
fix(renderer): contain local image sources

### DIFF
--- a/scripts/render_proposal_html.py
+++ b/scripts/render_proposal_html.py
@@ -93,23 +93,43 @@ def parse_front_matter(text: str) -> tuple[dict[str, str], str]:
     return metadata, text[end + 5 :]
 
 
-def normalize_image_src(submission_dir: Path, raw_src: str) -> str:
-    """Resolve *raw_src* to a report-relative local path.
-
-    Raises:
-        ValueError: If *raw_src* is a remote URL, an unsafe path (absolute or
-            containing ``..``), or if the target file does not exist.
-    """
+def resolve_local_image(submission_dir: Path, raw_src: str) -> tuple[Path, Path]:
+    """Resolve *raw_src* and prove that its target stays in the submission."""
     if re.match(r"^(?:https?:)?//", raw_src, re.I) or re.match(r"^(?:data|file|javascript):", raw_src, re.I):
         raise ValueError(f"remote or unsafe image source is not allowed: {raw_src}")
     clean = raw_src.split("#", 1)[0].split("?", 1)[0]
     pure = PurePosixPath(clean)
-    if pure.is_absolute() or ".." in pure.parts:
+    if (
+        not clean
+        or "\\" in clean
+        or pure.is_absolute()
+        or not pure.parts
+        or ".." in pure.parts
+        or any(re.match(r"^[A-Za-z]:", part) for part in pure.parts)
+    ):
         raise ValueError(f"image source must be a relative local path: {raw_src}")
-    image_path = submission_dir / pure.as_posix()
+    submission_root = submission_dir.resolve()
+    image_path = submission_root.joinpath(*pure.parts).resolve()
+    try:
+        relative = image_path.relative_to(submission_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"image source must stay within the submission directory: {raw_src}"
+        ) from exc
     if not image_path.exists():
         raise ValueError(f"image source is missing: {raw_src}")
-    return "../" + pure.as_posix()
+    return image_path, relative
+
+
+def normalize_image_src(submission_dir: Path, raw_src: str) -> str:
+    """Resolve *raw_src* to a safe report-relative local path.
+
+    Raises:
+        ValueError: If *raw_src* is remote, unsafe, outside the submission, or
+            if the target file does not exist.
+    """
+    _, relative = resolve_local_image(submission_dir, raw_src)
+    return "../" + relative.as_posix()
 
 
 def contained_output_path(submission_dir: Path, raw_path: str) -> Path:
@@ -142,11 +162,10 @@ def render_inputs(submission_dir: Path, proposal_paths: list[Path]) -> list[Path
         text = proposal_path.read_text(encoding="utf-8")
         for match in IMAGE_RE.finditer(text):
             raw_src = match.group(2).strip()
-            clean = raw_src.split("#", 1)[0].split("?", 1)[0]
-            pure = PurePosixPath(clean)
-            if pure.is_absolute() or ".." in pure.parts:
+            try:
+                candidate, _ = resolve_local_image(submission_dir, raw_src)
+            except ValueError:
                 continue
-            candidate = submission_dir.joinpath(*pure.parts)
             if candidate.is_file():
                 inputs.append(candidate)
     return inputs

--- a/scripts/render_proposal_html.py
+++ b/scripts/render_proposal_html.py
@@ -50,6 +50,7 @@ import re
 import stat
 import tempfile
 from pathlib import Path, PurePosixPath
+from urllib.parse import unquote_to_bytes
 
 
 IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
@@ -93,6 +94,17 @@ def parse_front_matter(text: str) -> tuple[dict[str, str], str]:
     return metadata, text[end + 5 :]
 
 
+def _is_unsafe_url_path_segment(segment: str) -> bool:
+    """Return true when URL parsing could reinterpret a filesystem segment."""
+    decoded = unquote_to_bytes(segment)
+    return (
+        decoded in {b".", b".."}
+        or b"/" in decoded
+        or b"\\" in decoded
+        or re.match(rb"^[A-Za-z]:", decoded) is not None
+    )
+
+
 def resolve_local_image(submission_dir: Path, raw_src: str) -> tuple[Path, Path]:
     """Resolve *raw_src* and prove that its target stays in the submission."""
     if re.match(r"^(?:https?:)?//", raw_src, re.I) or re.match(r"^(?:data|file|javascript):", raw_src, re.I):
@@ -106,6 +118,7 @@ def resolve_local_image(submission_dir: Path, raw_src: str) -> tuple[Path, Path]
         or not pure.parts
         or ".." in pure.parts
         or any(re.match(r"^[A-Za-z]:", part) for part in pure.parts)
+        or any(_is_unsafe_url_path_segment(part) for part in pure.parts)
     ):
         raise ValueError(f"image source must be a relative local path: {raw_src}")
     submission_root = submission_dir.resolve()

--- a/tests/test_render_proposal_html.py
+++ b/tests/test_render_proposal_html.py
@@ -208,6 +208,79 @@ summary: "离线阅读版"
             with self.assertRaisesRegex(ValueError, "remote or unsafe image source"):
                 render_html(submission_dir)
 
+    def test_render_html_rejects_windows_absolute_unc_and_backslash_traversal_images(self) -> None:
+        unsafe_sources = [
+            "C:/escape/x.png",
+            "./D:/escape/x.png",
+            r"\\server\share\x.png",
+            r"..\escape.png",
+        ]
+        for source in unsafe_sources:
+            with self.subTest(source=source), tempfile.TemporaryDirectory() as tmp:
+                submission_dir = Path(tmp)
+                (submission_dir / "proposal.md").write_text(
+                    f"![unsafe]({source})\n",
+                    encoding="utf-8",
+                )
+
+                with self.assertRaisesRegex(ValueError, "relative local path"):
+                    render_html(submission_dir)
+
+    @unittest.skipUnless(os.name == "nt", "Windows drive-path behavior")
+    def test_render_html_rejects_existing_image_outside_submission_by_drive_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission_dir = root / "submission"
+            submission_dir.mkdir()
+            outside_image = root / "outside.png"
+            outside_image.write_bytes(b"not an in-package image")
+            (submission_dir / "proposal.md").write_text(
+                f"![escaped]({outside_image.as_posix()})\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "relative local path"):
+                render_html(submission_dir)
+
+    def test_render_html_rejects_symlink_escape_from_submission_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as outside:
+            submission_dir = Path(tmp)
+            outside_image = Path(outside) / "outside.png"
+            outside_image.write_bytes(b"not an in-package image")
+            linked_image = submission_dir / "linked.png"
+            try:
+                linked_image.symlink_to(outside_image)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"local symlink creation is unavailable: {exc}")
+            (submission_dir / "proposal.md").write_text(
+                "![escaped](linked.png)\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "stay within the submission directory"):
+                render_html(submission_dir)
+
+    def test_render_html_resolves_internal_symlink_to_safe_relative_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission_dir = Path(tmp)
+            image = submission_dir / "assets" / "figures" / "overview.png"
+            image.parent.mkdir(parents=True)
+            image.write_bytes(b"in-package image")
+            linked_image = submission_dir / "linked.png"
+            try:
+                linked_image.symlink_to(image)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"local symlink creation is unavailable: {exc}")
+            (submission_dir / "proposal.md").write_text(
+                "![linked](linked.png)\n",
+                encoding="utf-8",
+            )
+
+            html = render_html(submission_dir)
+
+            self.assertIn('src="../assets/figures/overview.png"', html)
+            self.assertNotIn('src="../linked.png"', html)
+
     def test_render_english_proposal_marks_both_languages(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             submission_dir = Path(tmp)

--- a/tests/test_render_proposal_html.py
+++ b/tests/test_render_proposal_html.py
@@ -9,7 +9,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-from render_proposal_html import render_html  # noqa: E402
+from render_proposal_html import render_html, render_inputs  # noqa: E402
 
 
 class RenderProposalHtmlTests(unittest.TestCase):
@@ -225,6 +225,32 @@ summary: "离线阅读版"
 
                 with self.assertRaisesRegex(ValueError, "relative local path"):
                     render_html(submission_dir)
+
+    def test_render_html_rejects_url_encoded_path_escape_segments(self) -> None:
+        unsafe_sources = [
+            "assets/%2e%2e/%2e%2e/out.png",
+            "assets/%2E%2E/%2E%2E/out.png",
+            "assets/.%2e/.%2e/out.png",
+            "assets/%2e./%2e./out.png",
+            "assets/%2fescape/out.png",
+            "assets/%5cescape/out.png",
+            "C%3a/escape/out.png",
+        ]
+        for source in unsafe_sources:
+            with self.subTest(source=source), tempfile.TemporaryDirectory() as tmp:
+                submission_dir = Path(tmp)
+                image = submission_dir / source
+                image.parent.mkdir(parents=True)
+                image.write_bytes(b"not a safe browser URL")
+                proposal = submission_dir / "proposal.md"
+                proposal.write_text(
+                    f"![encoded]({source})\n",
+                    encoding="utf-8",
+                )
+
+                with self.assertRaisesRegex(ValueError, "relative local path"):
+                    render_html(submission_dir)
+                self.assertEqual([proposal], render_inputs(submission_dir, [proposal]))
 
     @unittest.skipUnless(os.name == "nt", "Windows drive-path behavior")
     def test_render_html_rejects_existing_image_outside_submission_by_drive_path(self) -> None:


### PR DESCRIPTION
## Summary

- reject Windows drive paths, UNC paths, and backslash traversal in Markdown image sources;
- reject percent-encoded dot segments, separators, and drive forms before browser URL parsing can reinterpret them;
- resolve every local image target and require the resolved path to remain inside the submission directory, closing symlink escapes;
- canonicalize safe in-package symlinks to their resolved package-relative paths;
- reuse the same resolver for renderer dependency discovery and HTML generation.

## Scope refresh

This refresh deliberately removes the older bilingual-label and language-link changes from the draft:

- English evidence-label localization is already in `main` via #1667;
- cross-platform relative language links are already in `main` via #2244;
- renderer output containment is already in `main` via #2356.

The remaining change is limited to image-input containment and its regression tests. It has no dependency on #780 and does not modify any submission package.

## Verification

- base: `233853bfdfdd7309f1f6e8de616a94c052f89235`;
- exact head: `6b23452408ca1854045baa23e00759d1ee5b25f8`;
- Windows / Python 3.12.12: renderer 24/24 and site-package contract 13/13 passed; the Windows drive-path test executed;
- Linux / Python 3.14.4: 24 tests completed — 23 passed and one expected Windows-only test skipped; Linux symlink tests executed and passed;
- Linux / Python 3.9.25: 24 tests completed — 23 passed and one expected Windows-only test skipped;
- encoded `%2e%2e`, `%2E%2E`, `.%2e`, `%2e.`, slash, backslash, and drive variants are rejected by both rendering and dependency discovery;
- `py_compile` passed on Windows and on Linux with Python 3.14.4 and 3.9.25;
- `git diff --check` passed on both platforms;
- `git merge-tree --write-tree` against observed `main` `d35e9e561a48f5ea757414df2d88691b0d0d35c8` completed without conflicts;
- the current bilingual `jingzhang-open-integrity-yard` proposal renders byte-identically before and after this patch.

The branch is rewritten from the previous draft head `b083141cad40637e4ba975ab4626d33f3d15628e`; that SHA remains the explicit rollback point.
