### PR TITLE
fix: skip malformed source draft URLs

### DIFF
--- a/scripts/prepare_source_registry_draft.py
+++ b/scripts/prepare_source_registry_draft.py
@@ -78,8 +78,14 @@ def normalize_id(value: str, fallback_url: str) -> str:
     return f"DRAFT-{base}"
 
 
-def canonicalize_url(url: str) -> str:
-    parsed = urllib.parse.urlsplit((url or "").strip())
+def canonicalize_url(url: str) -> str | None:
+    try:
+        parsed = urllib.parse.urlsplit((url or "").strip())
+        hostname = parsed.hostname
+    except ValueError:
+        return None
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.netloc or not hostname:
+        return None
     scheme = parsed.scheme.lower()
     netloc = parsed.netloc.lower()
     path = re.sub(r"/{2,}", "/", parsed.path)
@@ -103,7 +109,9 @@ def existing_urls(registry: dict[str, Any]) -> set[str]:
     urls = set()
     for source in registry.get("sources", []):
         if isinstance(source, dict) and source.get("url"):
-            urls.add(canonicalize_url(str(source["url"])))
+            canonical = canonicalize_url(str(source["url"]))
+            if canonical is not None:
+                urls.add(canonical)
     return urls
 
 
@@ -238,6 +246,8 @@ def dedupe_sources(sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
     by_url: dict[str, dict[str, Any]] = {}
     for source in sources:
         key = canonicalize_url(source["url"])
+        if key is None:
+            continue
         if key not in by_url:
             by_url[key] = source
     used_ids: set[str] = set()
@@ -270,11 +280,16 @@ def build_draft(
     existing = load_existing_registry(existing_registry_path)
     existing_url_set = existing_urls(existing)
     sources = []
+    skipped_invalid_urls = 0
     for row in rows:
         url = row_url(row)
         if not url:
             continue
-        if not include_existing and canonicalize_url(url) in existing_url_set:
+        canonical = canonicalize_url(url)
+        if canonical is None:
+            skipped_invalid_urls += 1
+            continue
+        if not include_existing and canonical in existing_url_set:
             continue
         sources.append(discovery_row_to_source(row, current_year))
         if limit and len(sources) >= limit:
@@ -283,6 +298,7 @@ def build_draft(
         "schema_version": "0.1.0",
         "updated_date": dt.date.today().isoformat(),
         "sources": dedupe_sources(sources),
+        "_skipped_invalid_urls": skipped_invalid_urls,
         "_draft_note": f"Generated from {input_format}; review manually before merging into data/source_registry.json.",
     }
 
@@ -335,6 +351,7 @@ def main() -> int:
         "input": input_path.relative_to(repo_root).as_posix() if input_path.is_relative_to(repo_root) else str(input_path),
         "out": out_path.relative_to(repo_root).as_posix() if out_path.is_relative_to(repo_root) else str(out_path),
         "source_count": len(draft["sources"]),
+        "skipped_invalid_urls": draft["_skipped_invalid_urls"],
         "validation_errors": report.errors,
         "validation_warnings": report.warnings,
     }
@@ -342,6 +359,8 @@ def main() -> int:
         print(json.dumps(summary, ensure_ascii=False, indent=2))
     else:
         print(f"wrote {summary['source_count']} draft sources to {summary['out']}")
+        if summary["skipped_invalid_urls"]:
+            print(f"WARNING: skipped {summary['skipped_invalid_urls']} rows with invalid HTTP(S) URLs")
         for warning in report.warnings:
             print(f"WARNING: {warning}")
         for error in report.errors:

--- a/scripts/prepare_source_registry_draft.py
+++ b/scripts/prepare_source_registry_draft.py
@@ -82,6 +82,7 @@ def canonicalize_url(url: str) -> str | None:
     try:
         parsed = urllib.parse.urlsplit((url or "").strip())
         hostname = parsed.hostname
+        _ = parsed.port
     except ValueError:
         return None
     if parsed.scheme.lower() not in {"http", "https"} or not parsed.netloc or not hostname:

--- a/scripts/prepare_source_registry_draft.py
+++ b/scripts/prepare_source_registry_draft.py
@@ -79,13 +79,16 @@ def normalize_id(value: str, fallback_url: str) -> str:
 
 
 def canonicalize_url(url: str) -> str | None:
+    value = (url or "").strip()
     try:
-        parsed = urllib.parse.urlsplit((url or "").strip())
+        parsed = urllib.parse.urlsplit(value)
         hostname = parsed.hostname
         _ = parsed.port
     except ValueError:
         return None
     if parsed.scheme.lower() not in {"http", "https"} or not parsed.netloc or not hostname:
+        return None
+    if any(char.isspace() for char in value):
         return None
     scheme = parsed.scheme.lower()
     netloc = parsed.netloc.lower()

--- a/tests/test_source_registry_draft.py
+++ b/tests/test_source_registry_draft.py
@@ -60,6 +60,16 @@ class SourceRegistryDraftTests(unittest.TestCase):
                         "url": "https://example.com:99999/source",
                     },
                     {
+                        "id": "broken_005",
+                        "title": "Whitespace in hostname URL",
+                        "url": "https://exa mple.com/source",
+                    },
+                    {
+                        "id": "broken_006",
+                        "title": "Whitespace in path URL",
+                        "url": "https://example.com/path with spaces",
+                    },
+                    {
                         "id": "valid_001",
                         "title": "Valid source",
                         "url": "https://example.com/source",
@@ -92,7 +102,7 @@ class SourceRegistryDraftTests(unittest.TestCase):
             self.assertNotIn("Traceback", completed.stderr)
             summary = json.loads(completed.stdout)
             self.assertEqual(summary["source_count"], 1)
-            self.assertEqual(summary["skipped_invalid_urls"], 4)
+            self.assertEqual(summary["skipped_invalid_urls"], 6)
             self.assertEqual(summary["validation_errors"], [])
             draft = json.loads(out_path.read_text(encoding="utf-8"))
             self.assertEqual(["DRAFT-VALID-001"], [source["source_id"] for source in draft["sources"]])

--- a/tests/test_source_registry_draft.py
+++ b/tests/test_source_registry_draft.py
@@ -50,6 +50,16 @@ class SourceRegistryDraftTests(unittest.TestCase):
                         "url": "https://example.com：443/source",
                     },
                     {
+                        "id": "broken_003",
+                        "title": "Nonnumeric port URL",
+                        "url": "https://example.com:bad/source",
+                    },
+                    {
+                        "id": "broken_004",
+                        "title": "Out-of-range port URL",
+                        "url": "https://example.com:99999/source",
+                    },
+                    {
                         "id": "valid_001",
                         "title": "Valid source",
                         "url": "https://example.com/source",
@@ -82,7 +92,7 @@ class SourceRegistryDraftTests(unittest.TestCase):
             self.assertNotIn("Traceback", completed.stderr)
             summary = json.loads(completed.stdout)
             self.assertEqual(summary["source_count"], 1)
-            self.assertEqual(summary["skipped_invalid_urls"], 2)
+            self.assertEqual(summary["skipped_invalid_urls"], 4)
             self.assertEqual(summary["validation_errors"], [])
             draft = json.loads(out_path.read_text(encoding="utf-8"))
             self.assertEqual(["DRAFT-VALID-001"], [source["source_id"] for source in draft["sources"]])

--- a/tests/test_source_registry_draft.py
+++ b/tests/test_source_registry_draft.py
@@ -20,6 +20,73 @@ def write_csv(path: Path, rows: list[dict[str, str]], fields: list[str]) -> None
 
 
 class SourceRegistryDraftTests(unittest.TestCase):
+    def test_malformed_url_is_skipped_without_aborting_valid_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "data").mkdir()
+            existing_path = root / "data" / "source_registry.json"
+            existing_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "0.1.0",
+                        "updated_date": "2026-06-07",
+                        "sources": [{"source_id": "BROKEN", "url": "https://[::1"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            seed_path = root / "seed.csv"
+            write_csv(
+                seed_path,
+                [
+                    {
+                        "id": "broken_001",
+                        "title": "Malformed IPv6 URL",
+                        "url": "https://[",
+                    },
+                    {
+                        "id": "broken_002",
+                        "title": "Malformed netloc URL",
+                        "url": "https://example.com：443/source",
+                    },
+                    {
+                        "id": "valid_001",
+                        "title": "Valid source",
+                        "url": "https://example.com/source",
+                    },
+                ],
+                ["id", "title", "url"],
+            )
+            out_path = root / "draft.json"
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "prepare_source_registry_draft.py"),
+                    "--repo-root",
+                    str(root),
+                    "--input",
+                    str(seed_path),
+                    "--existing-registry",
+                    str(existing_path),
+                    "--out",
+                    str(out_path),
+                    "--json",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+            self.assertNotIn("Traceback", completed.stderr)
+            summary = json.loads(completed.stdout)
+            self.assertEqual(summary["source_count"], 1)
+            self.assertEqual(summary["skipped_invalid_urls"], 2)
+            self.assertEqual(summary["validation_errors"], [])
+            draft = json.loads(out_path.read_text(encoding="utf-8"))
+            self.assertEqual(["DRAFT-VALID-001"], [source["source_id"] for source in draft["sources"]])
+
     def test_seed_csv_generates_needs_review_draft_and_skips_existing_urls(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary

- treat URL canonicalization as a fallible operation and accept only HTTP(S) URLs with a hostname
- reject malformed IPv6 authorities, invalid or out-of-range ports, invalid NFKC netlocs, and internal whitespace
- skip malformed candidate rows while reporting their count in CLI output
- tolerate malformed URLs already present in an existing registry and keep final deduplication defensive

## Reproduction

On current main, a seed row containing https://[ reaches urllib.parse.urlsplit() and terminates the draft command with ValueError: Invalid IPv6 URL. A malformed URL in the existing registry fails through the same path before candidate processing starts. URLs with nonnumeric or out-of-range ports, non-HTTP(S) schemes, missing hosts, or internal whitespace are also accepted by the old canonicalization path.

The draft importer is a review-preparation tool, so one bad discovered row should not prevent valid candidates from being emitted.

## Verification

Rebased onto main at 233853bfdfdd7309f1f6e8de616a94c052f89235.

- python3 -m unittest tests.test_source_registry_draft tests.test_data_registry -v (8 passed)
- python3 -m py_compile scripts/prepare_source_registry_draft.py tests/test_source_registry_draft.py
- python3 scripts/validate_data_registry.py --json (current registry passes)
- python3 scripts/prepare_source_registry_draft.py --json --out TARGET (67 sources, 0 invalid URLs in the current seed corpus)
- git diff --check upstream/main...HEAD
- synthetic merge with #1377: source draft + discovery tests (12 passed)
- synthetic merge with #1052: source draft + data registry tests (9 passed)
- synthetic merge with #1053: source draft + public source tests (13 passed)
- synthetic merge with #2215: source draft + public source tests (14 passed)

The regression test covers malformed IPv6 syntax, an invalid NFKC netloc, nonnumeric and out-of-range ports, whitespace in the hostname and path, a malformed existing-registry URL, and a valid candidate that must still be written.

## Related work

- #1377 protects the earlier scripts/discover_public_sources.py seed/search/link intake stage.
- #1052 tightens the later scripts/validate_data_registry.py registry validation stage.
- #1053 and #2215 harden the separate scripts/validate_sources.py public-source index path.

These PRs do not modify the same files as this draft-importer fix.
