### PR TITLE
fix: reject colliding standard reference filenames

### DIFF
--- a/scripts/fetch_standard_references.py
+++ b/scripts/fetch_standard_references.py
@@ -91,6 +91,24 @@ def slugify(value: str) -> str:
     return slug or "standard"
 
 
+def validate_unique_reference_slugs(standards: Any) -> None:
+    if not isinstance(standards, list):
+        return
+    seen: dict[str, str] = {}
+    for standard in standards:
+        if not isinstance(standard, dict) or not standard.get("standard_id"):
+            continue
+        standard_id = str(standard["standard_id"])
+        slug = slugify(standard_id)
+        previous = seen.get(slug)
+        if previous is not None:
+            raise ValueError(
+                f"standard reference filename collision for `{slug}.md`: "
+                f"`{previous}` and `{standard_id}`"
+            )
+        seen[slug] = standard_id
+
+
 def decode_html(raw: bytes, content_type: str | None) -> str:
     candidates: list[str] = []
     if content_type:
@@ -232,8 +250,12 @@ def main() -> int:
     repo_root = Path(args.repo_root)
     standards_path = repo_root / args.standards
     output_dir = repo_root / args.output_dir
-    output_dir.mkdir(parents=True, exist_ok=True)
     data = json.loads(standards_path.read_text(encoding="utf-8"))
+    try:
+        validate_unique_reference_slugs(data.get("standards"))
+    except ValueError as exc:
+        parser.error(str(exc))
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     index: list[dict[str, Any]] = []
     for standard in data.get("standards", []):

--- a/tests/test_fetch_standard_references.py
+++ b/tests/test_fetch_standard_references.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FETCHER = REPO_ROOT / "scripts" / "fetch_standard_references.py"
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from fetch_standard_references import validate_unique_reference_slugs  # noqa: E402
+
+
+class FetchStandardReferencesTests(unittest.TestCase):
+    def test_repo_standard_ids_have_unique_reference_filenames(self) -> None:
+        data = json.loads(
+            (REPO_ROOT / "brief" / "site-package" / "standards" / "standards.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        validate_unique_reference_slugs(data["standards"])
+
+    def test_filename_collisions_fail_before_fetch_or_output(self) -> None:
+        collision_sets = [
+            ("STD_A", "STD-A"),
+            ("城市设计标准", "建筑设计标准"),
+        ]
+        for standard_ids in collision_sets:
+            with self.subTest(standard_ids=standard_ids), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                standards = {
+                    "standards": [
+                        {"standard_id": standard_id, "source_url": "https://example.invalid/standard"}
+                        for standard_id in standard_ids
+                    ]
+                }
+                (root / "standards.json").write_text(
+                    json.dumps(standards, ensure_ascii=False), encoding="utf-8"
+                )
+
+                completed = subprocess.run(
+                    [
+                        sys.executable,
+                        str(FETCHER),
+                        "--repo-root",
+                        str(root),
+                        "--standards",
+                        "standards.json",
+                        "--output-dir",
+                        "references",
+                    ],
+                    cwd=REPO_ROOT,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+
+                self.assertEqual(completed.returncode, 2, completed.stdout + completed.stderr)
+                self.assertIn("filename collision", completed.stderr)
+                for standard_id in standard_ids:
+                    self.assertIn(standard_id, completed.stderr)
+                self.assertFalse((root / "references").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`fetch_standard_references.py` derives snapshot filenames by normalizing `standard_id`. Distinct IDs such as `STD_A` and `STD-A` both become `std-a.md`; IDs containing only non-ASCII characters all fall back to `standard.md`. The later record overwrites the earlier snapshot while the index retains a stale digest for the overwritten record.

## Change

- preflight all standard IDs for normalized filename collisions
- report both conflicting IDs and the shared filename through a normal CLI error
- run this preflight before creating the output directory, fetching URLs, or writing snapshots
- cover punctuation-equivalent IDs and non-ASCII fallback collisions
- verify the repository current standard registry remains collision-free

## Verification

- `python3 -m unittest tests.test_fetch_standard_references -v` (2 passed)
- `python3 -m py_compile scripts/fetch_standard_references.py tests/test_fetch_standard_references.py`
- `git diff --check`

Open-PR file overlap was checked before implementation; no active PR modifies either changed file.