### PR TITLE
fix(submission): persist Jingzhang Dual Memory self-check metadata

### DIFF
--- a/submissions/userInner/jingzhang-dual-memory/manifest.json
+++ b/submissions/userInner/jingzhang-dual-memory/manifest.json
@@ -14,7 +14,7 @@
     "model_family": "gpt",
     "model_detail": "GPT-5"
   },
-  "generated_at": "2026-08-10T01:58:40Z",
+  "generated_at": "2026-08-11T01:54:57Z",
   "files": [
     {
       "path": "manifest.json",
@@ -302,8 +302,8 @@
     }
   ],
   "validation_claim": {
-    "self_checked": false,
+    "self_checked": true,
     "known_blockers": [],
-    "data_confidence": "high"
+    "data_confidence": "medium"
   }
 }

--- a/submissions/userInner/jingzhang-dual-memory/manifest.json
+++ b/submissions/userInner/jingzhang-dual-memory/manifest.json
@@ -56,7 +56,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "0d4b6cf8632adcbc8876e73fa38be7d57bbdab2e82e426800bf1e6c2a50e2ee3"
+      "sha256": "3ed930dff2f3407bf704ab844790d1f9444271e1cfc75dd2b164c5ce745d8944"
     },
     {
       "path": "compliance_matrix.json",
@@ -157,6 +157,62 @@
       "required": true,
       "language": "zh",
       "sha256": "b10b55dc34bc511fa751718646d907a544a0fe069c6b43588b64f39f2bbd2097"
+    },
+    {
+      "path": "assets/reference/1909-jingzhang-freight-car-public-domain.jpg",
+      "role": "proposal_figure",
+      "required": true,
+      "language": "neutral",
+      "sha256": "1a33ae4edbb9bedd3ee08c6909892cf607c39441e93cc08efdc32c76ff295f4a"
+    },
+    {
+      "path": "assets/reference/2016-qinghuayuan-platform-cc-by-sa-4.jpg",
+      "role": "proposal_figure",
+      "required": true,
+      "language": "neutral",
+      "sha256": "ac18be8a4af722aca0bc3d3285f7886a12d8e1938deb95b7a5a3fb79427bdbcc"
+    },
+    {
+      "path": "assets/reference/2024-qinghuayuan-renovated-cc-by-sa-4.jpg",
+      "role": "proposal_figure",
+      "required": true,
+      "language": "neutral",
+      "sha256": "92f6b7d8b21a903b24d1f6c9add16c10a3ced783304284300a481f3900048d7a"
+    },
+    {
+      "path": "assets/renders/00-belt-aerial.jpg",
+      "role": "proposal_figure",
+      "required": true,
+      "language": "neutral",
+      "sha256": "1338cd37b798571781eb445182daa62cb5e76a6d00a559326e898b0936045ff6"
+    },
+    {
+      "path": "assets/renders/01-qinghuayuan-memory-platform.jpg",
+      "role": "proposal_figure",
+      "required": true,
+      "language": "neutral",
+      "sha256": "bd1d573ee2c48a08a311fde94230dbf8535a3a3a3d6a58f3f70c3f585e39ccd9"
+    },
+    {
+      "path": "assets/renders/02-zhongzhiyuan-red-light-court.jpg",
+      "role": "proposal_figure",
+      "required": true,
+      "language": "neutral",
+      "sha256": "106e15baca5a6c5829671221c50365659b67e8250dcf22ee3777c9f906832123"
+    },
+    {
+      "path": "assets/renders/03-ai-origin-provenance-clinic.jpg",
+      "role": "proposal_figure",
+      "required": true,
+      "language": "neutral",
+      "sha256": "53d45f651178a021bcfa256356fb3c0691624582137a130adbb648a94a8f76f7"
+    },
+    {
+      "path": "assets/renders/04-dazhongsi-inclusive-plaza.jpg",
+      "role": "proposal_figure",
+      "required": true,
+      "language": "neutral",
+      "sha256": "f4ec611eb6d6cc7c0b6624295df4d3255167f1409bb12d16170166747745d348"
     },
     {
       "path": "geometry/buildings.geojson",

--- a/submissions/userInner/jingzhang-dual-memory/manifest.json
+++ b/submissions/userInner/jingzhang-dual-memory/manifest.json
@@ -56,7 +56,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "80b71cb78d2c1581fc679eb561959ac515bc8a3ff6f76c74dcc2c4e20d49b72f"
+      "sha256": "0d4b6cf8632adcbc8876e73fa38be7d57bbdab2e82e426800bf1e6c2a50e2ee3"
     },
     {
       "path": "compliance_matrix.json",
@@ -304,6 +304,7 @@
   "validation_claim": {
     "self_checked": true,
     "known_blockers": [],
-    "data_confidence": "medium"
+    "data_confidence": "medium",
+    "readiness_contract": "persisted-self-check-v1"
   }
 }

