### PR TITLE
fix(review): honor enforced intake readiness

### DIFF
--- a/docs/github-settings.md
+++ b/docs/github-settings.md
@@ -53,7 +53,7 @@
 required CI 不接入 AI，也不配置模型密钥。它只执行受信任 checkout 中的确定性路径、格式、文件类型、文件大小、提交阶段语义、基础 GeoJSON 字段、空间、视觉和专业证据门禁；不会执行投稿者代码或把投稿者自写 self_check 当作四门运行证明。
 校验通过后 workflow 自动添加 `review/queued`；失败则添加 `review/ci-failed`，受信任 worker 只消费前者。
 
-可信空间复核和 AI 评审 agent 应作为独立的受信任 worker 运行，不应替代 `submission-validation` 这个硬门禁。worker 只能在 required CI 成功后读取固定 PR head SHA，不执行投稿代码，并在 review 与 merge 前再次核对 SHA 和 CI。当前 intake 政策允许四项 gate 与强制退件检查通过且 Review Agent 得分不低于 60/100 时自动合并；合并后自动进入方案展示，但不等同于首页精选、最终评分或落地实施结论。完整 SOP 见 [maintainer-workflow.md](maintainer-workflow.md)。
+可信空间复核和 AI 评审 agent 应作为独立的受信任 worker 运行，不应替代 `submission-validation` 这个硬门禁。worker 只能在 required CI 成功后读取固定 PR head SHA，不执行投稿代码，并在 review 与 merge 前再次核对 SHA 和 CI。对于 `auto_review_queue.py --apply` 的 worker 自动合并，当前策略要求四项 gate 与强制退件检查通过、`recommendation=formal-review-ready`、`can_enter_formal_review=true`、参与者 `required_next_actions_zh` 为空，且 Review Agent 得分不低于 60/100；这些自动化准入条件不改写维护者手工处理历史 `intake-provisional` 结果的语义。合并后自动进入方案展示，但不等同于首页精选、最终评分或落地实施结论。完整 SOP 见 [maintainer-workflow.md](maintainer-workflow.md)。
 
 ```bash
 python3 -m pip install -r requirements-review.txt

--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -265,15 +265,19 @@ export HAIDIAN_REVIEW_MODEL="gpt-5.6-sol"
 # 先评审并生成审计材料，不修改 GitHub
 python3 scripts/auto_review_queue.py --limit 10
 
-# 正式回写 review/label；通过 60 分门槛和四项 gate 的 PR 自动合并
+# 正式回写 review/label；同时满足分数、四项 gate 和审核准入状态的 PR 自动合并
 python3 scripts/auto_review_queue.py --limit 10 --concurrency 3 --apply --admin-merge
 ```
 
 固定顺序为：required CI → 单一作者目录 → 固定 head SHA worktree → 本地四项 gate →
-强制退件 → 多模态 100 分评审 → 决策前再次检查 head SHA/CI → review 与标签 →
+强制退件 → 多模态 100 分评审 → 分数门槛与审核准入状态 gate →
+决策前再次检查 head SHA/CI → review 与标签 →
 合并前最后一次检查 head SHA/CI。低于 60 分标记 `review/low-quality`；CI 未成功的
 PR 不调用模型；draft 不进入队列。合并仅表示仓库 intake，展示、精选、正式评分与
 实施决定继续由 `gallery-publication.json` 的独立流程控制。
+自动合并还要求 `recommendation=formal-review-ready`、`can_enter_formal_review=true`、
+参与者 `required_next_actions_zh` 为空；否则 fail closed 为修改请求。
+`publication_recommendation` 是独立的展示建议，不改变 60 分 repository intake 门槛。
 worker 每轮按 PR 编号从旧到新处理，避免持续新增投稿使早期稿件饥饿。
 模型调用和本地视觉检查默认三路并行；worktree 创建/清理以及 GitHub review、标签、
 SHA 复核和 merge 使用进程内锁串行执行，避免 Git 引用锁和 base-branch merge 竞态。

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -189,7 +189,20 @@ def decide(review: dict[str, Any], decision: dict[str, Any], threshold: float) -
         raise WorkerError("AI decision has no numeric weighted_score_100")
     if float(score) < threshold:
         return Decision("low-quality", float(score), f"score below {threshold:g}")
