### PR TITLE
fix(tooling): include tracks registry in participant bootstrap

### DIFF
--- a/scripts/bootstrap_participant_workspace.py
+++ b/scripts/bootstrap_participant_workspace.py
@@ -25,6 +25,7 @@ DEFAULT_SPARSE_PATHS = (
     "/scenarios",
     "/sources",
     "/templates",
+    "/tracks.json",
     "/requirements-review.txt",
     "/requirements-translation.txt",
 )
@@ -36,6 +37,7 @@ REQUIRED_FILES = (
     "scripts/scaffold_ai_submission.py",
     "scripts/self_check_submission.py",
     "requirements-review.txt",
+    "tracks.json",
 )
 REQUIRED_DIRECTORIES = ("scenarios",)
 GITHUB_LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$")

--- a/tests/test_lightweight_participant_flow.py
+++ b/tests/test_lightweight_participant_flow.py
@@ -69,6 +69,7 @@ class LightweightParticipantFlowTests(unittest.TestCase):
         self.assertEqual(report["depth"], 50)
         self.assertIn("/scenarios", report["sparse_paths"])
         self.assertIn("/sources", report["sparse_paths"])
+        self.assertIn("/tracks.json", report["sparse_paths"])
         flattened = [token for command in report["commands"] for token in command]
         self.assertIn("--filter=blob:none", flattened)
         self.assertIn("sparse-checkout", flattened)
@@ -80,6 +81,7 @@ class LightweightParticipantFlowTests(unittest.TestCase):
         self.assertIn("--no-cone", flattened)
         self.assertIn("/requirements-review.txt", flattened)
         self.assertIn("/requirements-translation.txt", flattened)
+        self.assertIn("/tracks.json", flattened)
 
     def test_bootstrap_defaults_fork_to_case_preserving_login(self) -> None:
         completed = self.run_command(


### PR DESCRIPTION
Fixes #1650.

The participant bootstrap sparse checkout now includes `/tracks.json`, and post-bootstrap required-file verification requires the same root registry. Added regression assertions to the lightweight participant flow dry-run test.

Validation:
- lightweight participant flow: 8/8
- tracks tests: 3/3
- py_compile: PASS
- git diff --check: PASS