### PR TITLE
tools: read-only diagnostic for duplicated font data in submission PDFs (#1211)

### DIFF
--- a/scripts/diagnose_pdf_fonts.py
+++ b/scripts/diagnose_pdf_fonts.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Read-only diagnostic: how much of a submission's PDF is duplicated font data.
+
+Motivation and measurement are in issue #1211. Across all 1,014 drawing PDFs in
+the repository, the 10 MiB per-file intake cap binds on almost nobody, and the
+size of a vector PDF is driven not by how much is drawn but by two font-side
+effects that are invisible unless you look for them:
+
+1. **Per-page duplication.** A booklet assembled by rendering each page
+   separately and merging afterwards stores one font subset per page. 92% of
+   multi-page PDFs in the field share every font program across all pages; the
+   ones that do not pay for the subset again on every sheet.
+2. **Retained CFF subroutines.** A CID-keyed CFF subset can carry the source
+   font's whole local-subroutine index — tens of thousands of entries — for a
+   few hundred glyphs. Measured on one package: 8.37 MiB of subroutine
+   bytecode against 1.00 MiB of actual outlines.
+
+This tool reports both and nothing else. It is deliberately not a gate:
+
+* **It never writes a PDF.** No re-subsetting, no desubroutinizing, no font
+  substitution, no layout change. It opens files read-only and prints.
+* **It says SKIP, not FAIL, when it has nothing to measure.** A rasterised
+  PDF or one that references fonts without embedding them has no embedded
+  glyph data, and reporting that as a problem would be a false positive on the
+  majority of the field.
+* **It says INDETERMINATE when it cannot parse.** Font references living
+  inside compressed object streams are not visible to a standard-library
+  scan; the tool detects that case and declines to conclude rather than
+  reporting zero.
+* **It reports the two intake limits separately** — the per-file cap and the
+  changed-file total — because a submission can approach the second while
+  every individual file is comfortably under the first.
+
+Standard library only, matching `validate_submission.py`.
+
+    python3 scripts/diagnose_pdf_fonts.py submissions/<login>/<slug>
+    python3 scripts/diagnose_pdf_fonts.py path/to/one.pdf --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import zlib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+MIB = 1024 * 1024
+PER_FILE_LIMIT = 10 * MIB
+CHANGED_TOTAL_LIMIT = 40 * MIB
+
+FONTFILE_REF = re.compile(rb"/FontFile[123]?\s+(\d+)\s+\d+\s+R")
+# A subset tag is six uppercase letters and a plus sign, assigned per document.
+# Two subsets of one typeface therefore never share a name even when they hold
+# the same glyphs, so the family is what identifies them as the same font.
+FONTNAME = re.compile(rb"/(?:FontName|BaseFont)\s*/(?:([A-Z]{6})\+)?([^\s/>\]]+)")
+OBJECT_HEAD = re.compile(rb"(?m)^(\d+)\s+0\s+obj\b")
+PAGE_TYPE = re.compile(rb"/Type\s*/Page[^s]")
+IMAGE_XOBJECT = re.compile(rb"/Subtype\s*/Image")
+OBJECT_STREAM = re.compile(rb"/Type\s*/ObjStm")
+LENGTH = re.compile(rb"/Length\s+(\d+)\b")
+
+SKIP_NO_GLYPHS = "SKIP"
+INDETERMINATE = "INDETERMINATE"
+MEASURED = "MEASURED"
+
+
+@dataclass
+class Program:
+    """One stored font program: its bytes, and the family it belongs to.
+
+    Grouping by family rather than by byte content is the correction that makes
+    this tool see the case it was built for. A subsetter that runs once per page
+    emits programs with the *same glyphs* and *different bytes* — different
+    subset tags, and for CID-keyed CFF a different internal ordering of the
+    FDArray sub-fonts. Counting byte-identical copies reported zero duplication
+    on a file carrying six near-identical megabyte subsets, which is the whole
+    problem, missed. Writing the test is what surfaced that.
+    """
+
+    digest: str
+    length: int
+    family: str = "?"
+    stored_copies: int = 0
+    references: int = 0
+
+
+@dataclass
+class Report:
+    path: str
+    size: int
+    status: str
+    pages: int = 0
+    programs: list[Program] = field(default_factory=list)
+    note: str = ""
+
+    @property
+    def glyph_bytes(self) -> int:
+        return sum(p.length * p.stored_copies for p in self.programs)
+
+    @property
+    def families(self) -> dict[str, list[Program]]:
+        out: dict[str, list[Program]] = {}
+        for p in self.programs:
+            out.setdefault(p.family, []).extend([p] * p.stored_copies)
+        return out
+
+    @property
+    def duplicated_bytes(self) -> int:
+        """What sharing one program per family would save.
+
+        Not "bytes that are byte-identical" — that measure reports zero on the
+        per-page-subset case, because each page's subset differs in its tag and
+        its internal ordering while holding the same glyphs.
+        """
+        saved = 0
+        for copies in self.families.values():
+            if len(copies) > 1:
+                saved += sum(c.length for c in copies) - max(c.length for c in copies)
+        return saved
+
+    @property
+    def distinct_programs(self) -> int:
+        return len(self.programs)
+
+    @property
+    def stored_programs(self) -> int:
+        return sum(p.stored_copies for p in self.programs)
+
+
+def _top_level_objects(raw: bytes) -> dict[int, tuple[bytes, bytes]]:
+    """Object number -> (header bytes, raw stream bytes), for uncompressed objects."""
+    found: dict[int, tuple[bytes, bytes]] = {}
+    for match in OBJECT_HEAD.finditer(raw):
+        number = int(match.group(1))
+        start = match.end()
+        end = raw.find(b"endobj", start)
+        if end < 0:
+            continue
+        body = raw[start:end]
+        marker = body.find(b"stream")
+        if marker < 0:
+            found[number] = (body, b"")
+            continue
+        head = body[:marker]
+        data_start = marker + len(b"stream")
+        while data_start < len(body) and body[data_start] in (13, 10):
+            data_start += 1
+        # Honour /Length when it is a direct integer. Taking everything up to
+        # `endstream` instead includes the end-of-line the writer puts before
+        # it, which inflated every program by a byte or two — small, but this
+        # tool reports byte counts and a byte count that is quietly wrong is
+        # worse than no byte count.
+        declared = LENGTH.search(head)
+        if declared:
+            data_end = data_start + int(declared.group(1))
+        else:
+            data_end = body.find(b"endstream", data_start)
+            if data_end > data_start and body[data_end - 1:data_end] in (b"\n", b"\r"):
+                data_end -= 1
+        found[number] = (head, body[data_start:data_end] if data_end > data_start else b"")
+    return found
+
+
+def diagnose(path: Path) -> Report:
+    raw = path.read_bytes()
+    size = len(raw)
+    references = [int(m.group(1)) for m in FONTFILE_REF.finditer(raw)]
+    pages = len(PAGE_TYPE.findall(raw))
+
+    if not references:
+        if OBJECT_STREAM.search(raw):
+            return Report(str(path), size, INDETERMINATE, pages, note=(
+                "font references may live in a compressed object stream, which a "
+                "standard-library scan cannot read; no conclusion drawn"))
+        rasterised = bool(IMAGE_XOBJECT.search(raw))
+        return Report(str(path), size, SKIP_NO_GLYPHS, pages, note=(
+            "no embedded glyph data" + (" (page content is imagery)" if rasterised else "")
+            + " — font duplication does not apply"))
+
+    objects = _top_level_objects(raw)
+    # Which family each font program belongs to, taken from the descriptor that
+    # points at it. Falls back to the program's own object number so that an
+    # unnamed program is never silently merged with another.
+    family_of: dict[int, str] = {}
+    for head, _stream in objects.values():
+        ref = FONTFILE_REF.search(head)
+        if not ref:
+            continue
+        name = FONTNAME.search(head)
+        family_of[int(ref.group(1))] = (
+            name.group(2).decode("latin-1") if name else f"object-{ref.group(1).decode()}")
+
+    by_digest: dict[str, Program] = {}
+    counted: set[int] = set()
+    for number in references:
+        entry = objects.get(number)
+        if entry is None:
+            continue
+        head, data = entry
+        if b"/FlateDecode" in head:
+            try:
+                data = zlib.decompress(data)
+            except zlib.error:
+                pass
+        digest = hashlib.md5(data).hexdigest()
+        program = by_digest.setdefault(
+            digest, Program(digest, len(data), family_of.get(number, f"object-{number}")))
+        program.references += 1
+        if number not in counted:
+            counted.add(number)
+            program.stored_copies += 1
+
+    if not by_digest:
+        return Report(str(path), size, INDETERMINATE, pages, note=(
+            "font programs are referenced but their objects could not be located; "
+            "no conclusion drawn"))
+    return Report(str(path), size, MEASURED, pages, sorted(
+        by_digest.values(), key=lambda p: -p.length * p.stored_copies))
+
+
+def findings(report: Report) -> list[str]:
+    """Observations, phrased as observations. Nothing here is a verdict."""
+    if report.status != MEASURED or report.pages <= 1:
+        return []
+    out: list[str] = []
+    if report.duplicated_bytes:
+        share = report.duplicated_bytes / report.size * 100
+        worst = max(report.families.items(), key=lambda kv: len(kv[1]))
+        out.append(
+            f"{report.stored_programs} stored font programs across {report.pages} pages, "
+            f"the most repeated family being {worst[0]} at {len(worst[1])} copies. "
+            f"Sharing one program per family would save {report.duplicated_bytes / MIB:.2f} "
+            f"MiB, {share:.0f}% of the file. Pages rendered separately and merged afterwards "
+            f"store one subset each — they differ in their subset tag and internal ordering, "
+            f"so a byte-identity check does not see them. Rendering the pages into a single "
+            f"document, or priming every page with the same glyph repertoire before merging, "
+            f"collapses them.")
+    per_page = report.glyph_bytes / max(report.pages, 1)
+    if per_page > 0.5 * MIB:
+        out.append(
+            f"{per_page / MIB:.2f} MiB of glyph data per page. A CID-keyed CFF subset can "
+            f"retain the source font's full local-subroutine index regardless of how many "
+            f"glyphs it keeps; if that is the cause, the outlines are a small fraction of "
+            f"this. Measuring it needs a CFF parser and is out of scope here.")
+    return out
+
+
+def render(reports: list[Report], as_json: bool) -> str:
+    total = sum(r.size for r in reports)
+    if as_json:
+        return json.dumps({
+            "per_file_limit_bytes": PER_FILE_LIMIT,
+            "changed_total_limit_bytes": CHANGED_TOTAL_LIMIT,
+            "total_bytes": total,
+            "files": [{
+                "path": r.path, "size_bytes": r.size, "status": r.status,
+                "pages": r.pages, "distinct_programs": r.distinct_programs,
+                "stored_programs": r.stored_programs,
+                "glyph_bytes": r.glyph_bytes, "duplicated_bytes": r.duplicated_bytes,
+                "note": r.note, "findings": findings(r),
+            } for r in reports],
+        }, ensure_ascii=False, indent=1)
+
+    lines = []
+    for r in reports:
+        pct = r.size / PER_FILE_LIMIT * 100
+        lines.append(f"{r.path}")
+        lines.append(f"  {r.size / MIB:.2f} MiB ({pct:.0f}% of the 10 MiB per-file limit), "
+                     f"{r.pages} page(s) — {r.status}")
+        if r.note:
+            lines.append(f"  {r.note}")
+        if r.status == MEASURED:
+            lines.append(f"  glyph data {r.glyph_bytes / MIB:.2f} MiB in "
+                         f"{r.stored_programs} stored program(s), "
+                         f"{r.distinct_programs} distinct")
+        for f in findings(r):
+            lines.append(f"  - {f}")
+    lines.append("")
+    lines.append(f"{len(reports)} file(s), {total / MIB:.2f} MiB together "
+                 f"({total / CHANGED_TOTAL_LIMIT * 100:.0f}% of the 40 MiB changed-file total, "
+                 f"which is a separate limit from the 10 MiB per-file cap).")
+    return "\n".join(lines)
+
+
+def collect(target: Path) -> list[Path]:
+    if target.is_file():
+        return [target]
+    return sorted(p for p in target.rglob("*.pdf") if p.is_file())
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("target", type=Path,
+                        help="a PDF, or a directory to search recursively")
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args(argv)
+
+    if not args.target.exists():
+        print(f"not found: {args.target}", file=sys.stderr)
+        return 2
+    paths = collect(args.target)
+    if not paths:
+        print(f"no PDF under {args.target}", file=sys.stderr)
+        return 0
+    print(render([diagnose(p) for p in paths], args.json))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/diagnose_pdf_fonts.py
+++ b/scripts/diagnose_pdf_fonts.py
@@ -25,8 +25,12 @@ This tool reports both and nothing else. It is deliberately not a gate:
   majority of the field.
 * **It says INDETERMINATE when it cannot parse.** Font references living
   inside compressed object streams are not visible to a standard-library
-  scan; the tool detects that case and declines to conclude rather than
-  reporting zero.
+  scan. When no reference is found at the top level *and* the file holds an
+  object stream, the tool declines to conclude rather than reporting zero.
+  This is deliberately one-directional: it never claims the references are in
+  the object stream, only that it cannot rule that out. A file whose
+  references are visible at the top level is measured normally, whatever else
+  it keeps in object streams.
 * **It reports the two intake limits separately** — the per-file cap and the
   changed-file total — because a submission can approach the second while
   every individual file is comfortably under the first.
@@ -174,8 +178,13 @@ def diagnose(path: Path) -> Report:
     if not references:
         if OBJECT_STREAM.search(raw):
             return Report(str(path), size, INDETERMINATE, pages, note=(
-                "font references may live in a compressed object stream, which a "
-                "standard-library scan cannot read; no conclusion drawn"))
+                "no /FontFile reference was found among the top-level objects, and the "
+                "file contains at least one compressed object stream that a "
+                "standard-library scan cannot read — so this is 'not found', not "
+                "'not present', and no conclusion is drawn. It does not assert that "
+                "font references are inside the object stream; it declines to rule it "
+                "out. A file whose font references *are* visible at the top level is "
+                "measured normally, whatever else it keeps in object streams."))
         rasterised = bool(IMAGE_XOBJECT.search(raw))
         return Report(str(path), size, SKIP_NO_GLYPHS, pages, note=(
             "no embedded glyph data" + (" (page content is imagery)" if rasterised else "")

--- a/tests/test_diagnose_pdf_fonts.py
+++ b/tests/test_diagnose_pdf_fonts.py
@@ -147,7 +147,35 @@ class DiagnoseTests(unittest.TestCase):
                                                  b"/Type /ObjStm /Type /Catalog", 1))
         report = diagnose(pdf)
         self.assertEqual(report.status, INDETERMINATE)
