### PR TITLE
fix: skip malformed source discovery URLs

### DIFF
--- a/scripts/discover_public_sources.py
+++ b/scripts/discover_public_sources.py
@@ -329,12 +329,21 @@ def host_of(url: str) -> str:
 
 
 def is_probably_supported_url(url: str) -> bool:
-    if not url.startswith(("http://", "https://")):
+    value = (url or "").strip()
+    try:
+        parsed = urllib.parse.urlsplit(value)
+        hostname = parsed.hostname
+        _ = parsed.port
+    except ValueError:
         return False
-    lower = url.lower()
+    if parsed.scheme.lower() not in {"http", "https"} or not hostname:
+        return False
+    if any(char.isspace() for char in value):
+        return False
+    lower = value.lower()
     if any(item in lower for item in EXCLUDED_HOST_KEYWORDS):
         return False
-    path = urllib.parse.urlsplit(lower).path
+    path = parsed.path.lower()
     return not any(path.endswith(ext) for ext in EXCLUDED_EXTENSIONS)
 
 

--- a/scripts/discover_public_sources.py
+++ b/scripts/discover_public_sources.py
@@ -604,8 +604,11 @@ def extract_links_from_html(html_text: str, base_url: str) -> list[tuple[str, st
         href = raw_href.strip()
         if not href or href.startswith(("javascript:", "mailto:", "tel:")):
             continue
-        url = urllib.parse.urljoin(base_url, href)
-        url = decode_duckduckgo_url(url)
+        try:
+            url = urllib.parse.urljoin(base_url, href)
+            url = decode_duckduckgo_url(url)
+        except ValueError:
+            continue
         if is_probably_supported_url(url):
             output.append((canonicalize_url(url), anchor))
     deduped: dict[str, str] = {}
@@ -705,7 +708,8 @@ def discover_seed_links(
     html_rows = [
         row
         for row in seed_rows
-        if row.get("type") in {"auto_html", "metadata_html"} and row.get("url", "").startswith("http")
+        if row.get("type") in {"auto_html", "metadata_html"}
+        and is_probably_supported_url(row.get("url", ""))
     ]
     for row in html_rows[:max_seed_pages]:
         seed_url = row["url"]

--- a/tests/test_discover_public_sources.py
+++ b/tests/test_discover_public_sources.py
@@ -1,3 +1,7 @@
+import contextlib
+import io
+import json
+import tempfile
 import unittest
 
 import sys
@@ -12,6 +16,8 @@ from discover_public_sources import (  # noqa: E402
     classify_recency,
     content_type_kind,
     extract_links_from_html,
+    is_probably_supported_url,
+    main as discover_main,
     parse_dateish,
     parse_html_metadata,
     score_candidate,
@@ -19,6 +25,54 @@ from discover_public_sources import (  # noqa: E402
 
 
 class DiscoverPublicSourcesTests(unittest.TestCase):
+    def test_malformed_seed_urls_are_skipped_before_discovery(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            seed_path = root / "seeds.csv"
+            seed_path.write_text(
+                "type,url\n"
+                "auto_html,https://[\n"
+                "auto_html,https://example.com:bad/path\n"
+                "auto_html,https://example.com:99999/path\n",
+                encoding="utf-8",
+            )
+            output_dir = root / "output"
+
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                result = discover_main(
+                    [
+                        "--seed-csv",
+                        str(seed_path),
+                        "--output-dir",
+                        str(output_dir),
+                        "--no-search",
+                        "--no-seed-links",
+                        "--no-default-queries",
+                        "--pause",
+                        "0",
+                    ]
+                )
+
+            self.assertEqual(0, result)
+            self.assertIn("wrote 0 candidates", stdout.getvalue())
+            summary = json.loads((output_dir / "run-summary.json").read_text(encoding="utf-8"))
+            self.assertEqual(0, summary["candidate_count"])
+            self.assertEqual(0, summary["discovered_counts"]["seed"])
+
+    def test_supported_url_check_validates_structure_and_ports(self) -> None:
+        self.assertTrue(is_probably_supported_url("HTTPS://Example.COM/source"))
+        for url in [
+            "https://[",
+            "https://example.com:bad/path",
+            "https://example.com:99999/path",
+            "https://exa mple.com/path",
+            "https://example.com/path with spaces",
+            "ftp://example.com/source",
+        ]:
+            with self.subTest(url=url):
+                self.assertFalse(is_probably_supported_url(url))
+
     def test_parse_html_metadata_extracts_title_meta_and_links(self) -> None:
         metadata = parse_html_metadata(
             """

--- a/tests/test_discover_public_sources.py
+++ b/tests/test_discover_public_sources.py
@@ -6,6 +6,7 @@ import unittest
 
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -39,7 +40,10 @@ class DiscoverPublicSourcesTests(unittest.TestCase):
             output_dir = root / "output"
 
             stdout = io.StringIO()
-            with contextlib.redirect_stdout(stdout):
+            with (
+                contextlib.redirect_stdout(stdout),
+                patch("discover_public_sources.fetch_url") as fetch_mock,
+            ):
                 result = discover_main(
                     [
                         "--seed-csv",
@@ -47,7 +51,6 @@ class DiscoverPublicSourcesTests(unittest.TestCase):
                         "--output-dir",
                         str(output_dir),
                         "--no-search",
-                        "--no-seed-links",
                         "--no-default-queries",
                         "--pause",
                         "0",
@@ -55,6 +58,7 @@ class DiscoverPublicSourcesTests(unittest.TestCase):
                 )
 
             self.assertEqual(0, result)
+            fetch_mock.assert_not_called()
             self.assertIn("wrote 0 candidates", stdout.getvalue())
             summary = json.loads((output_dir / "run-summary.json").read_text(encoding="utf-8"))
             self.assertEqual(0, summary["candidate_count"])
@@ -72,6 +76,13 @@ class DiscoverPublicSourcesTests(unittest.TestCase):
         ]:
             with self.subTest(url=url):
                 self.assertFalse(is_probably_supported_url(url))
+
+    def test_malformed_page_link_does_not_hide_valid_links(self) -> None:
+        links = extract_links_from_html(
+            '<a href="https://[">Broken</a><a href="/valid.html">Valid</a>',
+            "https://example.com/root/index.html",
+        )
+        self.assertEqual([("https://example.com/valid.html", "Valid")], links)
 
     def test_parse_html_metadata_extracts_title_meta_and_links(self) -> None:
         metadata = parse_html_metadata(


### PR DESCRIPTION
## Summary

- parse seed/search URLs defensively before accepting them for discovery
- reject malformed IPv6 authorities, invalid or out-of-range ports, internal whitespace, missing hosts, and non-HTTP(S) schemes
- skip malformed seed-link pages before fetching and isolate malformed HTML anchors so valid links from the same page remain discoverable
- keep a discovery run alive when every seed URL is malformed, producing a valid zero-candidate summary with no network requests

## Reproduction

On current `main`, `is_probably_supported_url("https://[")` raises `ValueError: Invalid IPv6 URL`. It also returns `True` for `https://example.com:bad/path` and `https://example.com:99999/path`, deferring those failures to the fetch stage. Default seed-link selection independently uses `startswith("http")`, and `extract_links_from_html()` lets one malformed absolute `href` abort extraction before later valid links are processed.

The guard now validates `urlsplit()`, hostname, and port in one fail-closed block before canonicalization or fetching. Seed-link crawling uses the same guard, while malformed individual anchors are skipped locally.

## Verification

- `python3 -m unittest tests.test_discover_public_sources tests.test_source_registry_draft -v` (11 passed)
- `python3 -m py_compile scripts/discover_public_sources.py tests/test_discover_public_sources.py`
- `git diff --check`

The end-to-end regression runs the CLI with only malformed seeds and verifies a successful zero-candidate summary plus zero fetch calls. A separate regression proves a malformed anchor does not hide a valid link from the same page.

## Related work

#1363 protects the later `prepare_source_registry_draft.py` import stage. This PR covers the separate `discover_public_sources.py` seed/search/link intake and does not modify the same files.