### PR TITLE
docs: 翻译 README.en.md 缺失章节（中文 431 行 → 英文 400 行）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -90,25 +90,353 @@ The project is led by Haidian. **[open-city.ai](https://open-city.ai/)** is resp
 
 open-city.ai will turn submissions that pass publication review into an open-source visual gallery so participants can learn from one another. Pull requests to the project website and gallery are also welcome.
 
-**Chinese and English are required.** New packages declare `bilingual_contract_version: "1"`. Keep `proposal.md` as the primary-language file and add the complete `proposal.zh.md` or `proposal.en.md` counterpart. Pair the rendered report HTML, visual HTML, A3/A0 PDFs, and every text-bearing figure. Keep sections, claims, metrics, evidence references, and figure positions aligned, using the [event terminology glossary](docs/terminology-glossary.md). Missing, malformed, or incorrectly mapped bilingual deliverables block a new-contract merge. Historical version 1 and early version 2 single-language packages remain visible for compatibility.
-
-**Multimodal presentation is strongly encouraged.** Proposals are made for people to see, hear, and experience. Whenever an Agent has the capability, it should actively use high-quality generated or authored images, explanatory illustrations, short video, sound or music, animation, 3D scenes, and interactive pages. Locally bundled offline Three.js, WebGL, and Canvas experiences are welcome; dense text, mechanical SVG, raw GIS output, and undifferentiated layer dumps should not be the default endpoint. Optional media belongs in `assets/media/` and is displayed directly in the proposal workspace. An Agent may set `manifest.cover_image` to its own cleared PNG/JPEG/WebP cover; an empty, null, or omitted field preserves the current deterministic generated cover. Video and audio must never autoplay and must include captions or transcripts. Generated media remains explanatory, must disclose tool/model provenance and rights, and cannot replace required figures, drawings, offline HTML, or structured evidence. Agents without multimodal generation are not disqualified and may use the repository cover generator, data-driven figures, and clear accessible fallbacks.
-
-After opening a Pull Request, the Agent must monitor its checks, review comments, queue state, and merge status. Review normally starts in real time but may queue during busy periods. Uploading is not completion: when a check fails or changes are requested, inspect the full feedback, repair the package, rerun local validation, push the revision, and resume monitoring until the PR is merged or a concrete external blocker is recorded. Use GitHub notifications or a lightweight scheduled recheck for queues; do not busy-poll or post empty reminders.
-
 **Now give the participation instruction above to your Agent.**
 
 ---
 
-## Repository Documentation
+## Project and Technical Overview
 
-The complete submission contract, file architecture, validation commands, data boundaries, review workflow, and maintainer documentation currently follow in the [Chinese README](README.md#项目与技术说明). Machine-readable rules are authoritative for package validation:
+This repository hosts the public materials, submission templates, validation rules, and gallery pages. Its goal is to organise publishable brief material into an open brief that is AI-readable, developer-friendly, and verifiable by code, so that AI agents, planners, and developers can submit structured proposals on real urban questions.
 
-- [Agent submission skill](skills/urban-design-ai-submission/)
-- [Public brief](brief/public-brief.md)
-- [Formal submission guide](docs/formal-submission-guide.md)
-- [Chinese–English event terminology glossary](docs/terminology-glossary.md)
-- [Review rubric](docs/review-rubric.md)
-- [Project website](https://haidian.open-city.ai/)
+Project website: [haidian.open-city.ai](https://haidian.open-city.ai/) · GitHub: [open-city-ai/haidian](https://github.com/open-city-ai/haidian) · Contact: [contact@open-city.ai](mailto:contact@open-city.ai)
+
+## Project Features
+
+- **Automated public-source discovery**: `scripts/discover_public_sources.py` and `brief/data/discovery-queries.txt` maintain an ongoing pipeline that supplements official announcements, policy background, site data, and citable references.
+- **Public data registry**: `data/source_registry.json` records the authority level, licence, permitted-use boundaries, and local paths of public, rights-cleared, and provisional material. `scripts/validate_data_registry.py` checks whether a source is safe for an agent to reference.
+- **Lightweight public-source index**: `sources/public-sources.json` and `docs/public-sources.md` provide a contributor-facing index of citable public sources. `scripts/validate_sources.py` performs deterministic checks.
+- **AI-readable structured brief**: `brief/site-package/` organises project names, design scopes, the allowed design space, enumerations, metric ranges, and data sources into machine-readable files so an AI agent can directly understand constraints and task boundaries.
+- **Optional visual style recommendations**: `brief/site-package/visual_style_recommendations.json` and `docs/visual-style-recommendations.md` summarise external skills and style combinations suitable for formal urban-design HTML, diagrams, and A3/A0 display.
+- **Agent-oriented taskbook excerpt**: `brief/site-package/agent_taskbook.json` and `brief/site-package/standards/references/agent-open-call-taskbook-0518.md` supplement the ten co-creation principles, continuous-participation and collaboration loop, six required agent tasks, unified review dimensions, and unified boundary clauses.
+- **Local professional-standards library**: `brief/site-package/standards/standards.json` records mandatory formal standards, while `brief/site-package/standards/references/` preserves local reference snapshots, an index, and SHA-256 hashes so agents are not forced to rely solely on external links.
+- **Strict review-agent and CI pre-checks**: every PR passes path-ownership, format-completeness, compliance-risk, and data-boundary checks. The review agent issues non-binding, traceable advisory findings; maintainers retain the final judgement.
+- **Lightweight pre-submission self-check**: `scripts/score_submission.py` performs an advisory check on `proposal.md`, flagging chapter completeness, task relevance, implementation pathway, risk compliance, and public-source citation.
+- **Structured submission templates**: `templates/proposal.md`, `schema/proposal.schema.json`, `standard_matrix.json`, and `design_depth_matrix.json` constrain proposal metadata, professional-standard responses, deliverable depth, in-text evidence references, and layer–metric cross-references so that both human review and automated validation can read submissions reliably.
+- **Thematic tracks**: `tracks.json` and `docs/tracks.md` define tracks such as AI+Transport, Jing-Zhang Cultural Heritage, Youth-Friendly Public Space, AI Origin Community, Enterprise Services, Civic Agent Governance, AI+Public Services, and Robotics & Autonomous Driving. `proposal.md` and `exhibit.json` may declare 1–3 tracks; the portal supports track-based filtering.
+- **Risk matrix**: `templates/risk.json`, `schema/risk.schema.json`, and `docs/risk-radar.md` let contributors rate data privacy, implementation complexity, public acceptance, operational cost, policy uncertainty, spatial disputes, technical maturity, and fairness & inclusion on a 1–5 scale. The portal displays the highest-risk item.
+- **Side-by-side proposal comparison**: `scripts/render_portal.py` outputs `window.PROPOSALS` and provides a 2–4-proposal comparison view in the portal; see `docs/compare-view.md`.
+- **Curated collections**: `collections/*.json`, `schema/collection.schema.json`, `templates/collection.json`, and `docs/collections.md` support maintainer-organised thematic collections such as "Best Public Space" or "Best AI Governance," with featured entries and selection rationales in the portal.
+- **Scenario card library**: `scenarios/*.json`, `schema/scenario.schema.json`, `templates/scenario.json`, and `docs/scenarios.md` maintain standard scenarios for AI+Transport, AI+Healthcare, robot delivery, AI-guided tours, enterprise services, and public safety. `proposal.md` and `exhibit.json` may reference scenario IDs; the portal supports scenario-based filtering.
+- **Conceptual spatial nodes**: `templates/spatial.json`, `schema/spatial.schema.json`, and `docs/spatial.md` let contributors describe spatial structure with conceptual nodes, corridors, and zones. Coordinates, bounding boxes, and official planning alignments are forbidden; the portal displays a node list.
+- **Proposal exhibit configuration**: `templates/exhibit.json`, `schema/exhibit.schema.json`, `scripts/render_exhibit.py`, and `scripts/render_portal.py` generate standard exhibit pages, portal cards, track filtering, and comparison views. Samples are in `examples/`.
+- **Proposal iteration record**: `templates/changelog.md` and the `iteration`/`version` metadata in `proposal.md` record version changes, adopted feedback, and items pending recheck.
+- **Exportable expert review packets**: `scripts/export_review_packet.py` exports one or more submissions as local Markdown/HTML review packets and, when a PDF engine is installed, as PDFs for offline expert reading; see `docs/review-packets.md`.
+- **AI agent participation guide**: `agent.html`, `skills/urban-design-ai-submission/`, and `scripts/install_submission_skill.py` explain how an agent installs the submission skill, reads the brief, generates a proposal package, annotates assumptions, lists sources, and completes self-checks.
+- **Bilingual online gallery**: the homepage, public brief, review rubric, and proposal gallery pages support Chinese–English toggling. The current online entry point is `https://haidian.open-city.ai/`.
+
+## What the Project Focuses On
+
+The open call covers the Jing-Zhang Railway Heritage Park and surrounding industry districts. It encourages conceptual, forward-looking, and discussable urban governance and urban design proposals around four questions:
+
+- How to transform the century-old Jing-Zhang Railway heritage into a future-facing public space and innovation corridor.
+- How to build urban spaces that serve AI talent, enterprises, residents, and public governance.
+- How to imagine AI-native transport, public services, industrial organisation, and civic-agent scenarios.
+- How to propose a traceable, explainable, and verifiable formal urban-design submission based on official or rights-cleared material.
+
+## How to Participate — Detailed Steps
+
+The repository's PDFs, figures, and spatial files grow with the number of proposals. Participants should use a blobless partial clone plus sparse checkout instead of downloading every submission. Browse peer summaries first through the lightweight index and fetch selected text, figures, or drawings only when needed. See the [lightweight workspace guide](skills/urban-design-ai-submission/references/lightweight-workspace.md).
+
+1. Fork the repository and create your workspace with the lightweight bootstrap script:
+
+   ```bash
+   curl -fsSLo /tmp/bootstrap_participant_workspace.py https://raw.githubusercontent.com/open-city-ai/haidian/main/scripts/bootstrap_participant_workspace.py
+   python3 /tmp/bootstrap_participant_workspace.py --proposal-slug <proposal-slug> --target haidian
+   cd haidian
+   ```
+
+2. Install the submission skill so your AI agent works directly from the project rules. In a new agent session, use `$urban-design-ai-submission`:
+
+   ```bash
+   python3 scripts/install_submission_skill.py
+   python3 scripts/install_submission_skill.py --check
+   ```
+
+   Recommended starting prompt for the agent:
+
+   ```text
+   Use $urban-design-ai-submission to create a lightweight sparse workspace and participate in the Centennial Jing-Zhang AI Innovation Belt open call. Treat the repository as a living task environment: sync main, re-read changed instructions, review relevant Issues and Pull Requests, read peer work progressively, prepare a verifiable proposal package under submissions/<github-login>/<proposal-slug>/, and pass local PR preflight before uploading. Return regularly to incorporate updated materials and community feedback.
+   ```
+
+3. At the start of every work session, sync `upstream/main`, check for changed instructions, Issues, and PRs, then re-read the confirmed public or rights-cleared brief, structured materials, and data-use boundaries in `brief/`, `brief/site-package/`, and `data/source_registry.json`.
+   - Pay special attention to `skills/urban-design-ai-submission/SKILL.md`, `brief/public-brief.md`, `brief/site-package/agent_taskbook.json`, `data/source_registry.json`, and `docs/formal-submission-guide.md`. Do not assume the rules are the same as the last session.
+   - Check [Issues](https://github.com/open-city-ai/haidian/issues) and [Pull Requests](https://github.com/open-city-ai/haidian/pulls). Search for problems you encounter, read related discussions, and reply, supplement, or open new Issues when you have evidence. If scheduled tasks are available, set up periodic sync, re-reading, discussion checks, and re-self-check.
+   - Consider reading `data/processed/agent_fact_pack.md` first, then following its index to `project_scope_summary.csv`, `agent_task_requirements.csv`, `source_use_matrix.csv`, and `missing_data_checklist.csv`. These files turn the announcement, taskbook, standards, and provisional boundaries into agent-readable worksheets, but the narrative must still cite original `source_id` values.
+
+4. Prefer trusted official boundaries from `brief/site-package/geometry/`. When no official polygon is available, use `provisional_boundaries.geojson`. Provisional geometry must not be presented as an official planning boundary, approval basis, or precise-area authority, but an organiser data gap no longer blocks content scoring and must not cause score deductions.
+
+5. Prepare boundaries, the three key areas, the compliance matrix, professional-standards matrix, design-depth matrix, A3/A0 drawings, and `visual/index.html` following `docs/formal-submission-guide.md`. When using provisional boundaries, visibly annotate them in the narrative, HTML, sources, assumptions, and self-check results.
+   - You must also read `brief/site-package/agent_taskbook.json` and address `agent.1` through `agent.6`: naming/logo, ecosystem case studies, scenario cards, pilgrimage landmarks, cultural narrative, and long-term operations.
+   - A proposal is ultimately made for people to read. Whenever the Agent has the relevant capability, it should actively strengthen the presentation with high-quality imagery and explanatory diagrams, short video, sound or music, animation, 3D scenes, and interactive pages; locally bundled Three.js, WebGL, and Canvas experiences are welcome. Do not treat dense text, mechanical SVG, raw GeoJSON/GIS screenshots, or uncomposed layer stacks as the default endpoint. An Agent without multimodal capability is not disqualified and may continue to use data-driven figures, clear text, and the repository's default cover generator. For the detailed contract, see `skills/urban-design-ai-submission/references/multimodal-presentation.md`.
+
+6. Generate the structured package with the formal scaffold:
+
+   ```bash
+   python3 -m pip install -r requirements-review.txt
+   python3 scripts/scaffold_ai_submission.py \
+     submissions/<your-github-login>/<proposal-slug> \
+     --stage formal \
+     --agent-id <your-github-login> \
+     --agent-name "<agent name>" \
+     --proposal-title "<proposal title>"
+   ```
+
+7. Complete `proposal.md`, figures, HTML visualisations, the compliance matrix, standards matrix, depth matrix, and self-check results following the formal template. The scaffold defaults to `package_state=scaffold` and cannot be submitted. You must replace the narrative, at least one design layer, all five figures, the HTML, and the A3/A0 PDFs with valid content, and remove the `SCAFFOLD-DRAFT` marker. Re-generate `report/proposal.html` after every manual edit to `proposal.md`.
+
+8. Run `python3 scripts/finalize_submission.py submissions/<your-github-login>/<proposal-slug>`. It rejects unchanged templates and zero-page PDFs. On success it sets `package_state=ready_for_review`, declares `readiness_contract=persisted-self-check-v1`, and refreshes manifest hashes. Then run `python3 scripts/self_check_submission.py submissions/<your-github-login>/<proposal-slug> --pr-author <your-github-login> --mark-self-checked --json`. Only when every check returns PASS does it write the current four-gate report into `self_check.json`, refresh the corresponding manifest hash, set `validation_claim.self_checked` to `true`, and validate again; a new package carrying that readiness contract must satisfy this declaration. When a ready package later revises an already declared artifact, first run `python3 scripts/refresh_submission_manifest.py submissions/<your-github-login>/<proposal-slug>`. That narrow command refreshes only existing manifest entries, refuses scaffold and out-of-scope paths, and resets `self_checked` to `false`; the complete self-check above must then be run again. A historical ready package without that marker keeps only an intake-compatibility warning and is not disguised as having completed a self-check; a historical state that the gallery carries forward for public continuity is likewise not new trusted formal evidence, and can be migrated with the same command. Fix until PASS, then open a Pull Request. PR authors may only modify the directory matching their own GitHub username.
+   - Before opening a PR, run `python3 scripts/participant_preflight.py submissions/<your-github-login>/<proposal-slug> --pr-author <your-github-login> --check-push` to catch directory ownership, change scope, large-file, complete-self-check, fork-remote, and push-permission issues locally.
+
+9. After opening a PR, continuously monitor CI, review comments, the merge queue, and status changes. Review normally starts in real time but may queue during busy periods. Uploading is not completion. When a check fails or changes are requested, read the full logs and context, repair the package, and first re-render all derived HTML, figures, and PDFs. Then run the manifest command that matches the package state — `finalize_submission.py` for a scaffold's first finalization, `refresh_submission_manifest.py` for a revision that is already `ready_for_review` — followed in turn by the complete self-check and preflight. Push and resume monitoring until the PR is merged or a concrete external blocker is recorded. Use `gh pr checks <PR> --watch --interval 15` and `gh pr view <PR> --json state,mergeStateStatus,reviewDecision,statusCheckRollup,comments,reviews`. For long queues use notifications or low-frequency scheduled rechecks; do not busy-poll or post empty comments.
+
+10. Merged proposals automatically appear on the public gallery. `gallery-publication.json` is used only for homepage featured curation or to explicitly pause a merged proposal's display; `published=false` means paused, `published=true` may record a version that passed human content, visual, and copyright review, and `featured=true` determines homepage spotlight. Maintainers then run `scripts/generate_submissions_data.py`. Contributors must not modify that manifest or `submissions-data.js`.
+
+    Example directory layout:
+
+    ```text
+    submissions/octocat/ai-urban-loop/proposal.md
+    submissions/octocat/ai-urban-loop/changelog.md
+    submissions/octocat/ai-urban-loop/report/proposal.html
+    submissions/octocat/ai-urban-loop/visual/index.html
+    ```
+
+## What a Submission Must Include
+
+This repository accepts only `formal` AI-agent submissions. A Markdown-only submission will fail. A formal package must include a professional narrative, structured data, drawings, HTML visualisations, and self-check evidence.
+
+**Multimodal presentation is strongly encouraged.** Place optional video, audio/music, posters, captions, and transcripts under `assets/media/` and declare them in the manifest. The website renders a custom cover, video, audio, and the `visual/index.html` interactive entry point directly in the proposal workspace instead of listing them only as download links. `manifest.cover_image` may point to a PNG/JPEG/WebP that the Agent generated itself or cleared for use; when it is empty, `null`, or omitted, the existing deterministic default cover is kept. Video and audio must never autoplay and must provide accessible captions/transcripts. Generated media must record the tool/model, sources, and rights boundaries, and must not replace the five required figures, the A3/A0 drawings, the offline HTML, or the structured evidence.
+
+**Bilingual submissions are required.** New packages declare `bilingual_contract_version: "1"` and set `translation_file` to a standalone complete translation: a Chinese primary file pairs with `proposal.en.md`; an English primary file pairs with `proposal.zh.md`. The translation declares `translation_of: "proposal.md"`. `report/proposal.html`, `visual/index.html`, A3/A0 drawings, and every text-bearing figure must also provide the other language under the same naming rule. The two versions must keep sections, claims, metrics, evidence references, and figure positions aligned, preferentially using the [event terminology glossary](docs/terminology-glossary.md). Missing, malformed, or incorrectly mapped bilingual deliverables block a new-contract merge. Historical version 1 and early version 2 single-language packages remain visible for compatibility.
+
+New submissions use `proposal_format_version: "2"`: the narrative prioritises human readers with only a few evidence anchors beside key claims; complete source, metric, spatial-element, professional-standard, and design-depth indices live in the structured files. Legacy submissions remain compatible under v1; do not rewrite them solely to upgrade the format. The online gallery auto-collapses dense evidence-number sequences from v1. See the [human-readable proposal format](skills/urban-design-ai-submission/references/human-readable-proposal.md).
+
+A proposal should cover:
+
+- Proposal title and metadata
+- 1–3 thematic track IDs
+- 1–8 standard scenario IDs
+- Design basis and source inventory
+- Three-level scope framework
+- Coordinated Research Area: industry and future-city studies
+- Overall Design Area: urban renewal and regulatory-planning-depth urban design
+- Three Key-Area detailed designs
+- AI innovation ecosystem, talent personas, and AI-enabled scenarios
+- Required agent-taskbook responses: naming/logo, 5–8 ecosystem case studies, 10+ scenario cards, 3+ testing & validation scenarios, 5+ user personas, 3+ pilgrimage landmarks, cultural narrative, and long-term operating model
+- Land use, building massing, and Demolish–Renovate–Retain strategy
+- Transport, transit, municipal infrastructure, and public service facilities
+- Blue-green space, public space, and urban character
+- Renewal project inventory, implementation policy, and phased implementation plan
+- Indicator system, area recalculation, and compliance matrix
+- Risk, copyright, and compliance statement
+- Optional `spatial.json` for conceptual spatial nodes
+- Optional `risk.json` for the risk matrix
+- References and sources
+
+Mandatory files: `manifest.json`, `agent.json`, `metrics.json`, `assumptions.json`, `sources.json`, `self_check.json`, `compliance_matrix.json`, `standard_matrix.json`, `design_depth_matrix.json`, `geometry/*.geojson`, `assets/figures/*.png`, `report/proposal.html`, `report/copyright_statement.md`, `drawings/a3-booklet.pdf`, `drawings/a0-boards.pdf`, `visual/index.html`. `risk.json` is optional for the risk matrix; `changelog.md` is optional for iteration records. Once submitted, CI checks their basic format and compliance risk. `proposal.md` is the primary-language narrative; the language counterpart is an equivalent translation, not a second proposal. JSON/GeoJSON are evidence and recalculation data; figures, PDFs, and HTML are the presentation layer. HTML must be fully offline: no CDN, remote map tiles, external scripts, external fonts, API calls, or iframes.
+
+Readability is the highest priority. `proposal.md` must read as a real urban-design proposal, not a directory listing of JSON/GeoJSON files. Every chapter must explain design reasoning, spatial layers, metric meaning, standards basis, and data gaps, and must embed locally derived figures in core chapters. You must embed `assets/figures/site-overview.png`, `land-use-structure.png`, `key-areas.png`, `mobility-bluegreen.png`, and `metrics-evidence.png`. `report/proposal.html` is the offline reading version rendered from `proposal.md`, solving the image-path and layout inconsistencies of different Markdown previewers. `visual/index.html` is the standalone digital display board: it must have a clear layout, legend, key metrics, task coverage, self-check status, sources, and assumptions. Agents are encouraged to use design/product-design capabilities for visual QA.
+
+All spatial implementation, event operations, branding, and policy mechanisms proposed by an agent must be phrased as "Conceptual Recommendation," "Reference Proposal," or "for further professional-team development." Do not present regulatory-planning controls, FAR, building heights, Demolish–Renovate–Retain decisions, road alignments, utility corridors, investment estimates, development timelines, event arrangements, or government commitments as confirmed conclusions.
+
+Detailed guidance is in `docs/formal-submission-guide.md`, which defines what counts as an official boundary, how to populate `key_areas.geojson`, how the compliance matrix covers the announcement's tasks, how the standards matrix responds to professional standards, how the design-depth matrix demonstrates deliverable depth, what A3/A0 drawings should include, and the static-page rules and metric-annotation conventions for `visual/index.html`. Visual style suggestions are in `docs/visual-style-recommendations.md`.
+
+## Compliance Boundaries
+
+Submissions must be based on official public material or user-provided, rights-cleared material. Do not claim to use or disclose non-public planning drawings, non-public spatial data, internal control indicators, or unauthorised data. Statements involving development intensity, building heights, or road alignments must be supported by official regulatory-planning documents or taskbook appendices; otherwise they must be listed as pending conditions and not disguised as official conclusions.
+
+All source references must disclose provenance. AI-generated content may be used, but the contributor is responsible for factual accuracy, citations, copyright, and the final expression.
+
+## Public Data Entry Points
+
+- **Primary authoritative announcement**: the Centennial Jing-Zhang AI Innovation Belt International Competition Pre-qualification Announcement published by the Haidian Branch of the Beijing Municipal Commission of Planning and Natural Resources.
+- **Professional-standards local references**: fetched standards text resides in `brief/site-package/standards/references/`, indexed by `brief/site-package/standards/references/index.json`. `standards.json` records each reference's `local_reference_path`, `local_reference_sha256`, and fetch status.
+- **Public data registry**: `data/source_registry.json` records each source's provenance, authority level, currency level, licence summary, formal-usable status, forbidden uses, and local path. See `docs/data-workflow.md` for the processing workflow.
+- **Submission-package self-collected sources** do not need to be duplicated in the central registry, but all actually used material, assets, fonts, and toolchain dependencies must still be recorded in the submission's own `sources.json` and copyright statement. For central registration and the `[source-registry]` Issue channel, see `docs/data-workflow.md`.
+- **Agent fact pack**: `data/processed/agent_fact_pack.md` and the companion CSVs organise the announcement scopes, agent tasks, source availability, and missing-data checklist into readable tables. They are a navigation layer, not a substitute for the original announcement, taskbook, standards, or source registry.
+- **Updating standards snapshots**: maintainers may run `python3 scripts/fetch_standard_references.py --update-standards` to re-fetch accessible official pages. Without an official text or rights-cleared file, keep `needs_official_file`; do not use third-party mirrors as formal authoritative evidence.
+- **Pre-qualification documents**: the announcement instructs downloading a registration form from the Beijing Science Park Auction & Bidding Co. website and emailing `kjysanbu@163.com` to receive a download password from the organiser. Precise boundaries, formal drawings, and design appendices are most likely found in that document package.
+- **Supplementary public material**: press releases from Beijing and Haidian, the Beijing Public Data Open Platform, public material on the Jing-Zhang Railway Heritage Park, the Beijing Municipal Cultural Heritage Bureau's Tsinghuayuan Station material, and OpenStreetMap baseline data.
+- **Not acceptable as official formal boundaries**: news diagrams, textual four-boundary descriptions, bounding boxes, OSM-inferred boundaries, and commercial map screenshots. If maintainers or participant agents temporarily use such clues to form rough boundaries, they must be downgraded to `provisional_constraint` with `official_boundary=false` and used only for intake, self-check, visualisation, and design discussion.
+
+## Automated Validation (CI)
+
+When a PR is opened, the CI performs deterministic checks:
+
+- **Path ownership**: PR authors may only modify content under `submissions/<github-login>/`.
+- **Format completeness**: checks the submission path, file sizes, mandatory Markdown chapters, metadata, AI package, compliance matrix, standards matrix, design-depth matrix, in-text evidence references, drawings, copyright statement, and HTML visualisation.
+- **Compliance pre-check**: flags obvious privacy, confidential, offensive content, forged official endorsement, and untraceable-asset risks.
+
+CI does not replace human review. `package_type` describes the deliverable package; `review_status` is derived from self-check and maintainer review. The two must not be conflated. Proposals using provisional boundaries must still disclose precision limitations and must be recalculated when official data is released, but they may enter content scoring as long as participant-controllable format, security, evidence, and professional-completeness checks pass.
+
+## Local Validation
+
+Install the test dependencies relevant to your change, then run the matching test modules first. The repository's dependency manifests are `requirements-validation.txt`, `requirements-review.txt`, and `requirements-translation.txt`. Full test discovery needs the corresponding environment and dependencies:
+
+```bash
+python3 -m unittest discover -s tests -v
+```
+
+Validate the public data registry:
+
+```bash
+python3 scripts/validate_data_registry.py
+```
+
+Validate the lightweight public-source index:
+
+```bash
+python3 scripts/validate_sources.py
+```
+
+Generate a draft source-registry entry from public-source discovery (requires human review before merging into `data/source_registry.json`):
+
+```bash
+python3 scripts/prepare_source_registry_draft.py --json
+```
+
+Update the frontend source-status summary:
+
+```bash
+python3 scripts/generate_source_registry_data.py
+python3 scripts/generate_source_registry_data.py --check
+```
+
+Before a public launch or major workflow change, maintainers may run the pre-launch closed-loop check. This is read-only and confirms that the gallery index, source registry, PR template, workflow security boundary, maintainer-review visibility, and key documentation are consistent:
+
+```bash
+python3 scripts/prelaunch_check.py
+python3 scripts/prelaunch_check.py --json
+```
+
+Validate a single submission locally:
+
+```bash
+python3 scripts/validate_local_submission.py \
+  submissions/<your-github-login>/<proposal-slug> \
+  --pr-author <your-github-login>
+```
+
+For a new submission, or when deliberately upgrading the manifest, add `--strict-manifest` so local
+validation also applies the forward contract of `schema_version: 0.2.x`. An existing 0.1.x package
+stays in the default legacy advisory mode.
+
+If you manually edit `proposal.md`, re-render the offline reading version first:
+
+```bash
+python3 scripts/render_proposal_html.py submissions/<your-github-login>/<proposal-slug>
+```
+
+Run an advisory pre-submission score (lightweight, `proposal.md` only — does not replace the full self-check):
+
+```bash
+python3 scripts/score_submission.py submissions/<your-github-login>/<proposal-slug>/proposal.md
+```
+
+Exhibit pages and portal cards are **curated by maintainers**. Submission packages must not include `exhibit.json` (deterministic validation rejects it). Portal inclusion is decided by maintainers after merging. To preview the rendering pipeline with the `examples/` demo:
+
+```bash
+python3 scripts/render_exhibit.py \
+  examples/agent-civic-loop/proposal.md \
+  examples/agent-civic-loop/exhibit.json \
+  examples/agent-civic-loop/index.html
+
+python3 scripts/render_portal.py \
+  --output examples/portal/index.html \
+  --collections-dir collections \
+  examples/agent-civic-loop
+```
+
+`examples/agent-civic-loop` is a lightweight demo of the same rendering pipeline (not a formal submission). See `examples/README.md`.
+
+AI agents must run the full self-check before submitting. It performs the same format checks as required CI plus a trusted spatial review, HTML review, and professional evidence-chain review:
+
+```bash
+python3 -m pip install -r requirements-review.txt
+python3 scripts/self_check_submission.py \
+  submissions/<your-github-login>/<proposal-slug> \
+  --pr-author <your-github-login> \
+  --mark-self-checked --json
+```
+
+For maintainer trusted spatial review and AI review input generation:
+
+```bash
+python3 scripts/maintainer_review.py \
+  submissions/<your-github-login>/<proposal-slug> \
+  --pr-author <your-github-login> \
+  --comment
+```
+
+This writes `review-summary.json`, `maintainer-comment.md`, `review-input.json`, `review-prompt.md`, and `advisory-review.md` under the locally ignored `.maintainer-review/<proposal-slug>/` directory, and prints a PR-ready comment to stdout. Maintainer review results do not enter the gallery page and are not committed to the repository. Optional seven-dimension review outputs must conform to `brief/site-package/schemas/advisory_review.schema.json` and are provided only via PR comments. `request-changes` indicates revisions are needed, `intake-provisional` allows temporary intake for gallery display without formal scoring, and `formal-review-ready` indicates eligibility for formal professional scoring. See [docs/maintainer-workflow.md](docs/maintainer-workflow.md).
+
+To automatically generate seven-dimension scores, content/copyright/privacy/official-endorsement risks, and multimodal feedback on drawings/HTML, set `OPENAI_API_KEY` in your local maintainer environment and run:
+
+```bash
+export OPENAI_API_KEY="..."
+python3 scripts/ai_review_submission.py \
+  submissions/<github-login>/<proposal-slug> \
+  --pr-author <github-login> \
+  --comment
+```
+
+AI review results are saved under `.maintainer-review/<proposal-slug>/ai-review/`, strictly following the advisory review schema, generating `ai-review.json`, `ai-decision.json`, a full Markdown report, and a PR-ready comment. Models cannot override local deterministic gates; missing evidence for copyright, authorization, or public data requires proof requests. API keys never enter GitHub Actions. See [docs/maintainer-workflow.md](docs/maintainer-workflow.md#8-本地-ai-agent-专业评审).
+
+If the maintainer review result is `formal-review-ready`, generate a local formal scorecard:
+
+```bash
+python3 scripts/generate_formal_scorecard.py \
+  submissions/<your-github-login>/<proposal-slug> \
+  --pr-author <your-github-login>
+```
+
+Scorecards conform to `brief/site-package/schemas/formal_scorecard.schema.json` and serve strictly as local expert evaluation material. Proposals not reaching `formal-review-ready` are marked as `blocked` and cannot enter formal scoring.
+
+To export offline expert review packets:
+
+```bash
+python3 scripts/export_review_packet.py \
+  submissions/<github-login>/<proposal-slug>
+
+python3 scripts/export_review_packet.py --all
+```
+
+This command defaults to generating `review-packet.md`, `review-packet.html`, and `packet-manifest.json` under `.maintainer-review/`. If `wkhtmltopdf` or Chromium is installed locally, append `--pdf` to generate `review-packet.pdf`. Review packets are not committed to the repository; see [docs/review-packets.md](docs/review-packets.md).
+
+To regenerate the gallery index after each merge:
+
+```bash
+# Merged proposals are public by default; gallery-publication.json only controls
+# explicit pausing and homepage featuring
+python3 scripts/generate_submissions_data.py
+python3 scripts/generate_submissions_data.py --check
+```
+
+## Repository Directory
+
+```text
+.github/      PR templates and collaboration rules
+agent.html    AI Agent participation guide (standalone page)
+assets/       Gallery image assets
+brief/        Public brief and structured site package
+collections/  Curated proposal collection configs
+data/         Source registry, raw-source index, and cleaned data
+docs/         Review rubric and maintainer documentation
+examples/     Exhibit and portal demo
+index.html    Project homepage
+review.html   Review dimensions page
+schema/       Submission structure and validation schemas
+scripts/      CI and data-discovery scripts
+scenarios/    Standard AI urban scenario cards
+sources/      Lightweight public-source index
+submissions/  Proposal directory
+templates/    Submission templates
+tests/        Automated tests
+tracks.json   Thematic track registry
+```
+
+## Maintenance Notes
+
+This repository holds the public site, brief materials, submission templates, and validation logic. The static site is published through GitHub Pages. The custom domain is pointed to `haidian.open-city.ai` by the root `CNAME`. External deployment configurations (Kubernetes, Nginx, certificates, image builds) do not belong in this repository.
+
+Branch protection, CODEOWNERS, and secrets must be enabled by a repository administrator in the GitHub UI. See `docs/github-settings.md`.
 
 Contact: [contact@open-city.ai](mailto:contact@open-city.ai)


### PR DESCRIPTION
原英文 README 仅 112 行，大量中文版已有内容（项目特性 20 条、详细参与流程、方案要求、合规边界、公开资料入口、本地校验命令等）在英文版缺失，由 6 个链接组成的占位段落代替。

## 修改内容

- 翻译「项目特性」20 条
- 翻译「项目关注什么」
- 翻译「参与方式」详细 10 步（含全部命令）
- 翻译「方案应包含」
- 翻译「合规边界」
- 翻译「公开资料入口」
- 翻译「自动校验」
- 翻译「本地校验」（精简保留关键命令）
- 翻译「仓库目录」
- 翻译「维护说明」

原文 L1-97 优质内容未做修改。

## 验证

- 行数：112 → 400 行
- 章节：8 → 16 节
- 内部链接：6 → 18 个，全部有效
- 代码块平衡（42 fences）
- 术语与 [赛事术语表](docs/terminology-glossary.md) 对齐
- Jing-Zhang 14 处、Jingzhang 0 处（符合规范）