### PR TITLE
jingzhang-ai-corridor: persist four-gate self-check (readiness_contract=persisted-self-check-v1)

### DIFF
--- a/submissions/lifecoder1988/jingzhang-ai-corridor/manifest.json
+++ b/submissions/lifecoder1988/jingzhang-ai-corridor/manifest.json
@@ -56,7 +56,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "80b71cb78d2c1581fc679eb561959ac515bc8a3ff6f76c74dcc2c4e20d49b72f"
+      "sha256": "c5700a544dace935854c870b19a06cbdfd30e752021b2c83ee14d1ca356ac4ec"
     },
     {
       "path": "compliance_matrix.json",
@@ -287,10 +287,11 @@
     }
   ],
   "validation_claim": {
-    "self_checked": false,
+    "self_checked": true,
     "known_blockers": [
       "官方精确边界与控规条件缺失：全部空间图层基于 PROV-SITE-001 临时粗略边界，面积复算仅供概念讨论；待官方 polygon 与控规条件发布后需重算全部图层与指标。"
     ],
-    "data_confidence": "medium"
+    "data_confidence": "medium",
+    "readiness_contract": "persisted-self-check-v1"
   }
 }

--- a/submissions/lifecoder1988/jingzhang-ai-corridor/self_check.json
+++ b/submissions/lifecoder1988/jingzhang-ai-corridor/self_check.json
@@ -1,40 +1,202 @@
 {
+  "ok": true,
+  "submission_dir": "submissions/lifecoder1988/jingzhang-ai-corridor",
+  "pr_author": "lifecoder1988",
+  "stage": "formal",
+  "deterministic_validation": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "errors": [],
+      "warnings": [
+        "submissions/lifecoder1988/jingzhang-ai-corridor/proposal.md: 可能涉及非公开或敏感资料; maintainer review required",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/manifest.json: known_blockers present; submission may pass intake but cannot enter formal professional scoring until resolved",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/geometry/site_boundary.geojson: uses provisional boundary; do not treat it as an official redline or precise-area basis. Organizer data gaps do not block content scoring; recalculate when official geometry is supplied"
+      ],
+      "proposal_files": [
+        "submissions/lifecoder1988/jingzhang-ai-corridor/proposal.md"
+      ],
+      "changelog_files": [
+        "submissions/lifecoder1988/jingzhang-ai-corridor/changelog.md"
+      ],
+      "changed_files": [
+        "submissions/lifecoder1988/jingzhang-ai-corridor/agent.json",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/assets/figures/key-areas.en.png",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/assets/figures/key-areas.png",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/assets/figures/land-use-structure.en.png",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/assets/figures/land-use-structure.png",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/assets/figures/metrics-evidence.en.png",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/assets/figures/metrics-evidence.png",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/assets/figures/mobility-bluegreen.en.png",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/assets/figures/mobility-bluegreen.png",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/assets/figures/site-overview.en.png",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/assets/figures/site-overview.png",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/assumptions.json",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/changelog.md",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/compliance_matrix.json",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/design_depth_matrix.json",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/drawings/a0-boards.en.pdf",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/drawings/a0-boards.pdf",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/drawings/a3-booklet.en.pdf",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/drawings/a3-booklet.pdf",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/geometry/buildings.geojson",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/geometry/constraints.geojson",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/geometry/green_space.geojson",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/geometry/key_areas.geojson",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/geometry/land_use.geojson",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/geometry/phasing.geojson",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/geometry/public_space.geojson",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/geometry/roads.geojson",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/geometry/site_boundary.geojson",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/manifest.json",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/metrics.json",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/proposal.en.md",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/proposal.md",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/report/copyright_statement.md",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/report/narrative.md",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/report/proposal.en.html",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/report/proposal.html",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/self_check.json",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/sources.json",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/standard_matrix.json",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/visual/index.en.html",
+        "submissions/lifecoder1988/jingzhang-ai-corridor/visual/index.html"
+      ],
+      "ai_package_stages": {
+        "submissions/lifecoder1988/jingzhang-ai-corridor": "formal"
+      },
+      "total_bytes": 6773442,
+      "maintainer_bypass": false
+    },
+    "stderr": ""
+  },
+  "spatial_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "stage": "formal",
+      "issues": [
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-001",
+          "expected": null,
+          "actual": null
+        },
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-002",
+          "expected": null,
+          "actual": null
+        },
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-003",
+          "expected": null,
+          "actual": null
+        }
+      ],
+      "metrics": {
+        "site_area_sqm": 11412825.386,
+        "green_space_area_sqm": 1411617.114,
+        "public_space_area_sqm": 135000.0,
+        "building_footprint_area_sqm": 949348.0,
+        "green_ratio": 0.123687,
+        "public_space_ratio": 0.011829
+      }
+    },
+    "stderr": ""
+  },
+  "visual_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "issues": [],
+      "metrics_seen": {
+        "site_area_sqm": 11412825.386,
+        "green_ratio": 0.123687,
+        "public_space_ratio": 0.011829
+      }
+    },
+    "stderr": ""
+  },
+  "professional_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "issues": [],
+      "summary": {
+        "standard_matrix_items": 6,
+        "design_depth_items": 15,
+        "known_metric_refs_required": 26,
+        "proposal_format_version": "2",
+        "evidence_contract": "section-anchors-plus-structured-audit",
+        "proposal_reference_counts": {
+          "source": 5,
+          "standard": 7,
+          "depth": 11,
+          "data": 9,
+          "metric": 9
+        }
+      }
+    },
+    "stderr": ""
+  },
+  "spatial_issue_ids": [
+    "KEY_AREA_PROVISIONAL",
+    "KEY_AREA_PROVISIONAL",
+    "KEY_AREA_PROVISIONAL"
+  ],
+  "visual_issue_ids": [],
+  "professional_issue_ids": [],
+  "missing_review_dependencies": [],
+  "can_enter_formal_review": true,
+  "package_type": "professional_design_package",
+  "review_status": "formal-review-ready",
+  "next_actions": [
+    "Resolve formal-readiness warning: submissions/lifecoder1988/jingzhang-ai-corridor/manifest.json: known_blockers present; submission may pass intake but cannot enter formal professional scoring until resolved"
+  ],
   "schema_version": "0.1.0",
   "checks": [
     {
-      "check_id": "BOUNDARY_TRUST",
+      "check_id": "DETERMINISTIC_VALIDATION",
       "result": "pass",
-      "severity": "major",
-      "target": "geometry/site_boundary.geojson",
-      "message": "Provisional boundary is present; replace with official redline before professional scoring."
+      "severity": "blocking",
+      "target": "validate_local_submission.py",
+      "message": "deterministic_validation: PASS"
     },
     {
-      "check_id": "KEY_AREAS_TRUST",
+      "check_id": "SPATIAL_REVIEW",
       "result": "pass",
-      "severity": "major",
-      "target": "geometry/key_areas.geojson",
-      "message": "Three required key areas are provisional; replace with official polygons before professional scoring."
+      "severity": "blocking",
+      "target": "spatial_review.py",
+      "message": "spatial_review: PASS"
     },
     {
-      "check_id": "LAND_USE_TOPOLOGY",
+      "check_id": "VISUAL_PACKAGING",
       "result": "pass",
-      "severity": "major",
-      "target": "geometry/land_use.geojson",
-      "message": "Initial land-use polygons are derived from site boundary partitioning."
-    },
-    {
-      "check_id": "VISUAL_STATIC",
-      "result": "pass",
-      "severity": "info",
-      "target": "visual/index.html",
-      "message": "Static HTML visualization is generated without external dependencies."
+      "severity": "blocking",
+      "target": "visual_review.py",
+      "message": "visual_review: PASS"
     },
     {
       "check_id": "PROFESSIONAL_EVIDENCE",
       "result": "pass",
-      "severity": "major",
-      "target": "proposal.md",
-      "message": "Proposal includes references to standards, design depth items, geometry, metrics, sources, and assumptions."
+      "severity": "blocking",
+      "target": "professional_review.py",
+      "message": "professional_review: PASS"
     }
   ]
 }


### PR DESCRIPTION
Follow-up to #1286: migrates the merged package to the new persisted self-check workflow introduced upstream.

- Ran `self_check_submission.py --pr-author lifecoder1988 --mark-self-checked --json`: all four gates PASS (deterministic / spatial / visual / professional)
- `self_check.json` now persists the four-gate report; manifest records `readiness_contract=persisted-self-check-v1` and `self_checked=true`, with refreshed hash
- No content changes to proposal, geometry, metrics, figures, or drawings
- `participant_preflight.py --check-push`: PASS