-    return Decision("accept", float(score), "threshold and all gates passed")
+    intake_blocks = []
+    if review.get("recommendation") != "formal-review-ready":
+        intake_blocks.append("recommendation")
+    if review.get("can_enter_formal_review") is not True:
+        intake_blocks.append("can_enter_formal_review")
+    if review.get("required_next_actions_zh") != []:
+        intake_blocks.append("required_next_actions_zh")
+    if intake_blocks:
+        return Decision(
+            "request-changes",
+            float(score),
+            f"intake blocked by review fields: {', '.join(intake_blocks)}",
+        )
+    return Decision("accept", float(score), "threshold, gates, and intake readiness passed")
 
 
 def pr_meta(repo: str, number: int, cwd: Path) -> dict[str, Any]:
@@ -299,7 +312,8 @@ def apply_review(
             raise WorkerError("PR became conflicting before merge")
         body = (
             f"{marker}\nMaintainer intake decision: Review Agent score {outcome.score:g}/100. "
-            "Mandatory rejection and all four local gates passed. Accepted for repository intake only; "
+            "Mandatory rejection, all four local gates, and review readiness passed. "
+            "Accepted for repository intake only; "
             "this is not gallery publication, award selection, implementation approval, or government endorsement."
         )
         run(["gh", "pr", "review", str(number), "--repo", repo, "--approve", "--body", body], cwd=cwd)

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -67,13 +67,19 @@ class AutoReviewQueueTests(unittest.TestCase):
                         ],
                         cwd=ROOT,
                     )
+                    review_command = next(
+                        call.args[0]
+                        for call in run_mock.call_args_list
+                        if call.args[0][:3] == ["gh", "pr", "review"]
+                    )
+                    self.assertIn("review readiness passed", review_command[-1])
 
     def test_default_image_budget_matches_bilingual_packet(self) -> None:
         with patch.object(sys, "argv", ["auto_review_queue"]):
             args = parse_args()
         self.assertEqual(18, args.max_images)
 
-    def test_accepts_score_at_threshold_when_all_gates_pass(self) -> None:
+    def test_accepts_score_at_threshold_when_intake_ready_even_if_not_publishable(self) -> None:
         review = {
             "mandatory_rejection": {"result": "pass"},
             "gate_checks": {
@@ -85,8 +91,75 @@ class AutoReviewQueueTests(unittest.TestCase):
                     "professional_evidence_review",
                 ]
             },
+            "recommendation": "formal-review-ready",
+            "can_enter_formal_review": True,
+            "required_next_actions_zh": [],
         }
