### PR TITLE
fix: keep peer downloads bounded with malformed lengths

### DIFF
--- a/scripts/read_peer_proposals.py
+++ b/scripts/read_peer_proposals.py
@@ -130,8 +130,17 @@ def fetch_bytes(url: str, max_bytes: int) -> bytes:
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
     with urllib.request.urlopen(request, timeout=30) as response:
         length = response.headers.get("Content-Length")
-        if length and int(length) > max_bytes:
-            raise PeerReaderError(f"remote file exceeds limit ({int(length)} bytes): {url}")
+        declared_length: int | None = None
+        if length:
+            try:
+                parsed_length = int(length)
+            except (TypeError, ValueError):
+                pass
+            else:
+                if parsed_length >= 0:
+                    declared_length = parsed_length
+        if declared_length is not None and declared_length > max_bytes:
+            raise PeerReaderError(f"remote file exceeds limit ({declared_length} bytes): {url}")
         chunks: list[bytes] = []
         total = 0
         while True:

--- a/tests/test_read_peer_proposals.py
+++ b/tests/test_read_peer_proposals.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from read_peer_proposals import PeerReaderError, fetch_bytes  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, content_length: str, chunks: list[bytes]) -> None:
+        self.headers = {"Content-Length": content_length}
+        self.chunks = iter(chunks)
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self, _size: int) -> bytes:
+        return next(self.chunks, b"")
+
+
+class ReadPeerProposalsTests(unittest.TestCase):
+    def test_malformed_content_length_uses_streamed_size_limit(self) -> None:
+        small = FakeResponse("unknown", [b"small", b""])
+        with mock.patch("read_peer_proposals.urllib.request.urlopen", return_value=small):
+            self.assertEqual(fetch_bytes("https://example.test/small", 10), b"small")
+
+        oversized = FakeResponse("-1", [b"123456", b""])
+        with mock.patch("read_peer_proposals.urllib.request.urlopen", return_value=oversized):
+            with self.assertRaisesRegex(PeerReaderError, "download exceeded limit"):
+                fetch_bytes("https://example.test/oversized", 5)
+
+    def test_malformed_content_length_rejects_oversized_body(self) -> None:
+        oversized = FakeResponse("unknown", [b"123456", b""])
+        with mock.patch("read_peer_proposals.urllib.request.urlopen", return_value=oversized):
+            with self.assertRaisesRegex(PeerReaderError, "download exceeded limit"):
+                fetch_bytes("https://example.test/oversized", 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The peer proposal reader treats the remote `Content-Length` header as a trusted integer. A malformed value raises an uncaught `ValueError`, so the download aborts with a traceback instead of relying on the existing streamed byte limit. Negative values are also not meaningful declared lengths.

## Change

- accept a declared length only when it parses as a non-negative integer
- treat malformed or negative lengths as unknown
- retain the streamed byte counter as the authoritative hard limit
- add a regression covering a small response with a malformed header and an oversized response with a negative header

## Verification

- `python3 -m unittest tests.test_read_peer_proposals tests.test_lightweight_participant_flow -v` (8 passed)
- `python3 -m py_compile scripts/read_peer_proposals.py tests/test_read_peer_proposals.py`
- `git diff --check`

No active PR modifies either changed file.