### PR TITLE
ci: prevent submission validation queue saturation

### DIFF
--- a/.github/workflows/submission-validation.yml
+++ b/.github/workflows/submission-validation.yml
@@ -13,9 +13,8 @@ permissions:
 # Serializing those calls avoids secondary-rate-limit 403s when several
 # submissions arrive together.
 concurrency:
-  group: submission-validation
+  group: submission-validation-v2
   cancel-in-progress: false
-  queue: max
 
 jobs:
   submission-validation:


### PR DESCRIPTION
Replace the saturated FIFO concurrency queue with a fresh single-pending group. This preserves serialized validation calls while preventing the legacy 100-run queue from rejecting new PR checks. The old queue remains for repository administrators to cancel separately.