### PR TITLE
fix(render): localize English evidence labels

### DIFF
--- a/scripts/render_proposal_html.py
+++ b/scripts/render_proposal_html.py
@@ -24,6 +24,13 @@ REFERENCE_LABELS = {
     "data": "空间数据",
     "metric": "指标",
 }
+REFERENCE_LABELS_EN = {
+    "source": "Source",
+    "standard": "Standard",
+    "depth": "Depth",
+    "data": "Spatial data",
+    "metric": "Metric",
+}
 
 
 def parse_front_matter(text: str) -> tuple[dict[str, str], str]:
@@ -55,7 +62,7 @@ def normalize_image_src(submission_dir: Path, raw_src: str) -> str:
     return "../" + pure.as_posix()
 
 
-def render_inline(text: str) -> str:
+def render_inline(text: str, language: str = "zh") -> str:
     escaped = html.escape(text)
     code_spans: list[str] = []
 
@@ -72,11 +79,13 @@ def render_inline(text: str) -> str:
     def replace_ref(match: re.Match[str]) -> str:
         kind = match.group(1)
         value = match.group(2)
-        label = REFERENCE_LABELS[kind]
+        labels = REFERENCE_LABELS_EN if language == "en" else REFERENCE_LABELS
+        label = labels[kind]
+        separator = ": " if language == "en" else "："
         escaped_value = html.escape(value)
         return (
             f'<sup class="evidence evidence-{kind}" data-evidence-kind="{kind}" '
-            f'data-evidence-value="{escaped_value}" title="{label}：{escaped_value}">'
+            f'data-evidence-value="{escaped_value}" title="{label}{separator}{escaped_value}">'
             f'{label}</sup>'
         )
 
@@ -146,12 +155,16 @@ def table_alignment(delimiter: str) -> str | None:
     return None
 
 
-def render_table_cell(tag: str, value: str, alignment: str | None) -> str:
+def render_table_cell(
+    tag: str, value: str, alignment: str | None, language: str = "zh"
+) -> str:
     alignment_class = f' class="align-{alignment}"' if alignment else ""
-    return f"<{tag}{alignment_class}>{render_inline(value)}</{tag}>"
+    return f"<{tag}{alignment_class}>{render_inline(value, language)}</{tag}>"
 
 
-def render_markdown_body(submission_dir: Path, markdown: str) -> str:
+def render_markdown_body(
+    submission_dir: Path, markdown: str, language: str = "zh"
+) -> str:
     blocks: list[str] = []
     paragraph: list[str] = []
     in_list = False
@@ -159,7 +172,7 @@ def render_markdown_body(submission_dir: Path, markdown: str) -> str:
     def flush_paragraph() -> None:
         nonlocal paragraph
         if paragraph:
-            blocks.append(f"<p>{render_inline(' '.join(paragraph))}</p>")
+            blocks.append(f"<p>{render_inline(' '.join(paragraph), language)}</p>")
             paragraph = []
 
     def close_list() -> None:
@@ -213,7 +226,7 @@ def render_markdown_body(submission_dir: Path, markdown: str) -> str:
                 close_list()
                 alignments = [table_alignment(cell) for cell in delimiter_cells]
                 header = "".join(
-                    render_table_cell("th", cell, alignment)
+                    render_table_cell("th", cell, alignment, language)
                     for cell, alignment in zip(header_cells, alignments)
                 )
                 index += 2