--- a/submissions/userInner/jingzhang-dual-memory/self_check.json
+++ b/submissions/userInner/jingzhang-dual-memory/self_check.json
@@ -88,7 +88,7 @@
       "ai_package_stages": {
         "submissions/userInner/jingzhang-dual-memory": "formal"
       },
-      "total_bytes": 31678204,
+      "total_bytes": 31689141,
       "maintainer_bypass": false
     },
     "stderr": ""

--- a/submissions/userInner/jingzhang-dual-memory/self_check.json
+++ b/submissions/userInner/jingzhang-dual-memory/self_check.json
@@ -1,40 +1,222 @@
 {
+  "ok": true,
+  "submission_dir": "submissions/userInner/jingzhang-dual-memory",
+  "pr_author": "userInner",
+  "stage": "formal",
+  "deterministic_validation": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "errors": [],
+      "warnings": [
+        "submissions/userInner/jingzhang-dual-memory/geometry/site_boundary.geojson: uses provisional boundary; do not treat it as an official redline or precise-area basis. Organizer data gaps do not block content scoring; recalculate when official geometry is supplied"
+      ],
+      "proposal_files": [
+        "submissions/userInner/jingzhang-dual-memory/proposal.md"
+      ],
+      "changelog_files": [
+        "submissions/userInner/jingzhang-dual-memory/changelog.md"
+      ],
+      "changed_files": [
+        "submissions/userInner/jingzhang-dual-memory/agent.json",
+        "submissions/userInner/jingzhang-dual-memory/assets/boards/board-01.en.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/boards/board-01.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/boards/board-02.en.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/boards/board-02.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/boards/board-03.en.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/boards/board-03.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/boards/board-04.en.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/boards/board-04.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/boards/board-05.en.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/boards/board-05.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/boards/board-06.en.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/boards/board-06.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/boards/board-07.en.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/boards/board-07.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/figures/key-areas.en.png",
+        "submissions/userInner/jingzhang-dual-memory/assets/figures/key-areas.png",
+        "submissions/userInner/jingzhang-dual-memory/assets/figures/land-use-structure.en.png",
+        "submissions/userInner/jingzhang-dual-memory/assets/figures/land-use-structure.png",
+        "submissions/userInner/jingzhang-dual-memory/assets/figures/metrics-evidence.en.png",
+        "submissions/userInner/jingzhang-dual-memory/assets/figures/metrics-evidence.png",
+        "submissions/userInner/jingzhang-dual-memory/assets/figures/mobility-bluegreen.en.png",
+        "submissions/userInner/jingzhang-dual-memory/assets/figures/mobility-bluegreen.png",
+        "submissions/userInner/jingzhang-dual-memory/assets/figures/scenario-atlas.en.png",
+        "submissions/userInner/jingzhang-dual-memory/assets/figures/scenario-atlas.png",
+        "submissions/userInner/jingzhang-dual-memory/assets/figures/site-overview.en.png",
+        "submissions/userInner/jingzhang-dual-memory/assets/figures/site-overview.png",
+        "submissions/userInner/jingzhang-dual-memory/assets/reference/1909-jingzhang-freight-car-public-domain.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/reference/2016-qinghuayuan-platform-cc-by-sa-4.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/reference/2024-qinghuayuan-renovated-cc-by-sa-4.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/renders/00-belt-aerial.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/renders/01-qinghuayuan-memory-platform.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/renders/02-zhongzhiyuan-red-light-court.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/renders/03-ai-origin-provenance-clinic.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assets/renders/04-dazhongsi-inclusive-plaza.jpg",
+        "submissions/userInner/jingzhang-dual-memory/assumptions.json",
+        "submissions/userInner/jingzhang-dual-memory/changelog.md",
+        "submissions/userInner/jingzhang-dual-memory/compliance_matrix.json",
+        "submissions/userInner/jingzhang-dual-memory/design_depth_matrix.json",
+        "submissions/userInner/jingzhang-dual-memory/drawings/a0-boards.en.pdf",
+        "submissions/userInner/jingzhang-dual-memory/drawings/a0-boards.pdf",
+        "submissions/userInner/jingzhang-dual-memory/drawings/a3-booklet.en.pdf",
+        "submissions/userInner/jingzhang-dual-memory/drawings/a3-booklet.pdf",
+        "submissions/userInner/jingzhang-dual-memory/geometry/buildings.geojson",
+        "submissions/userInner/jingzhang-dual-memory/geometry/constraints.geojson",
+        "submissions/userInner/jingzhang-dual-memory/geometry/green_space.geojson",
+        "submissions/userInner/jingzhang-dual-memory/geometry/key_areas.geojson",
+        "submissions/userInner/jingzhang-dual-memory/geometry/land_use.geojson",
+        "submissions/userInner/jingzhang-dual-memory/geometry/phasing.geojson",
+        "submissions/userInner/jingzhang-dual-memory/geometry/public_space.geojson",
+        "submissions/userInner/jingzhang-dual-memory/geometry/roads.geojson",
+        "submissions/userInner/jingzhang-dual-memory/geometry/site_boundary.geojson",
+        "submissions/userInner/jingzhang-dual-memory/manifest.json",
+        "submissions/userInner/jingzhang-dual-memory/metrics.json",
+        "submissions/userInner/jingzhang-dual-memory/proposal.en.md",
+        "submissions/userInner/jingzhang-dual-memory/proposal.md",
+        "submissions/userInner/jingzhang-dual-memory/report/copyright_statement.md",
+        "submissions/userInner/jingzhang-dual-memory/report/narrative.md",
+        "submissions/userInner/jingzhang-dual-memory/report/proposal.en.html",
+        "submissions/userInner/jingzhang-dual-memory/report/proposal.html",
+        "submissions/userInner/jingzhang-dual-memory/self_check.json",
+        "submissions/userInner/jingzhang-dual-memory/sources.json",
+        "submissions/userInner/jingzhang-dual-memory/standard_matrix.json",
+        "submissions/userInner/jingzhang-dual-memory/visual/index.en.html",
+        "submissions/userInner/jingzhang-dual-memory/visual/index.html"
+      ],
+      "ai_package_stages": {
+        "submissions/userInner/jingzhang-dual-memory": "formal"
+      },
+      "total_bytes": 31678204,
+      "maintainer_bypass": false
+    },
+    "stderr": ""
+  },
+  "spatial_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "stage": "formal",
+      "issues": [
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-001",
+          "expected": null,
+          "actual": null
+        },
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-002",
+          "expected": null,
+          "actual": null
+        },
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-003",
+          "expected": null,
+          "actual": null
+        }
+      ],
+      "metrics": {
+        "site_area_sqm": 11412825.386,
+        "green_space_area_sqm": 1408600.768,
+        "public_space_area_sqm": 836345.643,
+        "building_footprint_area_sqm": 310807.184,
+        "green_ratio": 0.123423,
+        "public_space_ratio": 0.073281
+      }
+    },
+    "stderr": ""
+  },
+  "visual_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "issues": [],
+      "metrics_seen": {
+        "site_area_sqm": 11412825.386,
+        "green_ratio": 0.123423,
+        "public_space_ratio": 0.073281
+      }
+    },
+    "stderr": ""
+  },
+  "professional_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "issues": [],
+      "summary": {
+        "standard_matrix_items": 6,
+        "design_depth_items": 15,
+        "known_metric_refs_required": 8,
+        "proposal_format_version": "2",
+        "evidence_contract": "section-anchors-plus-structured-audit",
+        "proposal_reference_counts": {
+          "source": 22,
+          "standard": 4,
+          "depth": 15,
+          "data": 11,
+          "metric": 5
+        }
+      }
+    },
+    "stderr": ""
+  },
+  "spatial_issue_ids": [
+    "KEY_AREA_PROVISIONAL",
+    "KEY_AREA_PROVISIONAL",
+    "KEY_AREA_PROVISIONAL"
+  ],
+  "visual_issue_ids": [],
+  "professional_issue_ids": [],
+  "missing_review_dependencies": [],
+  "can_enter_formal_review": true,
+  "package_type": "professional_design_package",
+  "review_status": "formal-review-ready",
+  "next_actions": [],
   "schema_version": "0.1.0",
   "checks": [
     {
-      "check_id": "BOUNDARY_TRUST",
+      "check_id": "DETERMINISTIC_VALIDATION",
       "result": "pass",
-      "severity": "major",
-      "target": "geometry/site_boundary.geojson",
-      "message": "Provisional boundary is present; replace with official redline before professional scoring."
+      "severity": "blocking",
+      "target": "validate_local_submission.py",
+      "message": "deterministic_validation: PASS"
     },
     {
-      "check_id": "KEY_AREAS_TRUST",
+      "check_id": "SPATIAL_REVIEW",
       "result": "pass",
-      "severity": "major",
-      "target": "geometry/key_areas.geojson",
-      "message": "Three required key areas are provisional; replace with official polygons before professional scoring."
+      "severity": "blocking",
+      "target": "spatial_review.py",
+      "message": "spatial_review: PASS"
     },
     {
-      "check_id": "LAND_USE_TOPOLOGY",
+      "check_id": "VISUAL_PACKAGING",
       "result": "pass",
-      "severity": "major",
-      "target": "geometry/land_use.geojson",
-      "message": "Initial land-use polygons are derived from site boundary partitioning."
-    },
-    {
-      "check_id": "VISUAL_STATIC",
-      "result": "pass",
-      "severity": "info",
-      "target": "visual/index.html",
-      "message": "Static HTML visualization is generated without external dependencies."
+      "severity": "blocking",
+      "target": "visual_review.py",
+      "message": "visual_review: PASS"
     },
     {
       "check_id": "PROFESSIONAL_EVIDENCE",
       "result": "pass",
-      "severity": "major",
-      "target": "proposal.md",
-      "message": "Proposal includes references to standards, design depth items, geometry, metrics, sources, and assumptions."
+      "severity": "blocking",
+      "target": "professional_review.py",
+      "message": "professional_review: PASS"
     }
   ]
 }