-        self.assertEqual("accept", decide(review, {"weighted_score_100": 60}, 60).action)
+        decision = {
+            "weighted_score_100": 60,
+            "publication_recommendation": "do-not-publish",
+        }
+        self.assertEqual("accept", decide(review, decision, 60).action)
+
+    def test_non_formal_recommendation_blocks_intake(self) -> None:
+        review = {
+            "mandatory_rejection": {"result": "pass"},
+            "gate_checks": {
+                name: {"status": "pass"}
+                for name in [
+                    "deterministic_validation",
+                    "spatial_review",
+                    "visual_review",
+                    "professional_evidence_review",
+                ]
+            },
+            "recommendation": "request-changes",
+            "can_enter_formal_review": True,
+            "required_next_actions_zh": [],
+        }
+        outcome = decide(review, {"weighted_score_100": 90}, 60)
+        self.assertEqual("request-changes", outcome.action)
+        self.assertEqual("intake blocked by review fields: recommendation", outcome.reason)
+
+    def test_false_formal_review_flag_blocks_intake(self) -> None:
+        review = {
+            "mandatory_rejection": {"result": "pass"},
+            "gate_checks": {
+                name: {"status": "pass"}
+                for name in [
+                    "deterministic_validation",
+                    "spatial_review",
+                    "visual_review",
+                    "professional_evidence_review",
+                ]
+            },
+            "recommendation": "formal-review-ready",
+            "can_enter_formal_review": False,
+            "required_next_actions_zh": [],
+        }
+        outcome = decide(review, {"weighted_score_100": 90}, 60)
+        self.assertEqual("request-changes", outcome.action)
+        self.assertEqual("intake blocked by review fields: can_enter_formal_review", outcome.reason)
+
+    def test_required_participant_actions_block_intake(self) -> None:
+        review = {
+            "mandatory_rejection": {"result": "pass"},
+            "gate_checks": {
+                name: {"status": "pass"}
+                for name in [
+                    "deterministic_validation",
+                    "spatial_review",
+                    "visual_review",
+                    "professional_evidence_review",
+                ]
+            },
+            "recommendation": "formal-review-ready",
+            "can_enter_formal_review": True,
+            "required_next_actions_zh": ["补充权属证明。"],
+        }
+        outcome = decide(review, {"weighted_score_100": 90}, 60)
+        self.assertEqual("request-changes", outcome.action)
+        self.assertEqual("intake blocked by review fields: required_next_actions_zh", outcome.reason)
 
     def test_low_score_is_not_merged(self) -> None:
         review = {
@@ -262,11 +335,15 @@ class AutoReviewQueueTests(unittest.TestCase):
                         "professional_evidence_review",
                     ]
                 },
+                "recommendation": "formal-review-ready",
+                "can_enter_formal_review": True,
+                "required_next_actions_zh": [],
             }
             decision = {
                 "submission_dir": "submissions/alice/plan",
                 "reviewed_package_sha256": digest,
                 "weighted_score_100": 61,
+                "publication_recommendation": "publish-qualified",
                 "dry_run": False,
                 "model_output_schema_valid": True,
             }


### PR DESCRIPTION
## What changed

- Fail closed when the trusted review output has any of these participant-readiness vetoes:
  - `recommendation` is not `formal-review-ready`;
  - `can_enter_formal_review` is not exactly `true`;
  - `required_next_actions_zh` is not exactly an empty list.
- Preserve the existing decision order: mandatory rejection, four local gates, numeric repository-intake threshold, then readiness.
- Keep `publication_recommendation` separate from repository intake: an otherwise ready submission scoring exactly 60/100 remains intake-eligible even when the gallery advisory is `do-not-publish`.
- Make the successful automated review text state that review readiness passed.
- Document that these readiness conditions govern `auto_review_queue.py --apply` worker auto-merge and do not redefine manual handling of historical `intake-provisional` results.

## Why

`ai_review_submission.py` already records whether participant-controlled repairs remain. The queue must honor those enforced readiness fields rather than approve and merge a high-scoring `request-changes` result. Gallery publication remains a separate decision from repository intake.

## Current-main replay

This four-file patch was replayed onto upstream `main` exact commit `9184dc4bbee535af278574cf96ceaf583808152e`. Before replay, the intervening main changes were checked and did not touch the four PR files.

Changed paths remain limited to:

- `scripts/auto_review_queue.py`
- `tests/test_auto_review_queue.py`
- `docs/maintainer-workflow.md`
- `docs/github-settings.md`

## Validation

- WSL Python 3.14: `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_auto_review_queue -v` — 15/15 passed.
- `python3 -m py_compile scripts/auto_review_queue.py tests/test_auto_review_queue.py` — passed.
- Cached scope check — exactly the four paths above.
- `git diff --cached --check` — passed before commit.

## Boundary with #1725

This PR does not include #1725's score high-water implementation or ledger. If #1725 lands first, combine the contracts in this order: absolute 60-point threshold, readiness vetoes, then historical high-water/restore evaluation. Update #1725's accept, score-regression, and restore fixtures with all three readiness fields, then rerun the complete `tests.test_auto_review_queue` module on the combined tree.

This PR does not change scoring weights, deterministic validation, gallery publication policy, or the score high-water ledger.