### PR TITLE
ci: sparsify trusted submission checkout

### DIFF
--- a/.github/workflows/submission-validation.yml
+++ b/.github/workflows/submission-validation.yml
@@ -36,6 +36,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.repository.default_branch }}
+          # The validator hydrates the touched participant package through the
+          # GitHub API.  Keep the trusted checkout limited to executable policy
+          # and schema inputs so hundreds of unrelated media-heavy submissions
+          # cannot delay every required check.
+          filter: blob:none
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /.github/
+            /brief/
+            /requirements-review.txt
+            /scenarios/
+            /scripts/
+            /tracks.json
 
       - name: Install trusted review dependencies
         run: python3 -m pip install --disable-pip-version-check -r requirements-review.txt

--- a/scripts/prelaunch_check.py
+++ b/scripts/prelaunch_check.py
@@ -206,6 +206,23 @@ def check_workflow_trusted_base(repo_root: Path, checks: list[dict[str, Any]]) -
         failures.append("workflow must run the deterministic PR validator")
     if "pip install" not in text or "requirements-review.txt" not in text:
         failures.append("workflow must install requirements-review.txt before trusted review gates")
+    if "filter: blob:none" not in text or "sparse-checkout-cone-mode: false" not in text:
+        failures.append("workflow must use a blobless sparse trusted checkout")
+    for required_path in (
+        "/.github/",
+        "/brief/",
+        "/requirements-review.txt",
+        "/scenarios/",
+        "/scripts/",
+        "/tracks.json",
+    ):
+        if required_path not in text:
+            failures.append(f"workflow sparse checkout must include {required_path}")
+    checkout_scope = text.split("Checkout current trusted default branch", 1)[-1].split(
+        "Install trusted review dependencies", 1
+    )[0]
+    if "/submissions/" in checkout_scope:
+        failures.append("workflow trusted checkout must not materialize submissions")
     add_check(
         checks,
         "workflow_uses_trusted_base",

--- a/tests/test_prelaunch_check.py
+++ b/tests/test_prelaunch_check.py
@@ -91,6 +91,9 @@ class PrelaunchCheckTests(unittest.TestCase):
         self.assertIn("python3 scripts/github_pr_validation.py", workflow)
         self.assertIn("pip install", workflow)
         self.assertIn("requirements-review.txt", workflow)
+        self.assertIn("filter: blob:none", workflow)
+        self.assertIn("sparse-checkout-cone-mode: false", workflow)
+        self.assertNotIn("/submissions/", workflow)
 
     def test_pr_template_and_gallery_keep_review_results_out_of_public_index(self) -> None:
         template = (ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md").read_text(encoding="utf-8")

--- a/tests/test_submission_validation_concurrency.py
+++ b/tests/test_submission_validation_concurrency.py
@@ -7,6 +7,28 @@ WORKFLOW = REPO_ROOT / ".github" / "workflows" / "submission-validation.yml"
 
 
 class SubmissionValidationConcurrencyTests(unittest.TestCase):
+    def test_trusted_checkout_excludes_unrelated_submission_media(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        checkout_scope = workflow.split(
+            "- name: Checkout current trusted default branch", 1
+        )[1].split("- name: Install trusted review dependencies", 1)[0]
+
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", checkout_scope)
+        self.assertIn("filter: blob:none", checkout_scope)
+        self.assertIn("sparse-checkout-cone-mode: false", checkout_scope)
+        for required_path in (
+            "/.github/",
+            "/brief/",
+            "/requirements-review.txt",
+            "/scenarios/",
+            "/scripts/",
+            "/tracks.json",
+        ):
+            self.assertIn(required_path, checkout_scope)
+
+        self.assertNotIn("/submissions/", checkout_scope)
+        self.assertNotIn("github.event.pull_request.head.sha", checkout_scope)
+
     def test_superseded_heads_cancel_without_parallelizing_api_hydration(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         workflow_scope, jobs_scope = workflow.split("\njobs:\n", 1)


### PR DESCRIPTION
## Summary

Limit the `pull_request_target` trusted checkout to the default-branch policy, schema, scenario, and validator inputs that the required check actually executes. Participant packages continue to be hydrated from the exact PR head through the existing GitHub API path.

This avoids materializing hundreds of unrelated media-heavy submissions for every required check without changing participant scope, trusted-base execution, validation rules, or API serialization.

## Verification

- `python3 -m unittest tests.test_submission_validation_concurrency -v` (3 passed)
- `python3 -m unittest tests.test_prelaunch_check.PrelaunchCheckTests.test_workflow_keeps_pull_request_target_safe -v` (1 passed)
- direct `check_workflow_trusted_base()` assertion (passed)
- local non-cone sparse checkout materialized `.github/`, `brief/`, `scenarios/`, `scripts/`, `requirements-review.txt`, and `tracks.json`; `submissions/` remained absent
- workflow YAML parse, `py_compile`, and `git diff --check` passed

## Security boundary

The checkout remains pinned to `${{ github.event.repository.default_branch }}`. It never checks out the PR head, and contributor package files remain inert API downloads validated by trusted scripts.