### PR TITLE
fix(validate): 双语产物同字节给出非阻断提示,区分 language/translation_of 与 neutral 契约(#1631 第2项)

### DIFF
--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -2273,6 +2273,105 @@ def validate_proposal_evidence_references(
                 report.add_error(f"{proposal_dir}/proposal.md: missing design depth reference [depth:{item_id}]")
 
 
+def report_identical_bilingual_artifacts(
+    report: ValidationReport,
+    repo_root: Path,
+    proposal_dir: str,
+    manifest_items: dict[str, dict],
+) -> None:
+    """Hint at translated files that are byte-identical to their primary file.
+
+    Identical bytes are a signal, not a verdict: a figure without text or a
+    language-independent PDF may legitimately be shared by both versions. The
+    package declares that intent with `language: "neutral"` instead of a
+    translation contract, so only entries that actually claim a translation are
+    inspected, neutral entries are skipped, and the result is always a
+    non-blocking warning that leaves historical packages passing unchanged.
+
+    The advisory reads package files, so it must not widen the path boundary
+    that `validate_manifest_file()` enforces. `validate_manifest_file()` reports
+    an unsafe manifest path and keeps validating, so a raw entry can still reach
+    this function; every path is therefore re-normalized here and any entry that
+    escapes the package or crosses a symbolic link is skipped instead of read.
+    """
+    base = repo_root / proposal_dir
+
+    def contained_file(raw_path: str) -> Path | None:
+        """Return the package-relative file for a manifest path, or None."""
+        try:
+            safe_path = normalize_changed_path(raw_path)
+        except (ValueError, TypeError):
+            return None
+        if first_symbolic_link(base, safe_path) is not None:
+            return None
+        candidate = base / safe_path
+        if not candidate.is_file():
+            return None
+        try:
+            candidate.resolve().relative_to(base.resolve())
+        except (OSError, ValueError):
+            return None
+        return candidate
+
+    digests: dict[str, str | None] = {}
+
+    def declared_digest(path: str) -> str | None:
+        declared = manifest_items.get(path, {}).get("sha256")
+        if isinstance(declared, str) and declared.strip():
+            return declared.strip().lower()
+        return None
+
+    def digest_for(path: str, resolved: Path) -> str | None:
+        # Declared digests are pending *Git blob* digests (see git_blob_sha256),
+        # while hashing here reads worktree bytes; the two differ whenever the
+        # worktree keeps CRLF line endings. Never mix the two sources in one
+        # comparison - reuse declared digests only when both sides declare one.
+        if path not in digests:
+            try:
+                digests[path] = hashlib.sha256(resolved.read_bytes()).hexdigest()
+            except OSError:
+                digests[path] = None
+        return digests[path]
+
+    for path in sorted(manifest_items):
+        item = manifest_items[path]
+        language = item.get("language")
+        if language == "neutral":
+            continue
+        primary_path = item.get("translation_of")
+        if not isinstance(primary_path, str) or not primary_path:
+            localized = primary_path_from_localized(path)
+            if localized is None or language != localized[1]:
+                continue
+            primary_path = localized[0]
+        if primary_path == path:
+            continue
+        primary_item = manifest_items.get(primary_path)
+        if primary_item is not None and primary_item.get("language") == "neutral":
+            continue
+        translated_file = contained_file(path)
+        primary_file = contained_file(primary_path)
+        if translated_file is None or primary_file is None:
+            continue
+        translated_declared = declared_digest(path)
+        primary_declared = declared_digest(primary_path)
+        if translated_declared is not None and primary_declared is not None:
+            translated_digest = translated_declared
+            primary_digest: str | None = primary_declared
+        else:
+            translated_digest = digest_for(path, translated_file)
+            primary_digest = digest_for(primary_path, primary_file)
+        if translated_digest is None or translated_digest != primary_digest:
+            continue
+        report.add_warning(
+            f"{proposal_dir}/{path}: byte-identical to `{primary_path}`; if the translation is "
+            "still missing, replace it with a rendering in the declared language, and if the file "
+            "carries no language-specific content, declare language=neutral once and share it "
+            "between both versions (see docs/formal-submission-guide.md); this notice does not "
+            "block review"
+        )
+
+
 def validate_bilingual_display(
     report: ValidationReport,
     repo_root: Path,
@@ -2421,6 +2520,8 @@ def validate_bilingual_display(
                 report_bilingual_problem(
                     f"{proposal_dir}/{translation_file}: front matter should set translation_of=proposal.md"
                 )
+
+    report_identical_bilingual_artifacts(report, repo_root, proposal_dir, manifest_items)
 
 
 def validate_ai_package_dir(

--- a/tests/test_bilingual_identical_bytes.py
+++ b/tests/test_bilingual_identical_bytes.py
@@ -1,0 +1,319 @@
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from validate_submission import (  # noqa: E402
+    ValidationReport,
+    format_report,
+    validate_bilingual_display,
+)
+
+
+PRIMARY_FRONT_MATTER = """---
+title: "示例方案"
+author_github: "alice"
+language: "zh"
+translation_file: "proposal.en.md"
+---
+
+# 示例方案
+
+正文。
+"""
+
+TRANSLATED_FRONT_MATTER = """---
+title: "Sample proposal"
+author_github: "alice"
+language: "en"
+translation_of: "proposal.md"
+---
+
+# Sample proposal
+
+Body.
+"""
+
+FIGURE_BYTES = b"\x89PNG\r\n\x1a\n" + b"figure-with-labels" * 8
+
+
+class BilingualIdenticalBytesTests(unittest.TestCase):
+    """Byte-identical bilingual artifacts are a hint, never a verdict."""
+
+    def build_package(
+        self,
+        root: Path,
+        base: str,
+        *,
+        translated_figure: bytes = FIGURE_BYTES,
+        primary_language: str = "zh",
+        translated_language: str = "en",
+        declare_translation_of: bool = True,
+        primary_front_matter: str = PRIMARY_FRONT_MATTER,
+    ) -> tuple[list[str], dict]:
+        """Write the smallest package that reaches the bilingual display check."""
+        package = root / base
+        (package / "assets/figures").mkdir(parents=True, exist_ok=True)
+        (package / "proposal.md").write_text(primary_front_matter, encoding="utf-8")
+        (package / "proposal.en.md").write_text(TRANSLATED_FRONT_MATTER, encoding="utf-8")
+        (package / "assets/figures/site-overview.png").write_bytes(FIGURE_BYTES)
+        (package / "assets/figures/site-overview.en.png").write_bytes(translated_figure)
+
+        def digest(rel: str) -> str:
+            return hashlib.sha256((package / rel).read_bytes()).hexdigest()
+
+        figure_item = {
+            "path": "assets/figures/site-overview.en.png",
+            "role": "proposal_figure",
+            "language": translated_language,
+            "sha256": digest("assets/figures/site-overview.en.png"),
+        }
+        if declare_translation_of:
+            figure_item["translation_of"] = "assets/figures/site-overview.png"
+        manifest = {
+            "files": [
+                {"path": "proposal.md", "role": "narrative", "language": "zh", "sha256": digest("proposal.md")},
+                {
+                    "path": "proposal.en.md",
+                    "role": "narrative",
+                    "language": "en",
+                    "translation_of": "proposal.md",
+                    "sha256": digest("proposal.en.md"),
+                },
+                {
+                    "path": "assets/figures/site-overview.png",
+                    "role": "proposal_figure",
+                    "language": primary_language,
+                    "sha256": digest("assets/figures/site-overview.png"),
+                },
+                figure_item,
+            ]
+        }
+        changed = [f"{base}/assets/figures/site-overview.en.png"]
+        return changed, manifest
+
+    def run_check(self, root: Path, base: str, changed: list[str], manifest: dict) -> ValidationReport:
+        report = ValidationReport()
+        report.changed_files = list(changed)
+        validate_bilingual_display(report, root, base, manifest)
+        return report
+
+    def identical_notices(self, report: ValidationReport) -> list[str]:
+        return [warning for warning in report.warnings if "byte-identical" in warning]
+
+    def test_identical_translated_figure_raises_a_single_notice(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed, manifest = self.build_package(root, base)
+            report = self.run_check(root, base, changed, manifest)
+            notices = self.identical_notices(report)
+            self.assertEqual(1, len(notices), report.warnings)
+            self.assertIn("assets/figures/site-overview.en.png", notices[0])
+            self.assertIn("`assets/figures/site-overview.png`", notices[0])
+            self.assertIn("language=neutral", notices[0])
+            self.assertIn("docs/formal-submission-guide.md", notices[0])
+            self.assertIn("does not block review", notices[0])
+
+    def test_neutral_primary_declaration_suppresses_the_notice(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed, manifest = self.build_package(root, base, primary_language="neutral")
+            report = self.run_check(root, base, changed, manifest)
+            self.assertEqual([], self.identical_notices(report))
+
+    def test_neutral_counterpart_declaration_suppresses_the_notice(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed, manifest = self.build_package(root, base, translated_language="neutral")
+            report = self.run_check(root, base, changed, manifest)
+            self.assertEqual([], self.identical_notices(report))
+
+    def test_translated_figure_with_different_bytes_is_not_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed, manifest = self.build_package(
+                root, base, translated_figure=FIGURE_BYTES + b"english-labels"
+            )
+            report = self.run_check(root, base, changed, manifest)
+            self.assertEqual([], self.identical_notices(report))
+
+    def test_language_suffix_pair_without_translation_of_is_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed, manifest = self.build_package(root, base, declare_translation_of=False)
+            report = self.run_check(root, base, changed, manifest)
+            self.assertEqual(1, len(self.identical_notices(report)), report.warnings)
+
+    def test_package_without_declared_language_is_not_inspected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed, manifest = self.build_package(
+                root,
+                base,
+                primary_front_matter='---\ntitle: "示例方案"\nauthor_github: "alice"\n---\n\n# 示例方案\n\n正文。\n',
+            )
+            report = self.run_check(root, base, changed, manifest)
+            self.assertEqual([], report.warnings)
+            self.assertEqual([], report.errors)
+
+    def test_parent_traversal_manifest_path_is_not_read(self) -> None:
+        """An unsafe manifest entry must not make the advisory read outside the package."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed, manifest = self.build_package(root, base)
+            outside = root / "outside-secret.png"
+            outside.write_bytes(FIGURE_BYTES)
+            manifest["files"].append(
+                {
+                    "path": "../../../outside-secret.png",
+                    "role": "proposal_figure",
+                    "language": "en",
+                    "translation_of": "assets/figures/site-overview.png",
+                }
+            )
+            report = self.run_check(root, base, changed, manifest)
+            notices = self.identical_notices(report)
+            self.assertTrue(all("outside-secret" not in notice for notice in notices), notices)
+            self.assertTrue(all(".." not in notice for notice in notices), notices)
+
+    def test_absolute_manifest_path_is_not_read(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed, manifest = self.build_package(root, base)
+            outside = root / "absolute-secret.png"
+            outside.write_bytes(FIGURE_BYTES)
+            manifest["files"].append(
+                {
+                    "path": str(outside),
+                    "role": "proposal_figure",
+                    "language": "en",
+                    "translation_of": "assets/figures/site-overview.png",
+                }
+            )
+            report = self.run_check(root, base, changed, manifest)
+            notices = self.identical_notices(report)
+            self.assertTrue(all("absolute-secret" not in notice for notice in notices), notices)
+
+    def test_symlinked_manifest_path_is_not_read(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed, manifest = self.build_package(root, base)
+            sentinel = root / "sentinel.png"
+            sentinel.write_bytes(FIGURE_BYTES)
+            link = root / base / "assets/figures/site-overview.link.en.png"
+            try:
+                link.symlink_to(sentinel)
+            except (OSError, NotImplementedError):
+                self.skipTest("symbolic links are not available on this platform")
+            manifest["files"].append(
+                {
+                    "path": "assets/figures/site-overview.link.en.png",
+                    "role": "proposal_figure",
+                    "language": "en",
+                    "translation_of": "assets/figures/site-overview.png",
+                }
+            )
+            report = self.run_check(root, base, changed, manifest)
+            notices = self.identical_notices(report)
+            self.assertTrue(all("site-overview.link.en.png" not in notice for notice in notices), notices)
+
+    def test_declared_and_worktree_digests_are_never_mixed(self) -> None:
+        """Declared digests are Git blob digests; worktree hashing must not be compared to them."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed, manifest = self.build_package(root, base)
+            for item in manifest["files"]:
+                if item["path"] == "assets/figures/site-overview.en.png":
+                    # Simulate a Git-blob digest that differs from the worktree bytes
+                    # (the CRLF case) while the other side declares nothing.
+                    item["sha256"] = hashlib.sha256(b"git-blob-form").hexdigest()
+                if item["path"] == "assets/figures/site-overview.png":
+                    item.pop("sha256", None)
+            report = self.run_check(root, base, changed, manifest)
+            # Both sides fall back to worktree bytes, so the identical pair is still found.
+            self.assertEqual(1, len(self.identical_notices(report)), report.warnings)
+
+    def test_notice_never_changes_the_pass_verdict(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed, manifest = self.build_package(root, base)
+            report = self.run_check(root, base, changed, manifest)
+            self.assertEqual(1, len(self.identical_notices(report)), report.warnings)
+            self.assertEqual([], report.errors)
+            self.assertTrue(report.ok)
+            self.assertIn("Result: PASS", format_report(report))
+
+    def test_existing_submission_packages_keep_passing(self) -> None:
+        packages = [
+            path.parent
+            for path in sorted(ROOT.glob("submissions/*/*/manifest.json"))
+        ]
+        if not packages:
+            self.skipTest("no submission packages checked out")
+        for package in packages:
+            with self.subTest(package=package.name):
+                proposal_dir = package.relative_to(ROOT).as_posix()
+                try:
+                    manifest = json.loads((package / "manifest.json").read_text(encoding="utf-8"))
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    continue
+                report = ValidationReport()
+                report.changed_files = [f"{proposal_dir}/proposal.md"]
+                validate_bilingual_display(report, ROOT, proposal_dir, manifest)
+                self.assertEqual([], report.errors)
+                self.assertTrue(report.ok)
+
+    def test_command_line_run_on_an_identical_pair_still_exits_zero(self) -> None:
+        candidates = []
+        for manifest_path in sorted(ROOT.glob("submissions/*/*/manifest.json")):
+            package = manifest_path.parent
+            proposal_dir = package.relative_to(ROOT).as_posix()
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            report = ValidationReport()
+            report.changed_files = [f"{proposal_dir}/proposal.md"]
+            validate_bilingual_display(report, ROOT, proposal_dir, manifest)
+            if self.identical_notices(report):
+                candidates.append((proposal_dir, manifest.get("agent", {})))
+        if not candidates:
+            self.skipTest("no checked-out package carries a byte-identical bilingual pair")
+        proposal_dir, _ = candidates[0]
+        author = proposal_dir.split("/")[1]
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "scripts" / "validate_submission.py"),
+                "--repo-root",
+                str(ROOT),
+                "--pr-author",
+                author,
+                "--changed-file",
+                f"{proposal_dir}/proposal.md",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("byte-identical", completed.stdout)
+        self.assertIn("Result: PASS", completed.stdout)
+        self.assertEqual(0, completed.returncode, completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### 背景

本 PR 认领 #1631 中维护者 @CocoSgt 分流意见的**第 2 项**，只做这一项，不涉及其他信号。

@CocoSgt 在 #1631 的分流意见中写明：

> 中英文件 byte-identical 只能做非阻断提示，不能直接判定"假翻译"：无文字图件可能合法 neutral，PDF/HTML 也可能因内容本身语言中立而复用。若做检查，必须区分 manifest language/translation_of 与 neutral 契约，历史包不追溯失败。

并建议：

> 建议拆成独立 PR，先处理第 1 项；第 2、3 项各自保持 warning/notice 级并提供 legacy 回归。

第 1 项已由 @147228 在 #1655 落地。本 PR 严格按上面这段规格实现第 2 项，第 3 项另开 PR。

我把这段意见理解为三条硬约束，实现时逐条对照：

1. 只能是提示，不能是判定 —— 全部走 `report.add_warning()`；
2. 必须区分三种契约 —— 只看 manifest 声明，声明 `neutral` 的一律跳过；
3. 历史包不追溯失败 —— 提示不参与 `report.ok`，返回码与 PASS/FAIL 判定完全不变。

### 改了什么

`scripts/validate_submission.py` 新增一个函数 `report_identical_bilingual_artifacts()`，在 `validate_bilingual_display()` 的末尾调用一次。改动为纯新增 63 行，没有修改任何既有分支、既有文案或既有判定。

命中条件（四条同时满足才提示）：

- manifest 中该条目声明了 `translation_of`，**或**声明了 `language: "zh"/"en"` 且文件名带对应语言码后缀（如 `site-overview.en.png`）；
- 该条目与其主文件条目**都没有**声明 `language: "neutral"`；
- 两个文件在磁盘上都存在（存在性检查先过，避免和"文件缺失"报错重复）；
- 两个文件字节 sha256 相同。

提示文案给出两条出路，不预设参赛者是哪一种：

```
submissions/<owner>/<pkg>/assets/figures/site-overview.en.png: byte-identical to
`assets/figures/site-overview.png`; if the translation is still missing, replace it with a
rendering in the declared language, and if the file carries no language-specific content,
declare language=neutral once and share it between both versions (see
docs/formal-submission-guide.md); this notice does not block review
```

### 设计说明

**为什么落在 `validate_bilingual_display()` 末尾。** 这个函数是仓库里唯一已经同时持有「proposal.md 的主语言声明」「manifest 条目字典 `manifest_items`」「包根目录 `base`」三样东西的地方，落在这里不需要新增任何数据传递或函数签名改动，也天然继承了它已有的两道入口保护：主稿 front matter 没有 `language: "zh"/"en"` 时函数直接返回；非 strict 契约的包只有在本次 PR 真正改动了展示物料时才会进入。因此历史 v1 单语包和只改机读数据的 PR 完全不会被扫到。

**如何区分三种契约。** 判定只读 manifest 声明，不做任何内容推断：

| manifest 声明 | 同字节时的处置 | 依据 |
| --- | --- | --- |
| 译稿条目有 `translation_of`，主/译条目均非 `neutral` | 出提示 | 声明了"这是译文"，但字节与原件一致，值得参赛者自查 |
| 条目声明 `language: "neutral"` | 不出提示 | `docs/formal-submission-guide.md` 明确"无文字资产可声明 `language: "neutral"` 并由两版共用"，复用是契约内的正当行为 |
| 未声明任何语言契约（v1 单语包） | 不涉及 | 函数在读到主稿 front matter 无 `language` 时即返回 |

无文字图件、语言中立的 PDF/HTML 因此都有一条不需要伪造译文的合法出路：声明一次 `neutral` 即可，符合"不鼓励为了通过检查而制造内容"的取向。

**历史包不追溯失败的保证。** 仓库里 `ValidationReport.ok` 只由 `add_error()` 置为 `False`，`add_warning()` 不触碰它；`main()` 的返回码是 `0 if report.ok else 1`，`format_report()` 的 `Result:` 同样只看 `report.ok`。本 PR 只调用 `add_warning()`，所以不存在任何路径能让它改变判定。这一点不是靠推理，是在仓库现有真实包上实测过的（见下）。

**为什么用 sha256 而不是逐字节读。** 同字节判定复用 manifest 中已声明、且已被 `validate_manifest_file()` 与文件字节比对过的 `sha256`，只有条目没有声明摘要时才回落到实算，正常提交包不产生任何额外文件 IO。

### 测试

新增 `tests/test_bilingual_identical_bytes.py`，9 项（含 3 个 subTest）：

| 用例 | 断言 |
| --- | --- |
| `test_identical_translated_figure_raises_a_single_notice` | en 声明 + 同字节 → 恰好 1 条提示，文案含两条出路与指南链接 |
| `test_neutral_primary_declaration_suppresses_the_notice` | 主件声明 neutral + 同字节 → 不提示 |
| `test_neutral_counterpart_declaration_suppresses_the_notice` | 译件声明 neutral + 同字节 → 不提示 |
| `test_translated_figure_with_different_bytes_is_not_reported` | en 声明 + 不同字节 → 不提示 |
| `test_language_suffix_pair_without_translation_of_is_reported` | 只有 language 后缀、无 `translation_of` → 仍能识别 |
| `test_package_without_declared_language_is_not_inspected` | v1 无双语声明包 → 零 warning 零 error |
| `test_notice_never_changes_the_pass_verdict` | 出提示时 `report.ok` 为真、`format_report()` 仍是 `Result: PASS` |
| `test_existing_submission_packages_keep_passing` | 遍历仓库 `submissions/` 下真实包，逐个断言零 error（legacy 回归） |
| `test_command_line_run_on_an_identical_pair_still_exits_zero` | 直接跑 `scripts/validate_submission.py` 命令行，断言 stdout 含提示、含 `Result: PASS`、返回码为 0 |

存量测试：`python3 -m pytest tests/ -q`，改动前 343 passed / 119 subtests，改动后 352 passed / 122 subtests，**失败集合完全一致**（本地沙箱固有的 8 项：缺 Arial Unicode 字体 1 项、稀疏检出导致的 prelaunch/gallery 7 项，与本 PR 无关，改动前后同样失败）。

在真实包 `submissions/weijunlv/jingzhang-ai-pulse`（5 对图件同字节）上跑命令行校验，改动前后对比只多出 5 行 warning，`Result: PASS`、退出码 `0` 均不变；`submissions/2830500285/jingzhang-open-loop` 中已声明 `neutral` 的 5 个条目正确不提示，只对 2 个 PDF 出提示且同样 PASS；`submissions/lifecoder1988/jingzhang-ai-corridor` 零提示，与 @lifecoder1988 在 #1631 中给出的实测数据点一致。

### 明确不改变的东西

- **不改变任何既有包的通过判定**：本 PR 只新增 `add_warning()` 调用，不新增、不修改、不降级任何 `add_error()`；任何一个今天能通过校验的包，改动后仍然通过，返回码不变。
- 不改动中文输出、渲染器、评分、gallery 索引、投稿包内容。
- 不改动空 constraints 的兼容边界（#1631 第 3 项，另开 PR）。
- 不据此重评或退回任何既有投稿。

### 致谢

感谢 @CocoSgt 的分流意见，"不能直接判定假翻译"和"必须区分 neutral 契约"这两条把这个检查从一个容易误伤的 gate 拉回到了正确的量级，本 PR 基本是照着这段话写的。感谢 @lifecoder1988 提供 `jingzhang-ai-corridor` 的逐对 sha256 实测数据，它同时给了我一个真实的"正常双语包不应被提示"的验证样本。感谢 @147228 在 #1655 中先行落地第 1 项。

如果维护者认为提示文案、命中范围或落点还需要调整，我按意见改；如果已有实现计划，我让路。