### PR TITLE
fix: report sparse bootstrap validation failures

### DIFF
--- a/scripts/bootstrap_participant_workspace.py
+++ b/scripts/bootstrap_participant_workspace.py
@@ -25,6 +25,8 @@ DEFAULT_SPARSE_PATHS = (
     "scenarios",
     "sources",
     "templates",
+    "requirements-review.txt",
+    "requirements-translation.txt",
 )
 REQUIRED_FILES = (
     "skills/urban-design-ai-submission/SKILL.md",
@@ -211,6 +213,25 @@ def render_text(report: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def render_failure(report: dict[str, Any]) -> str:
+    """Render validation failures without assuming command errors are present."""
+    if report.get("error"):
+        return f"Bootstrap failed: {report['error']}"
+
+    details: list[str] = []
+    missing_files = report.get("missing_required_files", [])
+    if missing_files:
+        details.append("missing required files: " + ", ".join(str(item) for item in missing_files))
+    missing_directories = report.get("missing_required_directories", [])
+    if missing_directories:
+        details.append(
+            "missing required directories: " + ", ".join(str(item) for item in missing_directories)
+        )
+    if not details:
+        details.append("validation failed without additional details")
+    return "Bootstrap failed: " + "; ".join(details)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--target", default="haidian", help="New workspace directory")
@@ -246,7 +267,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.json:
         print(json.dumps(report, ensure_ascii=False, indent=2))
     else:
-        print(render_text(report) if report.get("ok") else f"Bootstrap failed: {report['error']}")
+        print(render_text(report) if report.get("ok") else render_failure(report))
     return 0 if report.get("ok") else 1
 
 

--- a/tests/test_lightweight_participant_flow.py
+++ b/tests/test_lightweight_participant_flow.py
@@ -74,6 +74,8 @@ class LightweightParticipantFlowTests(unittest.TestCase):
         self.assertIn("sparse-checkout", flattened)
         self.assertIn("scenarios", flattened)
         self.assertIn("sources", flattened)
+        self.assertIn("requirements-review.txt", flattened)
+        self.assertIn("requirements-translation.txt", flattened)
         self.assertIn("submissions/octocat/agent-city", flattened)
         self.assertIn("submission/octocat/agent-city", flattened)
         self.assertIn("upstream", flattened)
@@ -127,6 +129,19 @@ class LightweightParticipantFlowTests(unittest.TestCase):
             with mock.patch.object(bootstrap, "run", return_value="true"):
                 complete_report = bootstrap.build_report(args, target, [])
             self.assertTrue(complete_report["ok"])
+
+    def test_bootstrap_text_failure_reports_validation_details(self) -> None:
+        bootstrap = load_bootstrap_module()
+        rendered = bootstrap.render_failure(
+            {
+                "ok": False,
+                "missing_required_files": ["requirements-review.txt"],
+                "missing_required_directories": ["scenarios"],
+            }
+        )
+        self.assertIn("requirements-review.txt", rendered)
+        self.assertIn("scenarios", rendered)
+        self.assertNotIn("KeyError", rendered)
 
     def test_peer_catalog_reads_local_index_without_materializing_media(self) -> None:
         completed = self.run_command(


### PR DESCRIPTION
## Summary

Fixes #1473.

- materialize `requirements-review.txt` and `requirements-translation.txt` in the lightweight sparse workspace
- render `missing_required_files` and `missing_required_directories` instead of assuming every failed report has `error`
- add regression coverage for the CLI failure-detail path

This is a tooling-only fix. It does not alter submission packages, scores, gallery data, or publication state.

## Verification

- `python3 -m unittest tests.test_lightweight_participant_flow -q` (8/8)
- `python3 -m py_compile scripts/bootstrap_participant_workspace.py`
- `git diff --check`
