### PR TITLE
fix(review): bind merge to reviewed head

### DIFF
--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -304,7 +304,17 @@ def apply_review(
         )
         run(["gh", "pr", "review", str(number), "--repo", repo, "--approve", "--body", body], cwd=cwd)
         assert_live(pr_meta(repo, number, cwd), head_sha, require_success=True)
-        merge = ["gh", "pr", "merge", str(number), "--repo", repo, "--merge"]
+        merge = [
+            "gh",
+            "pr",
+            "merge",
+            str(number),
+            "--repo",
+            repo,
+            "--merge",
+            "--match-head-commit",
+            head_sha,
+        ]
         if admin_merge:
             merge.append("--admin")
         run(merge, cwd=cwd)

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -25,7 +25,7 @@ from generate_submissions_data import package_sha256  # noqa: E402
 
 
 class AutoReviewQueueTests(unittest.TestCase):
-    def test_merge_is_bound_to_reviewed_head(self) -> None:
+    def test_merge_is_bound_to_reviewed_head_for_all_merge_modes(self) -> None:
         head_sha = "a" * 40
         live = {
             "headRefOid": head_sha,
@@ -36,35 +36,37 @@ class AutoReviewQueueTests(unittest.TestCase):
                 {"name": "submission-validation", "conclusion": "SUCCESS"}
             ],
         }
-        with (
-            patch("auto_review_queue.pr_meta", return_value=live),
-            patch("auto_review_queue.run") as run_mock,
-        ):
-            apply_review(
-                "open-city-ai/haidian",
-                42,
-                head_sha,
-                Decision("accept", 90, "accepted"),
-                ROOT / "unused-comment.md",
-                ROOT,
-                admin_merge=True,
-            )
+        for admin_merge in (False, True):
+            with self.subTest(admin_merge=admin_merge):
+                with (
+                    patch("auto_review_queue.pr_meta", return_value=live),
+                    patch("auto_review_queue.run") as run_mock,
+                ):
+                    apply_review(
+                        "open-city-ai/haidian",
+                        42,
+                        head_sha,
+                        Decision("accept", 90, "accepted"),
+                        ROOT / "unused-comment.md",
+                        ROOT,
+                        admin_merge=admin_merge,
+                    )
 
-        run_mock.assert_any_call(
-            [
-                "gh",
-                "pr",
-                "merge",
-                "42",
-                "--repo",
-                "open-city-ai/haidian",
-                "--merge",
-                "--match-head-commit",
-                head_sha,
-                "--admin",
-            ],
-            cwd=ROOT,
-        )
+                    run_mock.assert_any_call(
+                        [
+                            "gh",
+                            "pr",
+                            "merge",
+                            "42",
+                            "--repo",
+                            "open-city-ai/haidian",
+                            "--merge",
+                            "--match-head-commit",
+                            head_sha,
+                            *(["--admin"] if admin_merge else []),
+                        ],
+                        cwd=ROOT,
+                    )
 
     def test_default_image_budget_matches_bilingual_packet(self) -> None:
         with patch.object(sys, "argv", ["auto_review_queue"]):

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -10,7 +10,9 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
 from auto_review_queue import (  # noqa: E402
+    Decision,
     WorkerError,
+    apply_review,
     ci_state,
     decide,
     load_cached_review,
@@ -23,6 +25,47 @@ from generate_submissions_data import package_sha256  # noqa: E402
 
 
 class AutoReviewQueueTests(unittest.TestCase):
+    def test_merge_is_bound_to_reviewed_head(self) -> None:
+        head_sha = "a" * 40
+        live = {
+            "headRefOid": head_sha,
+            "state": "OPEN",
+            "isDraft": False,
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [
+                {"name": "submission-validation", "conclusion": "SUCCESS"}
+            ],
+        }
+        with (
+            patch("auto_review_queue.pr_meta", return_value=live),
+            patch("auto_review_queue.run") as run_mock,
+        ):
+            apply_review(
+                "open-city-ai/haidian",
+                42,
+                head_sha,
+                Decision("accept", 90, "accepted"),
+                ROOT / "unused-comment.md",
+                ROOT,
+                admin_merge=True,
+            )
+
+        run_mock.assert_any_call(
+            [
+                "gh",
+                "pr",
+                "merge",
+                "42",
+                "--repo",
+                "open-city-ai/haidian",
+                "--merge",
+                "--match-head-commit",
+                head_sha,
+                "--admin",
+            ],
+            cwd=ROOT,
+        )
+
     def test_default_image_budget_matches_bilingual_packet(self) -> None:
         with patch.object(sys, "argv", ["auto_review_queue"]):
             args = parse_args()


### PR DESCRIPTION
## Summary

- pass the reviewed exact head to `gh pr merge --match-head-commit`
- keep the existing live head/CI checks while making the final merge server-side conditional
- add a command-level regression test for the admin merge path

## Problem

`apply_review()` verifies the PR head after approving it, then invokes `gh pr merge --merge` (optionally with `--admin`) without a head precondition. A contributor push between that last API read and the merge command can therefore make the worker merge a head that was not reviewed. The risk is stronger on the admin path because it intentionally bypasses branch requirements.

`--match-head-commit` makes GitHub reject the merge if the live head no longer equals the SHA used for the review, closing the interval without changing the rest of the queue flow.

## Verification

- `python3 -m unittest tests.test_auto_review_queue -v` (10 passed)
- `python3 -m py_compile scripts/auto_review_queue.py tests/test_auto_review_queue.py`
- `git diff --check`
- local `gh pr merge --help` confirms `--match-head-commit SHA` is supported

## Related open work

PRs #1296, #1190, #778, and #306 also modify `auto_review_queue.py`. Their current heads still construct the unbound merge command, so this focused fix is not duplicated there; it may need a straightforward conflict resolution if one lands first.