@@ -240,7 +253,7 @@ def render_markdown_body(submission_dir: Path, markdown: str) -> str:
                     body_rows.append(
                         "<tr>"
                         + "".join(
-                            render_table_cell("td", cell, alignment)
+                            render_table_cell("td", cell, alignment, language)
                             for cell, alignment in zip(cells, alignments)
                         )
                         + "</tr>"
@@ -291,7 +304,7 @@ def render_markdown_body(submission_dir: Path, markdown: str) -> str:
                     quote_paragraphs.append([])
                 index += 1
             rendered_quotes = "".join(
-                f"<p>{render_inline(' '.join(items))}</p>"
+                f"<p>{render_inline(' '.join(items), language)}</p>"
                 for items in quote_paragraphs
                 if items
             )
@@ -303,7 +316,7 @@ def render_markdown_body(submission_dir: Path, markdown: str) -> str:
             close_list()
             level = min(len(line) - len(line.lstrip("#")), 4)
             title = line[level:].strip()
-            blocks.append(f"<h{level}>{render_inline(title)}</h{level}>")
+            blocks.append(f"<h{level}>{render_inline(title, language)}</h{level}>")
             index += 1
             continue
 
@@ -312,7 +325,7 @@ def render_markdown_body(submission_dir: Path, markdown: str) -> str:
             if not in_list:
                 blocks.append("<ul>")
                 in_list = True
-            blocks.append(f"<li>{render_inline(line[2:].strip())}</li>")
+            blocks.append(f"<li>{render_inline(line[2:].strip(), language)}</li>")
             index += 1
             continue
 
@@ -340,12 +353,12 @@ def render_html(
         english_body = body[: translation_match.start()]
         translation_body = body[translation_match.end() :]
         rendered_body = (
-            f'<section lang="en">{render_markdown_body(submission_dir, english_body)}</section>'
+            f'<section lang="en">{render_markdown_body(submission_dir, english_body, "en")}</section>'
             f'<section lang="zh-CN"><h1>中文正式译文</h1>'
-            f'{render_markdown_body(submission_dir, translation_body)}</section>'
+            f'{render_markdown_body(submission_dir, translation_body, "zh")}</section>'
         )
     else:
-        rendered_body = render_markdown_body(submission_dir, body)
+        rendered_body = render_markdown_body(submission_dir, body, language)
     translation_link = ""
     if translation_href:
         link_label = "Read in English" if language == "zh" else "阅读中文版本"

--- a/tests/test_render_proposal_html.py
+++ b/tests/test_render_proposal_html.py
@@ -52,6 +52,54 @@ class RenderProposalHtmlTests(unittest.TestCase):
             self.assertIn("第二行。</p><p>独立第二段。</p></blockquote>", html)
             self.assertNotIn("&gt;", html)
 
+    def test_render_english_proposal_localizes_evidence_labels(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission_dir = Path(tmp)
+            (submission_dir / "proposal.md").write_text(
+                """---
+title: "English proposal"
+language: "en"
+---
+
+# English proposal
+
+Evidence [source:SITE-PACKAGE] and [metric:site_area].
+""",
+                encoding="utf-8",
+            )
+
+            html = render_html(submission_dir)
+
+            self.assertIn(">Source</sup>", html)
+            self.assertIn('title="Source: SITE-PACKAGE"', html)
+            self.assertNotIn(">来源</sup>", html)
+
+    def test_embedded_chinese_translation_keeps_chinese_evidence_labels(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission_dir = Path(tmp)
+            (submission_dir / "proposal.md").write_text(
+                """---
+title: "English proposal"
+language: "en"
+---
+
+# English proposal
+
+English [source:SITE-PACKAGE].
+
+# 中文正式译文
+
+中文 [source:SITE-PACKAGE]。
+""",
+                encoding="utf-8",
+            )
+
+            html = render_html(submission_dir)
+
+            self.assertIn('lang="en"', html)
+            self.assertIn('title="Source: SITE-PACKAGE"', html)
+            self.assertIn('title="来源：SITE-PACKAGE"', html)
+
     def test_render_html_rewrites_local_figure_paths(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             submission_dir = Path(tmp)


### PR DESCRIPTION
## What changed

Fix the offline proposal renderer's evidence labels for English reports.

`render_inline()` previously used Chinese labels and the full-width separator for every language. The renderer now carries the document language through paragraphs, tables, blockquotes, headings and lists. English reports use `Source`, `Standard`, `Depth`, `Spatial data`, and `Metric` with an English separator, while Chinese output keeps the existing labels and punctuation. An embedded Chinese translation inside an English proposal remains Chinese.

## Why

This addresses the renderer-localization gap documented in #1631. The current behavior makes otherwise English report surfaces contain Chinese evidence labels and can obscure the intended language boundary.

## Scope

- `scripts/render_proposal_html.py`
- `tests/test_render_proposal_html.py`

No submission package, gallery index, score data, or publication workflow is changed.

## Validation

- `python3 -m unittest tests/test_render_proposal_html.py -v` — 15 passed
- `python3 -m py_compile scripts/render_proposal_html.py`
- `git diff --check`
