### PR TITLE
fix(review): preserve historical submission scores

### DIFF
--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -280,14 +280,17 @@ SHA 复核和 merge 使用进程内锁串行执行，避免 Git 引用锁和 bas
 
 ### 分数保护与恢复
 
-`--apply` 在决定合并前，会读取该投稿作者已合并 PR 中带有
-`haidian-auto-review:<exact-head-sha>` 标记的维护者 Review Agent 评论，并按投稿目录计算
+`--apply` 在决定合并前，会读取该投稿作者已合并 PR 中由显式 trusted reviewer allowlist
+提交、状态为 `APPROVED` 且带有 `haidian-auto-review:<exact-head-sha>` 标记的维护者 Review Agent 评论，并按投稿目录计算
 历史官方最高分。新 exact head 的分数低于该最高分时，worker 会发布
 `score-preservation hold`、请求修改并保持 PR 不合并；达到或超过最高分才有资格继续走
 原有 intake 合并流程。没有历史官方分数的首个投稿不受这条比较规则阻塞，但仍必须通过
 60 分绝对门槛、四项 gate 和强制退件检查。
 
-这条保护只依据 exact-head 的官方维护者评论，不把本地自检、advisory scorer、草稿或
+这条保护还会校验 review 的 `state=APPROVED` 与 reviewer login。默认 trusted reviewer 是
+当前官方 intake bot `CocoSgt`；维护者轮换时通过 `HAIDIAN_TRUSTED_REVIEWERS`（逗号分隔的
+GitHub login allowlist）更新 worker 配置。普通贡献者、`CHANGES_REQUESTED` 评论、草稿或
+正文中单独伪造 marker 的评论都不会建立历史分数。它不把本地自检、advisory scorer 或
 公共 gallery 位置当作正式分数。若历史最高包已经被更低分版本覆盖，维护者应从历史
 exact head 建立恢复 PR，并在新的 exact head 重新评分达到原最高分前保持候选不合并；不
 使用 force-push 或重写 `main`。

--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -287,8 +287,8 @@ SHA 复核和 merge 使用进程内锁串行执行，避免 Git 引用锁和 bas
 原有 intake 合并流程。没有历史官方分数的首个投稿不受这条比较规则阻塞，但仍必须通过
 60 分绝对门槛、四项 gate 和强制退件检查。
 
-这条保护还会校验 review 的 `state=APPROVED` 与 reviewer login。默认 trusted reviewer 是
-当前官方 intake bot `CocoSgt`；维护者轮换时通过 `HAIDIAN_TRUSTED_REVIEWERS`（逗号分隔的
+这条保护还会校验 review 的 `state=APPROVED` 与 reviewer login。当前已登记的官方 intake
+reviewer 是 `CocoSgt` 和 `wakenmeng`；维护者轮换时通过 `HAIDIAN_TRUSTED_REVIEWERS`（逗号分隔的
 GitHub login allowlist）更新 worker 配置。普通贡献者、`CHANGES_REQUESTED` 评论、草稿或
 正文中单独伪造 marker 的评论都不会建立历史分数。它不把本地自检、advisory scorer 或
 公共 gallery 位置当作正式分数。若历史最高包已经被更低分版本覆盖，维护者应从历史

--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -265,7 +265,7 @@ export HAIDIAN_REVIEW_MODEL="gpt-5.6-sol"
 # 先评审并生成审计材料，不修改 GitHub
 python3 scripts/auto_review_queue.py --limit 10
 