-        self.assertIn("no conclusion drawn", report.note)
+        self.assertIn("no conclusion is drawn", report.note)
+
+    def test_object_streams_do_not_block_a_visible_font(self) -> None:
+        """Raised by @147228 on #1273: the conservative branch must be one-directional.
+
+        A PDF may keep unrelated metadata in an object stream while its font
+        references sit in ordinary top-level objects. That file is measurable
+        and must be measured; INDETERMINATE is only for the case where nothing
+        was found *and* something unreadable is present.
+        """
+        pdf = self.dir / "objstm_with_font.pdf"
+        minimal_pdf(pdf, [b"TAG001" + b"A" * 20000, b"TAG002" + b"A" * 20000])
+        pdf.write_bytes(pdf.read_bytes().replace(
+            b"/Type /Catalog", b"/Type /Catalog /Metadata << /Type /ObjStm >>", 1))
+        report = diagnose(pdf)
+        self.assertEqual(report.status, MEASURED,
+                         "an object stream elsewhere must not suppress a visible font")
+        self.assertEqual(report.stored_programs, 2)
+        self.assertGreater(report.duplicated_bytes, 0)
+
+    def test_indeterminate_note_does_not_overclaim(self) -> None:
+        pdf = self.dir / "objstm_only.pdf"
+        minimal_pdf(pdf, [])
+        pdf.write_bytes(pdf.read_bytes().replace(
+            b"/Type /Catalog", b"/Type /Catalog /Metadata << /Type /ObjStm >>", 1))
+        report = diagnose(pdf)
+        self.assertEqual(report.status, INDETERMINATE)
+        self.assertIn("'not found', not", report.note)
+        self.assertIn("declines to rule it out", report.note)
 
     def test_reports_both_limits_separately(self) -> None:
         a = minimal_pdf(self.dir / "a.pdf", [b"A" * 1000])

