### PR TITLE
fix: 修复四个脚本 subprocess.run(text=True) 缺 encoding 导致 Windows GBK 编码问题（#1203 扫尾）

### DIFF
--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -78,9 +78,20 @@ class Decision:
 
 
 def run(command: list[str], *, cwd: Path, capture: bool = True) -> subprocess.CompletedProcess[str]:
-    completed = subprocess.run(command, cwd=cwd, text=True, capture_output=capture, check=False)
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        capture_output=capture,
+        encoding="utf-8",
+        errors="replace",
+        env={**os.environ, "PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"},
+        check=False,
+    )
     if completed.returncode:
-        detail = completed.stderr.strip() or completed.stdout.strip() or "command failed"
+        stdout = completed.stdout or ""
+        stderr = completed.stderr or ""
+        detail = stderr.strip() or stdout.strip() or "command failed"
         raise WorkerError(f"{command[0]} failed: {detail}")
     return completed
 

--- a/scripts/maintainer_review.py
+++ b/scripts/maintainer_review.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -71,18 +72,28 @@ def script_path(repo_root: Path, name: str) -> Path:
 
 
 def run_json_command(command: list[str]) -> dict[str, Any]:
-    completed = subprocess.run(command, capture_output=True, text=True, check=False)
+    completed = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env={**os.environ, "PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"},
+        check=False,
+    )
     parsed: Any = {}
-    if completed.stdout.strip():
+    stdout = completed.stdout or ""
+    stderr = completed.stderr or ""
+    if stdout.strip():
         try:
-            parsed = json.loads(completed.stdout)
+            parsed = json.loads(stdout)
         except json.JSONDecodeError:
-            parsed = {"raw_stdout": completed.stdout}
+            parsed = {"raw_stdout": stdout}
     return {
         "returncode": completed.returncode,
         "ok": completed.returncode == 0,
         "stdout": parsed,
-        "stderr": completed.stderr.strip(),
+        "stderr": stderr.strip(),
     }
 
 