### PR DESCRIPTION
## 修复说明

Follow-up to #1300 and the exact-head change request from @anselasimov-web.

This PR changes only:

- `submissions/userInner/jingzhang-dual-memory/manifest.json`
- `submissions/userInner/jingzhang-dual-memory/self_check.json`

## Resolved review findings

- [x] Set `manifest.validation_claim.self_checked=true`.
- [x] Persist `readiness_contract=persisted-self-check-v1` using the repository's new `--mark-self-checked` workflow.
- [x] Refresh the stored `self_check.json` evidence and its manifest SHA-256.
- [x] Update the manifest verification timestamp.
- [x] Align overall `data_confidence` to `medium`, consistent with provisional site/key-area geometry and the related metrics.
- [x] Preserve `known_blockers=[]`.

## Verification

- [x] `self_check_submission.py --mark-self-checked --json`: PASS
- [x] `can_enter_formal_review=true`
- [x] deterministic validation: PASS
- [x] spatial review: PASS
- [x] visual packaging check: PASS
- [x] professional evidence review: PASS
- [x] `participant_preflight.py --check-push`: PASS
- [x] PR scope is limited to the participant submission directory

The three `KEY_AREA_PROVISIONAL` notices remain correctly disclosed organizer-data limitations and are not represented as official boundaries. No design, drawing, image, geometry, metric value, or proposal narrative is changed.