--- a/tests/test_diagnose_pdf_fonts.py
+++ b/tests/test_diagnose_pdf_fonts.py
@@ -1,0 +1,186 @@
+"""Tests for the read-only PDF font diagnostic.
+
+The fixtures are *generated*, not committed. `minimal_pdf` below writes a valid
+uncompressed PDF with a chosen number of pages and a chosen font-program
+layout, which makes every case in these tests a public, inspectable, minimal
+reproduction that anyone can regenerate and open in a viewer — rather than a
+binary blob whose contents have to be taken on trust.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from diagnose_pdf_fonts import (  # noqa: E402
+    INDETERMINATE,
+    MEASURED,
+    SKIP_NO_GLYPHS,
+    diagnose,
+    findings,
+    main,
+    render,
+)
+
+
+def minimal_pdf(path: Path, page_programs: list[bytes], with_image: bool = False) -> Path:
+    """Write a valid uncompressed PDF: one page per entry in `page_programs`.
+
+    Each entry is the byte content of that page's embedded font program. Pass
+    the same bytes twice to model a shared subset stored once, or distinct
+    bytes to model the per-page duplication this tool exists to report. Pass an
+    empty list for a PDF with no embedded fonts at all.
+    """
+    objects: list[bytes] = []
+
+    def add(body: bytes) -> int:
+        objects.append(body)
+        return len(objects)
+
+    page_count = max(len(page_programs), 1)
+    pages_id = 2
+    kids: list[int] = []
+    add(b"<< /Type /Catalog /Pages 2 0 R >>")
+    add(b"")  # placeholder for /Pages, filled once kids are known
+
+    stored: dict[bytes, int] = {}
+    for program in page_programs:
+        if program not in stored:
+            stored[program] = add(
+                b"<< /Length " + str(len(program)).encode() + b" /Subtype /CIDFontType0C >>\n"
+                b"stream\n" + program + b"\nendstream")
+        file_id = stored[program]
+        desc = add(b"<< /Type /FontDescriptor /FontName /AAAAAA+Test /FontFile3 "
+                   + str(file_id).encode() + b" 0 R >>")
+        font = add(b"<< /Type /Font /Subtype /Type0 /BaseFont /AAAAAA+Test "
+                   b"/DescendantFonts [<< /Type /Font /Subtype /CIDFontType0 "
+                   b"/FontDescriptor " + str(desc).encode() + b" 0 R >>] >>")
+        resources = b"<< /Font << /F1 " + str(font).encode() + b" 0 R >> >>"
+        kids.append(add(b"<< /Type /Page /Parent " + str(pages_id).encode()
+                        + b" 0 R /MediaBox [0 0 200 200] /Resources " + resources + b" >>"))
+
+    if not page_programs:
+        resources = (b"<< /XObject << /I0 " + str(add(
+            b"<< /Type /XObject /Subtype /Image /Width 1 /Height 1 /Length 1 >>\n"
+            b"stream\n\x00\nendstream")).encode() + b" 0 R >> >>") if with_image else b"<< >>"
+        kids.append(add(b"<< /Type /Page /Parent " + str(pages_id).encode()
+                        + b" 0 R /MediaBox [0 0 200 200] /Resources " + resources + b" >>"))
+
+    objects[pages_id - 1] = (b"<< /Type /Pages /Count " + str(len(kids)).encode()
+                             + b" /Kids [" + b" ".join(f"{k} 0 R".encode() for k in kids)
+                             + b"] >>")
+
+    out = bytearray(b"%PDF-1.7\n")
+    offsets = [0]
+    for number, body in enumerate(objects, start=1):
+        offsets.append(len(out))
+        out += f"{number} 0 obj\n".encode() + body + b"\nendobj\n"
+    xref = len(out)
+    out += f"xref\n0 {len(objects) + 1}\n".encode()
+    out += b"0000000000 65535 f \n"
+    for off in offsets[1:]:
+        out += f"{off:010d} 00000 n \n".encode()
+    out += (b"trailer\n<< /Size " + str(len(objects) + 1).encode()
+            + b" /Root 1 0 R >>\nstartxref\n" + str(xref).encode() + b"\n%%EOF\n")
+    path.write_bytes(bytes(out))
+    assert page_count  # documents the intent of the argument
+    return path
+
+
+class DiagnoseTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_per_page_duplication_is_detected_across_differing_bytes(self) -> None:
+        """The case the tool exists for.
+
+        Three pages, three subsets of one family, each holding different bytes —
+        which is what a per-document subsetter produces, because the subset tag
+        and the internal ordering differ even when the glyphs do not. A
+        byte-identity check reports nothing here; grouping by family reports two
+        copies' worth of waste.
+        """
+        pdf = minimal_pdf(self.dir / "dup.pdf",
+                          [b"TAG001" + b"A" * 40000,
+                           b"TAG002" + b"A" * 40000,
+                           b"TAG003" + b"A" * 40000])
+        report = diagnose(pdf)
+        self.assertEqual(report.status, MEASURED)
+        self.assertEqual(report.pages, 3)
+        self.assertEqual(report.stored_programs, 3)
+        self.assertEqual(report.distinct_programs, 3, "byte contents genuinely differ")
+        self.assertEqual(report.duplicated_bytes, 2 * 40006,
+                         "sharing one program per family would save two copies")
+        text = " ".join(findings(report))
+        self.assertIn("stored font programs across 3 pages", text)
+        self.assertIn("a byte-identity check does not see them", text)
+
+    def test_a_shared_program_reports_no_waste(self) -> None:
+        shared = minimal_pdf(self.dir / "shared.pdf", [b"A" * 40000] * 3)
+        report = diagnose(shared)
+        self.assertEqual(report.stored_programs, 1, "identical bytes are stored once")
+        self.assertEqual(report.duplicated_bytes, 0)
+        self.assertEqual(findings(report), [],
+                         "a file that already shares its fonts has nothing to report")
+
+    def test_no_embedded_fonts_is_skip_not_a_failure(self) -> None:
+        pdf = minimal_pdf(self.dir / "raster.pdf", [], with_image=True)
+        report = diagnose(pdf)
+        self.assertEqual(report.status, SKIP_NO_GLYPHS)
+        self.assertIn("no embedded glyph data", report.note)
+        self.assertIn("imagery", report.note)
+        self.assertEqual(findings(report), [], "SKIP must not produce findings")
+
+    def test_object_streams_are_indeterminate_not_zero(self) -> None:
+        """A standard-library scan cannot see into /ObjStm, and says so."""
+        pdf = self.dir / "objstm.pdf"
+        minimal_pdf(pdf, [])
+        pdf.write_bytes(pdf.read_bytes().replace(b"/Type /Catalog",
+                                                 b"/Type /ObjStm /Type /Catalog", 1))
+        report = diagnose(pdf)
+        self.assertEqual(report.status, INDETERMINATE)
+        self.assertIn("no conclusion drawn", report.note)
+
+    def test_reports_both_limits_separately(self) -> None:
+        a = minimal_pdf(self.dir / "a.pdf", [b"A" * 1000])
+        b = minimal_pdf(self.dir / "b.pdf", [b"B" * 1000])
+        text = render([diagnose(a), diagnose(b)], as_json=False)
+        self.assertIn("per-file limit", text)
+        self.assertIn("40 MiB changed-file total", text)
+        self.assertIn("separate limit", text)
+
+        payload = json.loads(render([diagnose(a)], as_json=True))
+        self.assertEqual(payload["per_file_limit_bytes"], 10 * 1024 * 1024)
+        self.assertEqual(payload["changed_total_limit_bytes"], 40 * 1024 * 1024)
+
+    def test_never_writes_to_the_pdf(self) -> None:
+        pdf = minimal_pdf(self.dir / "ro.pdf", [b"A" * 5000, b"B" * 5000])
+        before = pdf.read_bytes()
+        mtime = pdf.stat().st_mtime_ns
+        diagnose(pdf)
+        main([str(pdf)])
+        main([str(self.dir), "--json"])
+        self.assertEqual(pdf.read_bytes(), before)
+        self.assertEqual(pdf.stat().st_mtime_ns, mtime)
+
+    def test_single_page_files_produce_no_duplication_finding(self) -> None:
+        pdf = minimal_pdf(self.dir / "one.pdf", [b"A" * 900000])
+        self.assertEqual(findings(diagnose(pdf)), [],
+                         "one page cannot duplicate across pages")
+
+    def test_directory_scan_and_exit_codes(self) -> None:
+        minimal_pdf(self.dir / "x.pdf", [b"A" * 1000])
+        self.assertEqual(main([str(self.dir)]), 0)
+        self.assertEqual(main([str(self.dir / "missing.pdf")]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
按 #1211 中 @CocoSgt 提出的四条验收条件实现的只读诊断工具。**不改任何 gate、阈值或上限，不触碰 `validate_submission.py`，也不主张放宽 10 MiB 单文件上限**——#1211 的实测结论正是它对全场几乎不构成约束，维护者结论是保持不变，本 PR 与之一致。

## 它报什么

两件事，仅此两件：一份 PDF 存了多少份字体程序（对多少页），以及**按字体族共享一份可以省下多少**。纯标准库，与 `validate_submission.py` 一致。

```
submissions/<login>/<slug>/drawings/a3-booklet.pdf
  0.47 MiB (5% of the 10 MiB per-file limit), 7 page(s) — MEASURED
  glyph data 0.34 MiB in 3 stored program(s), 3 distinct

4 file(s), 1.16 MiB together (3% of the 40 MiB changed-file total,
which is a separate limit from the 10 MiB per-file cap).
```

## 逐条对照验收条件

| 条件 | 实现 |
|---|---|
| 只读，不修改 PDF 内容／版面 | 只 `read_bytes` 与打印。无重新子集化、无去子程序化、无字体替换、无版面改动。有测试断言库调用与两次 CLI 调用之后，输入文件的**字节与 mtime 均未变**。 |
| 位图／无内嵌字体 PDF 明确 SKIP | 无内嵌字形数据即报 `SKIP` 并说明原因，且**不产生任何 finding**。全场 1,014 份里 790 份 80% 以上是位图、502 份完全不内嵌字体——把这些报成问题就是对全场多数方案误报。 |
| 可公开的最小复现 fixture | `tests/` 里的 fixture 是**生成的，不是提交的二进制**。`minimal_pdf()` 写出一份有效的未压缩 PDF，页数与字体布局可指定，因此每个用例都可复现、可打开、可检视，不需要人相信一个二进制块。 |
| 区分单文件上限与 40 MiB 变更总量 | 两个数分别打印，并在文案里写明它们是两条不同的限制。JSON 输出里是两个独立字段。 |

另加一条条件里没要求、但我认为必须有的：**解析不到时报 `INDETERMINATE`，而不是报零**。字体引用若位于压缩对象流（`/ObjStm`）内，标准库扫描看不见；工具会检测这一情形并拒绝下结论。

## 写测试时改掉的两处，值得单说

**一、按字节相同来数重复，什么也数不到。** 逐页运行的子集化器产出的程序**字形相同、字节不同**——子集标签不同，CID-keyed CFF 的 FDArray 子字体排序也不同。第一版工具在**恰恰是催生它的那些文件上报告零重复**。现改为按字体族分组，重复量是「按族共享一份能省多少」。这个缺陷是写测试时才暴露的。

**二、流长度改为遵循 `/Length`。** 读到 `endstream` 会把它前面的换行也算进去，使每份程序虚增一两个字节。量很小，但这个工具报的就是字节数，**一个悄悄错掉的字节数比没有字节数更糟**。

## 明确不做

自动去子程序化、字体替换、版面重写——按 @CocoSgt 的划分属于另一类，本 PR 不实现，也不建议由 gate 自动执行。工具只报告，改不改、怎么改由投稿者决定。

## 校验

- `python3 tests/test_diagnose_pdf_fonts.py` — **8 tests, OK**
- `py_compile`、`git diff --check` 通过
- 已对一份真实的四份 PDF 投稿包与一份全场的位图投稿 PDF 实跑，输出见 #1211

利害声明：本工具起因于我自己的包曾持有全场最大与第二大的两份 PDF（9.52 / 8.77 MiB，全场唯一逼近上限 10% 的一份）。我已在自己包内修好（现为 479 / 452 KB），因此本 PR 对我自己不再有任何实际作用；提交它是因为 #1211 的测量表明这个成本对矢量输出的方案普遍存在而不可见。