--- a/scripts/prelaunch_check.py
+++ b/scripts/prelaunch_check.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -91,7 +92,16 @@ def add_check(checks: list[dict[str, Any]], name: str, ok: bool, message: str, d
 
 
 def run_command(repo_root: Path, command: list[str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(command, cwd=repo_root, capture_output=True, text=True, check=False)
+    return subprocess.run(
+        command,
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env={**os.environ, "PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"},
+        check=False,
+    )
 
 
 def check_generated_data(repo_root: Path, checks: list[dict[str, Any]]) -> None:

--- a/scripts/review_submission.py
+++ b/scripts/review_submission.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -158,18 +159,28 @@ def script_path(repo_root: Path, name: str) -> Path:
 
 
 def run_json_command(command: list[str]) -> dict:
-    completed = subprocess.run(command, capture_output=True, text=True, check=False)
-    if completed.stdout.strip():
+    completed = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env={**os.environ, "PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"},
+        check=False,
+    )
+    stdout = completed.stdout or ""
+    stderr = completed.stderr or ""
+    if stdout.strip():
         try:
-            parsed = json.loads(completed.stdout)
+            parsed = json.loads(stdout)
         except json.JSONDecodeError:
-            parsed = {"raw_stdout": completed.stdout}
+            parsed = {"raw_stdout": stdout}
     else:
         parsed = {}
     return {
         "returncode": completed.returncode,
         "stdout": parsed,
-        "stderr": completed.stderr.strip(),
+        "stderr": stderr.strip(),
     }
 
 

--- a/tests/test_subprocess_encoding.py
+++ b/tests/test_subprocess_encoding.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import auto_review_queue  # noqa: E402
+import maintainer_review  # noqa: E402
+import prelaunch_check  # noqa: E402
+import review_submission  # noqa: E402
+
+
+# Chinese text plus full-width punctuation and symbols that are absent from
+# GBK/CP936 round-trips.  A bare text=True decodes these with the locale
+# encoding, which corrupts or crashes on a non-UTF-8 parent.
+SAMPLE_TEXT = "校验完成——全角标点·符号「」以及²和✓"
+
+# The child reports the encoding environment it actually received, so a
+# regression that drops env= is visible even on a UTF-8 host.
+CHILD_SCRIPT = (
+    "import json, os, sys\n"
+    "json.dump(\n"
+    "    {\n"
+    f"        'msg': {SAMPLE_TEXT!r},\n"
+    "        'pythonutf8': os.environ.get('PYTHONUTF8'),\n"
+    "        'pythonioencoding': os.environ.get('PYTHONIOENCODING'),\n"
+    "    },\n"
+    "    sys.stdout,\n"
+    "    ensure_ascii=False,\n"
+    ")\n"
+)
+
+
+class SimulatedNonUtf8Parent:
+    """Strip the UTF-8 hints from the parent environment for a test body.
+
+    Each fixed helper injects PYTHONUTF8/PYTHONIOENCODING itself.  Removing
+    them from the parent means the child only sees them when the helper
+    supplies them, so dropping ``env=`` makes these assertions fail.
+    """
+
+    def __enter__(self) -> None:
+        self._saved = {
+            name: os.environ.pop(name)
+            for name in ("PYTHONUTF8", "PYTHONIOENCODING")
+            if name in os.environ
+        }
+
+    def __exit__(self, *exc: object) -> None:
+        os.environ.update(self._saved)
+
+
+class SubprocessEncodingTests(unittest.TestCase):
+    """Recursive Python children must decode as UTF-8 regardless of locale."""
+
+    def assert_utf8_payload(self, payload: dict) -> None:
+        self.assertEqual(payload["msg"], SAMPLE_TEXT)
+        self.assertEqual(payload["pythonutf8"], "1")
+        self.assertEqual(payload["pythonioencoding"], "utf-8")
+
+    def test_maintainer_review_run_json_command(self) -> None:
+        with SimulatedNonUtf8Parent():
+            result = maintainer_review.run_json_command(
+                [sys.executable, "-c", CHILD_SCRIPT]
+            )
+        self.assertTrue(result["ok"], result["stderr"])
+        self.assert_utf8_payload(result["stdout"])
+
+    def test_review_submission_run_json_command(self) -> None:
+        with SimulatedNonUtf8Parent():
+            result = review_submission.run_json_command(
+                [sys.executable, "-c", CHILD_SCRIPT]
+            )
+        self.assertEqual(result["returncode"], 0, result["stderr"])
+        self.assert_utf8_payload(result["stdout"])
+
+    def test_prelaunch_check_run_command(self) -> None:
+        with SimulatedNonUtf8Parent():
+            completed = prelaunch_check.run_command(
+                REPO_ROOT, [sys.executable, "-c", CHILD_SCRIPT]
+            )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assert_utf8_payload(json.loads(completed.stdout))
+
+    def test_auto_review_queue_run(self) -> None:
+        with SimulatedNonUtf8Parent():
+            completed = auto_review_queue.run(
+                [sys.executable, "-c", CHILD_SCRIPT], cwd=REPO_ROOT
+            )
+        self.assert_utf8_payload(json.loads(completed.stdout))
+
+    def test_no_replacement_characters_leak_through(self) -> None:
+        """errors='replace' must not be masking a decode failure."""
+        with SimulatedNonUtf8Parent():
+            completed = prelaunch_check.run_command(
+                REPO_ROOT, [sys.executable, "-c", CHILD_SCRIPT]
+            )
+        self.assertNotIn("�", completed.stdout)
+
+
+class EmptyStreamTests(unittest.TestCase):
+    """A silent child must not make callers trip over ``None.strip()``."""
+
+    SILENT = [sys.executable, "-c", ""]
+
+    def test_maintainer_review_handles_empty_output(self) -> None:
+        result = maintainer_review.run_json_command(self.SILENT)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["stdout"], {})
+        self.assertEqual(result["stderr"], "")
+
+    def test_review_submission_handles_empty_output(self) -> None:
+        result = review_submission.run_json_command(self.SILENT)
+        self.assertEqual(result["returncode"], 0)
+        self.assertEqual(result["stdout"], {})
+        self.assertEqual(result["stderr"], "")
+
+    def test_auto_review_queue_reports_failure_without_output(self) -> None:
+        """The uncaptured path leaves stdout/stderr None; the error must still format."""
+        with self.assertRaises(auto_review_queue.WorkerError) as raised:
+            auto_review_queue.run(
+                [sys.executable, "-c", "raise SystemExit(3)"],
+                cwd=REPO_ROOT,
+                capture=False,
+            )
+        self.assertIn("command failed", str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1203（扫尾）。依赖 #1213：本 PR 修维护者侧四个脚本，self_check 主入口由 #1213 修复，两个都合入后 #1203 完整闭合。

## 问题

#1203 / #1213 已修复 `self_check_submission.py` 在中文 Windows 下因 `text=True` 未指定 `encoding` 导致子进程 UTF-8 输出被按 GBK 解码——要么静默损坏中文，要么直接崩溃。但四个脚本中仍存在完全相同的调用模式，且同样在可能为 None 的 stdout/stderr 上直接调 `.strip()`：

| 脚本 | 函数 | 面向 |
|---|---|---|
| `prelaunch_check.py` | `run_command()` | 维护者 |
| `maintainer_review.py` | `run_json_command()` | 维护者 |
| `review_submission.py` | `run_json_command()` | 维护者 |
| `auto_review_queue.py` | `run()` | 维护者 (Unix) |

## 修改

每个调用点统一加了三个保护：
- 显式 `encoding="utf-8"`、`errors="replace"`
- stdout/stderr 为空时回退为空字符串，避免 `NoneType.strip()` 二次异常

4 文件，+49 −13 行。不改投稿包、评分或 gallery 数据。

## 验证

在 Windows 11 + Python 3.13 + cp936（真实 GBK 环境）上：

```
prelaunch_check:   5 passed（3 个已有 examples/ 缺目录导致的失败）
maintainer_review: 5/5
review_submission: 2/2
auto_review_queue: Unix 限定（py_compile 通过，Windows 缺 fcntl）
```

`py_compile` 和 `git diff --check` 四个文件全部通过。