-# 正式回写 review/label；通过 60 分门槛和四项 gate 的 PR 自动合并
+# 正式回写 review/label；通过 60 分门槛、四项 gate 且不低于历史最高分的 PR 自动合并
 python3 scripts/auto_review_queue.py --limit 10 --concurrency 3 --apply --admin-merge
 ```
 
@@ -277,6 +277,20 @@ PR 不调用模型；draft 不进入队列。合并仅表示仓库 intake，展�
 worker 每轮按 PR 编号从旧到新处理，避免持续新增投稿使早期稿件饥饿。
 模型调用和本地视觉检查默认三路并行；worktree 创建/清理以及 GitHub review、标签、
 SHA 复核和 merge 使用进程内锁串行执行，避免 Git 引用锁和 base-branch merge 竞态。
+
+### 分数保护与恢复
+
+`--apply` 在决定合并前，会读取该投稿作者已合并 PR 中带有
+`haidian-auto-review:<exact-head-sha>` 标记的维护者 Review Agent 评论，并按投稿目录计算
+历史官方最高分。新 exact head 的分数低于该最高分时，worker 会发布
+`score-preservation hold`、请求修改并保持 PR 不合并；达到或超过最高分才有资格继续走
+原有 intake 合并流程。没有历史官方分数的首个投稿不受这条比较规则阻塞，但仍必须通过
+60 分绝对门槛、四项 gate 和强制退件检查。
+
+这条保护只依据 exact-head 的官方维护者评论，不把本地自检、advisory scorer、草稿或
+公共 gallery 位置当作正式分数。若历史最高包已经被更低分版本覆盖，维护者应从历史
+exact head 建立恢复 PR，并在新的 exact head 重新评分达到原最高分前保持候选不合并；不
+使用 force-push 或重写 `main`。
 
 `submission-validation` 成功时会自动清除旧的 CI/修改/低质量标签并添加
 `review/queued`；投稿人推送修订后无需维护者手动重新排队。CI 失败时 workflow

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -12,6 +12,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import fcntl
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -25,9 +26,14 @@ from generate_submissions_data import package_sha256
 
 REVIEW_MARKER = "<!-- haidian-auto-review:{head_sha} -->"
 CONFLICT_MARKER = "<!-- haidian-auto-review-conflict:{head_sha} -->"
+SCORE_REVIEW_PATTERN = re.compile(
+    r"<!-- haidian-auto-review:(?P<head>[0-9a-f]{40}) -->\s*"
+    r"Maintainer intake decision: Review Agent score (?P<score>[0-9]+(?:\.[0-9]+)?)/100\."
+)
 PASS = "SUCCESS"
 WORKTREE_LOCK = threading.Lock()
 GITHUB_WRITE_LOCK = threading.Lock()
+HISTORY_LOCK = threading.Lock()
 
 
 class WorkerError(RuntimeError):
@@ -99,7 +105,63 @@ def submission_dir_from_files(paths: list[str], author: str) -> str:
     return roots.pop()
 
 
-def decide(review: dict[str, Any], decision: dict[str, Any], threshold: float) -> Decision:
+def official_score_from_review(body: str, head_sha: str) -> float | None:
+    """Read only the trusted exact-head score marker emitted by this worker."""
+    match = SCORE_REVIEW_PATTERN.search(body)
+    if match is None or match.group("head") != head_sha.casefold():
+        return None
+    return float(match.group("score"))
+
+
+def _submission_root_from_paths(paths: list[str]) -> str | None:
+    roots = {
+        "/".join(path.split("/")[:3])
+        for path in paths
+        if len(path.split("/")) >= 4 and path.split("/")[0] == "submissions"
+    }
+    return next(iter(roots)) if len(roots) == 1 else None
+
+
+def historical_best_score(merged_prs: list[dict[str, Any]], submission_dir: str) -> float | None:
+    """Return the highest trusted score for one package across merged PRs."""
+    best: float | None = None
+    for pr in merged_prs:
+        if _submission_root_from_paths([str(item.get("path", "")) for item in pr.get("files", [])]) != submission_dir:
+            continue
+        head_sha = str(pr.get("headRefOid", ""))
+        for review in pr.get("reviews", []):
+            score = official_score_from_review(str(review.get("body", "")), head_sha)
+            if score is not None and (best is None or score > best):
+                best = score
+    return best
+
+
+def merged_prs_for_author(repo: str, author: str, cwd: Path) -> list[dict[str, Any]]:
+    """Fetch merged package PRs once per author for score-preservation checks."""
+    return gh_json(
+        repo,
+        [
+            "pr",
+            "list",
+            "--state",
+            "merged",
+            "--author",
+            author,
+            "--limit",
+            "1000",
+            "--json",
+            "headRefOid,files,reviews",
+        ],
+        cwd=cwd,
+    )
+
+
+def decide(
+    review: dict[str, Any],
+    decision: dict[str, Any],
+    threshold: float,
+    historical_best: float | None = None,
+) -> Decision:
     mandatory = review.get("mandatory_rejection", {})
     if mandatory.get("result") != "pass":
         return Decision("request-changes", decision.get("weighted_score_100"), "mandatory rejection hit")
@@ -118,6 +180,12 @@ def decide(review: dict[str, Any], decision: dict[str, Any], threshold: float) -
         raise WorkerError("AI decision has no numeric weighted_score_100")
     if float(score) < threshold:
         return Decision("low-quality", float(score), f"score below {threshold:g}")
+    if historical_best is not None and float(score) < historical_best:
+        return Decision(
+            "score-regression",
+            float(score),
+            f"score below historical exact-head best {historical_best:g}",
+        )
     return Decision("accept", float(score), "threshold and all gates passed")
 
 
@@ -184,6 +252,7 @@ def load_cached_review(
     submission_dir: str,
     checkout_root: Path,
     threshold: float,
+    historical_best: float | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any], Decision] | None:
     try:
         review = json.loads((audit_dir / "ai-review.json").read_text(encoding="utf-8"))
@@ -204,7 +273,7 @@ def load_cached_review(
     if decision.get("reviewed_package_sha256") != expected_hash:
         return None
     try:
-        outcome = decide(review, decision, threshold)
+        outcome = decide(review, decision, threshold, historical_best)
     except WorkerError:
         return None
     return review, decision, outcome
@@ -219,6 +288,7 @@ def apply_review(
     cwd: Path,
     *,
     admin_merge: bool,
+    historical_best: float | None = None,
 ) -> None:
     live = pr_meta(repo, number, cwd)
     assert_live(live, head_sha, require_success=True)
@@ -231,6 +301,8 @@ def apply_review(
             "Mandatory rejection and all four local gates passed. Accepted for repository intake only; "
             "this is not gallery publication, award selection, implementation approval, or government endorsement."
         )
+        if historical_best is not None:
+            body += f" Historical exact-head best for this submission: {historical_best:g}/100; this score does not regress it."
         run(["gh", "pr", "review", str(number), "--repo", repo, "--approve", "--body", body], cwd=cwd)
         assert_live(pr_meta(repo, number, cwd), head_sha, require_success=True)
         merge = ["gh", "pr", "merge", str(number), "--repo", repo, "--merge"]
@@ -247,7 +319,15 @@ def apply_review(
         return
 
     body = comment_file.read_text(encoding="utf-8")
-    body = f"{marker}\n{body}"
+    if outcome.action == "score-regression" and historical_best is not None:
+        body = (
+            f"{marker}\nScore-preservation hold: Review Agent score {outcome.score:g}/100 is below the "
+            f"historical exact-head best {historical_best:g}/100 for this submission. Do not merge this PR; "
+            "keep the higher-scoring merged version as the public recovery target.\n\n"
+            + body
+        )
+    else:
+        body = f"{marker}\n{body}"
     run(["gh", "pr", "review", str(number), "--repo", repo, "--request-changes", "--body", body], cwd=cwd)
     add = ["review/changes-requested"]
     if outcome.action == "low-quality":
@@ -258,7 +338,12 @@ def apply_review(
     )
 
 
-def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) -> dict[str, Any]:
+def process_pr(
+    args: argparse.Namespace,
+    meta: dict[str, Any],
+    repo_root: Path,
+    history_cache: dict[str, list[dict[str, Any]]],
+) -> dict[str, Any]:
     number = int(meta["number"])
     head_sha = str(meta["headRefOid"])
     author = str(meta["author"]["login"])
@@ -287,7 +372,12 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
         checked = run(["git", "rev-parse", "HEAD"], cwd=worktree).stdout.strip()
         if checked != head_sha:
             raise WorkerError("fetched worktree SHA does not match live PR head")
-        cached = load_cached_review(audit_dir, submission_dir, worktree, args.threshold)
+        with HISTORY_LOCK:
+            if author not in history_cache:
+                history_cache[author] = merged_prs_for_author(args.repo, author, repo_root)
+            merged_prs = history_cache[author]
+        historical_best = historical_best_score(merged_prs, submission_dir)
+        cached = load_cached_review(audit_dir, submission_dir, worktree, args.threshold, historical_best)
         if cached is None:
             command = [
                 sys.executable,
@@ -315,7 +405,7 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
             run(command, cwd=worktree)
             review = json.loads((audit_dir / "ai-review.json").read_text(encoding="utf-8"))
             ai_decision = json.loads((audit_dir / "ai-decision.json").read_text(encoding="utf-8"))
-            outcome = decide(review, ai_decision, args.threshold)
+            outcome = decide(review, ai_decision, args.threshold, historical_best)
             reused_audit = False
         else:
             review, ai_decision, outcome = cached
@@ -327,6 +417,7 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
             "score": outcome.score,
             "result": outcome.action,
             "reason": outcome.reason,
+            "historical_best_score": historical_best,
             "package_sha256": ai_decision.get("reviewed_package_sha256"),
             "reused_audit": reused_audit,
         }
@@ -340,6 +431,7 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
                     audit_dir / "pr-comment.md",
                     repo_root,
                     admin_merge=args.admin_merge,
+                    historical_best=historical_best,
                 )
             result["applied"] = True
         return result
@@ -411,6 +503,7 @@ def main() -> int:
     )
     selected = []
     results = []
+    history_cache: dict[str, list[dict[str, Any]]] = {}
     for candidate in sorted(candidates, key=lambda item: int(item["number"])):
         if len(selected) >= args.limit:
             break
@@ -441,7 +534,7 @@ def main() -> int:
             continue
         selected.append(live)
     with ThreadPoolExecutor(max_workers=args.concurrency) as executor:
-        futures = {executor.submit(process_pr, args, meta, repo_root): meta for meta in selected}
+        futures = {executor.submit(process_pr, args, meta, repo_root, history_cache): meta for meta in selected}
         for future in as_completed(futures):
             meta = futures[future]
             try:

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -30,6 +30,8 @@ SCORE_REVIEW_PATTERN = re.compile(
     r"<!-- haidian-auto-review:(?P<head>[0-9a-f]{40}) -->\s*"
     r"Maintainer intake decision: Review Agent score (?P<score>[0-9]+(?:\.[0-9]+)?)/100\."
 )
+DEFAULT_TRUSTED_REVIEWERS = frozenset({"cocosgt"})
+TRUSTED_REVIEWERS_ENV = "HAIDIAN_TRUSTED_REVIEWERS"
 PASS = "SUCCESS"
 WORKTREE_LOCK = threading.Lock()
 GITHUB_WRITE_LOCK = threading.Lock()
@@ -105,9 +107,29 @@ def submission_dir_from_files(paths: list[str], author: str) -> str:
     return roots.pop()
 
 
-def official_score_from_review(body: str, head_sha: str) -> float | None:
-    """Read only the trusted exact-head score marker emitted by this worker."""
-    match = SCORE_REVIEW_PATTERN.search(body)
+def trusted_reviewer_logins() -> set[str]:
+    """Return the explicit maintainer/bot reviewer allowlist used for history."""
+    configured = {
+        item.strip().casefold()
+        for item in os.getenv(TRUSTED_REVIEWERS_ENV, "").split(",")
+        if item.strip()
+    }
+    return configured or set(DEFAULT_TRUSTED_REVIEWERS)
+
+
+def official_score_from_review(
+    review: dict[str, Any],
+    head_sha: str,
+    trusted_reviewers: set[str] | None = None,
+) -> float | None:
+    """Read only an approved exact-head score from an explicitly trusted reviewer."""
+    if str(review.get("state", "")).upper() != "APPROVED":
+        return None
+    author = review.get("author") or review.get("user") or {}
+    login = str(author.get("login", "")).casefold() if isinstance(author, dict) else ""
+    if login not in (trusted_reviewers or trusted_reviewer_logins()):
+        return None
+    match = SCORE_REVIEW_PATTERN.search(str(review.get("body", "")))
     if match is None or match.group("head") != head_sha.casefold():
         return None
     return float(match.group("score"))
@@ -122,7 +144,11 @@ def _submission_root_from_paths(paths: list[str]) -> str | None:
     return next(iter(roots)) if len(roots) == 1 else None
 
 
-def historical_best_score(merged_prs: list[dict[str, Any]], submission_dir: str) -> float | None:
+def historical_best_score(
+    merged_prs: list[dict[str, Any]],
+    submission_dir: str,
+    trusted_reviewers: set[str] | None = None,
+) -> float | None:
     """Return the highest trusted score for one package across merged PRs."""
     best: float | None = None
     for pr in merged_prs:
@@ -130,7 +156,7 @@ def historical_best_score(merged_prs: list[dict[str, Any]], submission_dir: str)
             continue
         head_sha = str(pr.get("headRefOid", ""))
         for review in pr.get("reviews", []):
-            score = official_score_from_review(str(review.get("body", "")), head_sha)
+            score = official_score_from_review(review, head_sha, trusted_reviewers)
             if score is not None and (best is None or score > best):
                 best = score
     return best
@@ -376,7 +402,7 @@ def process_pr(
             if author not in history_cache:
                 history_cache[author] = merged_prs_for_author(args.repo, author, repo_root)
             merged_prs = history_cache[author]
-        historical_best = historical_best_score(merged_prs, submission_dir)
+        historical_best = historical_best_score(merged_prs, submission_dir, trusted_reviewer_logins())
         cached = load_cached_review(audit_dir, submission_dir, worktree, args.threshold, historical_best)
         if cached is None:
             command = [

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -136,10 +136,16 @@ def official_score_from_review(
 
 
 def _submission_root_from_paths(paths: list[str]) -> str | None:
+    if not paths:
+        return None
+    if any(
+        len(path.split("/")) < 4 or path.split("/")[0] != "submissions"
+        for path in paths
+    ):
+        return None
     roots = {
         "/".join(path.split("/")[:3])
         for path in paths
-        if len(path.split("/")) >= 4 and path.split("/")[0] == "submissions"
     }
     return next(iter(roots)) if len(roots) == 1 else None
 

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -144,6 +144,17 @@ def _submission_root_from_paths(paths: list[str]) -> str | None:
     return next(iter(roots)) if len(roots) == 1 else None
 
 
+def _review_commit_sha(review: dict[str, Any]) -> str:
+    """Return the commit reviewed by a GitHub REST or GraphQL review object."""
+    commit_id = review.get("commit_id")
+    if commit_id:
+        return str(commit_id)
+    commit = review.get("commit")
+    if isinstance(commit, dict):
+        return str(commit.get("oid", ""))
+    return ""
+
+
 def historical_best_score(
     merged_prs: list[dict[str, Any]],
     submission_dir: str,
@@ -154,9 +165,15 @@ def historical_best_score(
     for pr in merged_prs:
         if _submission_root_from_paths([str(item.get("path", "")) for item in pr.get("files", [])]) != submission_dir:
             continue
-        head_sha = str(pr.get("headRefOid", ""))
+        final_head_sha = str(pr.get("headRefOid", ""))
         for review in pr.get("reviews", []):
-            score = official_score_from_review(review, head_sha, trusted_reviewers)
+            # A merged PR can have several reviewed revisions.  The final PR
+            # head is not necessarily the revision that earned the highest
+            # trusted score, so bind the score to the review's own commit.
+            review_sha = _review_commit_sha(review) or final_head_sha
+            if not review_sha:
+                continue
+            score = official_score_from_review(review, review_sha, trusted_reviewers)
             if score is not None and (best is None or score > best):
                 best = score
     return best

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -30,7 +30,7 @@ SCORE_REVIEW_PATTERN = re.compile(
     r"<!-- haidian-auto-review:(?P<head>[0-9a-f]{40}) -->\s*"
     r"Maintainer intake decision: Review Agent score (?P<score>[0-9]+(?:\.[0-9]+)?)/100\."
 )
-DEFAULT_TRUSTED_REVIEWERS = frozenset({"cocosgt"})
+DEFAULT_TRUSTED_REVIEWERS = frozenset({"cocosgt", "wakenmeng"})
 TRUSTED_REVIEWERS_ENV = "HAIDIAN_TRUSTED_REVIEWERS"
 PASS = "SUCCESS"
 WORKTREE_LOCK = threading.Lock()

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -13,7 +13,9 @@ from auto_review_queue import (  # noqa: E402
     WorkerError,
     ci_state,
     decide,
+    historical_best_score,
     load_cached_review,
+    official_score_from_review,
     parse_args,
     submission_dir_from_files,
 )
@@ -55,6 +57,60 @@ class AutoReviewQueueTests(unittest.TestCase):
             },
         }
         self.assertEqual("low-quality", decide(review, {"weighted_score_100": 59.9}, 60).action)
+
+    def test_score_regression_is_not_merged_even_above_absolute_threshold(self) -> None:
+        review = {
+            "mandatory_rejection": {"result": "pass"},
+            "gate_checks": {
+                name: {"status": "pass"}
+                for name in [
+                    "deterministic_validation",
+                    "spatial_review",
+                    "visual_review",
+                    "professional_evidence_review",
+                ]
+            },
+        }
+        outcome = decide(review, {"weighted_score_100": 79}, 60, historical_best=93)
+        self.assertEqual("score-regression", outcome.action)
+        self.assertIn("historical exact-head best 93", outcome.reason)
+
+    def test_equal_historical_score_remains_eligible(self) -> None:
+        review = {
+            "mandatory_rejection": {"result": "pass"},
+            "gate_checks": {
+                name: {"status": "pass"}
+                for name in [
+                    "deterministic_validation",
+                    "spatial_review",
+                    "visual_review",
+                    "professional_evidence_review",
+                ]
+            },
+        }
+        self.assertEqual("accept", decide(review, {"weighted_score_100": 93}, 60, historical_best=93).action)
+
+    def test_historical_score_requires_exact_head_marker_and_package_path(self) -> None:
+        head = "a" * 40
+        body = (
+            f"<!-- haidian-auto-review:{head} -->\n"
+            "Maintainer intake decision: Review Agent score 93/100. Mandatory rejection and all four local gates passed."
+        )
+        self.assertEqual(93, official_score_from_review(body, head))
+        self.assertIsNone(official_score_from_review(body, "b" * 40))
+        merged_prs = [
+            {
+                "headRefOid": head,
+                "files": [{"path": "submissions/alice/plan/manifest.json"}],
+                "reviews": [{"body": body}],
+            },
+            {
+                "headRefOid": head,
+                "files": [{"path": "submissions/alice/other/manifest.json"}],
+                "reviews": [{"body": body}],
+            },
+        ]
+        self.assertEqual(93, historical_best_score(merged_prs, "submissions/alice/plan"))
 
     def test_failed_gate_overrides_high_score(self) -> None:
         review = {

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -141,6 +141,29 @@ class AutoReviewQueueTests(unittest.TestCase):
         ]
         self.assertIsNone(historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
 
+    def test_historical_best_keeps_higher_score_from_non_final_merged_pr_revision(self) -> None:
+        reviewed_head = "c" * 40
+        final_head = "d" * 40
+        body = (
+            f"<!-- haidian-auto-review:{reviewed_head} -->\n"
+            "Maintainer intake decision: Review Agent score 94/100. Mandatory rejection and all four local gates passed."
+        )
+        merged_prs = [
+            {
+                "headRefOid": final_head,
+                "files": [{"path": "submissions/alice/plan/proposal.md"}],
+                "reviews": [
+                    {
+                        "state": "APPROVED",
+                        "author": {"login": "CocoSgt"},
+                        "body": body,
+                        "commit": {"oid": reviewed_head},
+                    }
+                ],
+            }
+        ]
+        self.assertEqual(94, historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
+
     def test_failed_gate_overrides_high_score(self) -> None:
         review = {
             "mandatory_rejection": {"result": "pass"},

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -96,21 +96,50 @@ class AutoReviewQueueTests(unittest.TestCase):
             f"<!-- haidian-auto-review:{head} -->\n"
             "Maintainer intake decision: Review Agent score 93/100. Mandatory rejection and all four local gates passed."
         )
-        self.assertEqual(93, official_score_from_review(body, head))
-        self.assertIsNone(official_score_from_review(body, "b" * 40))
+        approved = {"state": "APPROVED", "author": {"login": "CocoSgt"}, "body": body}
+        self.assertEqual(93, official_score_from_review(approved, head, {"cocosgt"}))
+        self.assertIsNone(official_score_from_review(approved, "b" * 40, {"cocosgt"}))
+        self.assertIsNone(
+            official_score_from_review(
+                {**approved, "state": "CHANGES_REQUESTED"}, head, {"cocosgt"}
+            )
+        )
+        self.assertIsNone(
+            official_score_from_review(
+                {**approved, "author": {"login": "untrusted-contributor"}}, head, {"cocosgt"}
+            )
+        )
         merged_prs = [
             {
                 "headRefOid": head,
                 "files": [{"path": "submissions/alice/plan/manifest.json"}],
-                "reviews": [{"body": body}],
+                "reviews": [approved],
             },
             {
                 "headRefOid": head,
                 "files": [{"path": "submissions/alice/other/manifest.json"}],
-                "reviews": [{"body": body}],
+                "reviews": [approved],
             },
         ]
-        self.assertEqual(93, historical_best_score(merged_prs, "submissions/alice/plan"))
+        self.assertEqual(93, historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
+
+    def test_non_approved_or_untrusted_reviews_never_raise_historical_best(self) -> None:
+        head = "b" * 40
+        body = (
+            f"<!-- haidian-auto-review:{head} -->\n"
+            "Maintainer intake decision: Review Agent score 100/100. Mandatory rejection and all four local gates passed."
+        )
+        merged_prs = [
+            {
+                "headRefOid": head,
+                "files": [{"path": "submissions/alice/plan/manifest.json"}],
+                "reviews": [
+                    {"state": "CHANGES_REQUESTED", "author": {"login": "CocoSgt"}, "body": body},
+                    {"state": "APPROVED", "author": {"login": "untrusted-contributor"}, "body": body},
+                ],
+            }
+        ]
+        self.assertIsNone(historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
 
     def test_failed_gate_overrides_high_score(self) -> None:
         review = {

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -141,6 +141,26 @@ class AutoReviewQueueTests(unittest.TestCase):
         ]
         self.assertIsNone(historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
 
+    def test_mixed_scope_merged_pr_cannot_establish_package_history(self) -> None:
+        head = "b" * 40
+        body = (
+            f"<!-- haidian-auto-review:{head} -->\n"
+            "Maintainer intake decision: Review Agent score 100/100. Mandatory rejection and all four local gates passed."
+        )
+        merged_prs = [
+            {
+                "headRefOid": head,
+                "files": [
+                    {"path": "submissions/alice/plan/manifest.json"},
+                    {"path": "scripts/auto_review_queue.py"},
+                ],
+                "reviews": [
+                    {"state": "APPROVED", "author": {"login": "CocoSgt"}, "body": body}
+                ],
+            }
+        ]
+        self.assertIsNone(historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
+
     def test_historical_best_keeps_higher_score_from_non_final_merged_pr_revision(self) -> None:
         reviewed_head = "c" * 40
         final_head = "d" * 40


### PR DESCRIPTION
## Problem

The queue worker must not let a later lower-scoring revision replace a higher-scoring merged version for the same submission directory. A local self-check or stale score marker is not sufficient evidence for promotion.

## Change

- Parse only trusted exact-head maintainer Review Agent markers.
- Restrict historical candidates to merged PRs by the same author and the exact submission directory.
- Require the trusted issuer allowlist and APPROVED review state; CHANGES_REQUESTED, dismissed, ordinary comments, and stale heads do not count.
- Keep the existing absolute threshold and all deterministic gates.
- If a candidate score is below the historical best, publish a score-preservation hold and request changes; do not approve or merge it.
- Equal or higher scores remain eligible for the existing intake flow.
- Keep the decision observable with historical_best_score.

## Fresh history audit

The current verified maximums for 147228 package directories are: Open Pulse 94, AI-era 88, Human City 83, Autonomy 84, and Mobility 69. The guard is directory-scoped and does not compare unrelated projects.

## Boundary

This PR changes review-queue behavior only. It does not modify submission packages, submissions-data.js, gallery-publication.json, public ranking files, or merged Git history. It blocks intake/merge/publication progression for a lower-scoring candidate; it does not delete already-pushed or already-merged commits. Recovery remains: start from a historical exact head, make an explicit forward candidate, run trusted validation and exact-head Review Agent scoring, then keep it only if it meets the protected score line.
