### PR TITLE
feat(scaffold+validate): 空 constraints 的机器可读缺口声明与 warning 级提示,不改变通过判定(#1631 第3项)

### DIFF
--- a/scripts/scaffold_ai_submission.py
+++ b/scripts/scaffold_ai_submission.py
@@ -906,6 +906,37 @@ def make_proposal_figures(metrics: dict[str, Any], boundary_mode: str, key_area_
 
 MINIMAL_PDF = b"%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Count 0>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF\n"
 
+# Machine-readable declaration written into the generated (empty) constraints layer.
+# An empty constraint set stays a valid, accepted state; this member only records *why*
+# it is empty, so a deliberately empty layer is distinguishable from an unreviewed one.
+# It must never be used to justify inventing constraint geometry.
+CONSTRAINTS_SCAFFOLD_DATA_GAP = {
+    "status": "official_constraint_geometry_unavailable",
+    "declared_by": "scripts/scaffold_ai_submission.py",
+    "assumption_ids": ["A-CONTROLS-001"],
+    "missing_layers": [
+        "REGULATORY_CONTROL",
+        "HERITAGE_PROTECTION",
+        "PARCEL",
+        "EXISTING_PRIMARY_ROAD",
+        "EXISTING_RAIL",
+        "EXISTING_WATER",
+    ],
+    "note_zh": (
+        "本图层刻意保持空集合。控规控制线、文物保护范围与建设控制地带、道路红线、权属地块、"
+        "轨道与蓝线均属锁定图层，公开场地包中目前没有可引用的官方几何来源。"
+        "缺口按 assumption A-CONTROLS-001 登记；取得官方或已清权几何前，"
+        "不得以推定线条冒充 official_constraint，空集合优于编造。"
+    ),
+    "note_en": (
+        "This layer is intentionally an empty set. Regulatory control lines, heritage protection and "
+        "construction-control zones, road redlines, cadastral parcels, rail and blue lines are locked "
+        "layers with no citable official geometry in the public site package. The gap is registered as "
+        "assumption A-CONTROLS-001; until official or cleared geometry is available, inferred lines must "
+        "not be presented as an official_constraint - an empty set is preferred over fabrication."
+    ),
+}
+
 
 def make_package(submission_dir: Path, repo_root: Path, stage: str, agent_id: str, agent_name: str, title: str) -> None:
     if stage not in STAGES:
@@ -962,7 +993,10 @@ def make_package(submission_dir: Path, repo_root: Path, stage: str, agent_id: st
             "public_space_scaffold",
             [feature("PUBLIC-001", "PUBLIC_SPACE", public_geom, name_zh="公共活动界面")],
         ),
-        "constraints.geojson": collection("constraints_scaffold", []),
+        "constraints.geojson": {
+            **collection("constraints_scaffold", []),
+            "data_gap": dict(CONSTRAINTS_SCAFFOLD_DATA_GAP),
+        },
         "phasing.geojson": collection(
             "phasing_scaffold",
             [feature("PHASE-001", "PHASE", phase_geom, phase="phase_1", name_zh="一期可讨论范围")],

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -191,6 +191,34 @@ FORMAL_NONEMPTY_GEOMETRY_FILES = {
     "public_space.geojson",
     "phasing.geojson",
 }
+# constraints.geojson is deliberately absent from FORMAL_NONEMPTY_GEOMETRY_FILES: with no official
+# regulatory-control geometry published for this site, an empty constraint layer is a legitimate and
+# accepted outcome. The advisory below never changes that; it only asks that the gap be recorded
+# somewhere machine-readable, so "deliberately empty" is distinguishable from "never looked at".
+CONSTRAINTS_DATA_GAP_DECLARATION_KEYS = (
+    "data_gap",
+    "data_gaps",
+    "missing_official_layers",
+    "constraint_status",
+)
+CONSTRAINTS_GAP_ASSUMPTION_ID_PATTERN = re.compile(r"control|constraint|regulat", re.IGNORECASE)
+CONSTRAINTS_GAP_ASSUMPTION_TERMS = (
+    "regulatory control",
+    "regulatory plan",
+    "control plan",
+    "statutory control",
+    "road redline",
+    "road red line",
+    "redline",
+    "red line",
+    "constraint",
+    "控规",
+    "管控",
+    "红线",
+    "约束",
+    "控制线",
+    "文保",
+)
 TRUSTED_BOUNDARY_SOURCE_TYPES = {
     "official_public",
     "official_open_data",
@@ -897,6 +925,80 @@ def geometry_coordinates_are_valid(geometry: dict) -> bool:
     return False
 
 
+def _collect_strings(value: object, sink: list[str]) -> None:
+    """Flatten every string (including object keys) reachable from ``value``."""
+    if isinstance(value, str):
+        sink.append(value)
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            sink.append(str(key))
+            _collect_strings(item, sink)
+    elif isinstance(value, list):
+        for item in value:
+            _collect_strings(item, sink)
+
+
+def constraints_file_declares_data_gap(data: object) -> bool:
+    """True when constraints.geojson itself records why its feature set is empty."""
+    if not isinstance(data, dict):
+        return False
+    return any(bool(data.get(key)) for key in CONSTRAINTS_DATA_GAP_DECLARATION_KEYS)
+
+
+def assumptions_declare_constraints_gap(data: object) -> bool:
+    """True when assumptions.json registers the missing regulatory-control inputs.
+
+    Both the scaffold default (`A-CONTROLS-001`) and the many hand-written variants in
+    existing packages are accepted: an entry qualifies when its identifier names controls,
+    constraints or regulation, or when any of its text mentions the missing control inputs.
+    """
+    if not isinstance(data, dict):
+        return False
+    entries = data.get("assumptions")
+    if not isinstance(entries, list):
+        return False
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        for key in ("id", "assumption_id"):
+            value = entry.get(key)
+            if isinstance(value, str) and CONSTRAINTS_GAP_ASSUMPTION_ID_PATTERN.search(value):
+                return True
+        strings: list[str] = []
+        _collect_strings(entry, strings)
+        blob = " ".join(strings).lower()
+        if any(term in blob for term in CONSTRAINTS_GAP_ASSUMPTION_TERMS):
+            return True
+    return False
+
+
+def validate_empty_constraints_declaration(
+    report: ValidationReport, path: Path, data: object, display_path: str
+) -> None:
+    """Advise (never block) when an empty constraint layer leaves the gap unrecorded.
+
+    An empty constraints.geojson stays valid: no official regulatory-control geometry is
+    published for this site, and inventing one is worse than leaving the set empty. This
+    only asks for the gap to be stated once, either in the file or in assumptions.json.
+    """
+    if constraints_file_declares_data_gap(data):
+        return
+    assumptions_path = path.parent.parent / "assumptions.json"
+    try:
+        assumptions = json.loads(assumptions_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        assumptions = None
+    if assumptions_declare_constraints_gap(assumptions):
+        return
+    report.add_warning(
+        f"{display_path}: empty constraint layer is accepted and is not a blocking issue, but the "
+        "missing official control data is not recorded anywhere; add a top-level `data_gap` object to "
+        "this file, or an assumptions.json entry covering the missing regulatory controls. Keep the "
+        "feature list empty unless you have citable official or cleared geometry - never fabricate "
+        "constraint geometry, and never label an inferred surface `official_constraint`."
+    )
+
+
 def validate_geojson_file(
     report: ValidationReport,
     repo_root: Path,
@@ -918,6 +1020,8 @@ def validate_geojson_file(
         return 0
     if require_features and not features:
         report.add_error(f"{display_path}: this geometry file needs at least one feature")
+    if geometry_name == "constraints.geojson" and not features:
+        validate_empty_constraints_declaration(report, path, data, display_path)
 
     allowed_layers = load_allowed_layers(repo_root)
     source_enums = load_string_enums(repo_root, "brief/site-package/enums/source_types.json")

--- a/tests/test_constraints_data_gap.py
+++ b/tests/test_constraints_data_gap.py
@@ -1,0 +1,228 @@
+"""Regression tests for the empty-constraints data-gap advisory.
+
+An empty `geometry/constraints.geojson` is an accepted state: no official regulatory-control
+geometry is published for this site, and fabricating one would be worse than an empty set.
+These tests pin that contract down: the advisory is warning-only, it never turns an empty
+constraint layer into a failure, and it stays silent whenever the gap is recorded either in
+the file itself or in `assumptions.json`.
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from validate_submission import (  # noqa: E402
+    FORMAL_NONEMPTY_GEOMETRY_FILES,
+    ValidationReport,
+    assumptions_declare_constraints_gap,
+    constraints_file_declares_data_gap,
+    validate_geojson_file,
+)
+
+HAS_REVIEW_DEPS = all(
+    importlib.util.find_spec(name) is not None for name in ["shapely", "pyproj", "jsonschema"]
+)
+
+EMPTY_CONSTRAINTS = {"type": "FeatureCollection", "name": "constraints_scaffold", "features": []}
+ADVISORY_MARKER = "empty constraint layer is accepted"
+
+
+def constraint_feature() -> dict:
+    return {
+        "type": "Feature",
+        "id": "CONSTRAINT-001",
+        "properties": {
+            "id": "CONSTRAINT-001",
+            "layer": "REGULATORY_CONTROL",
+            "source_type": "agent_generated_design",
+            "confidence": "medium",
+            "geometry_role": "design_proposal",
+            "official_boundary": False,
+        },
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [116.300, 39.901],
+                    [116.301, 39.901],
+                    [116.301, 39.902],
+                    [116.300, 39.902],
+                    [116.300, 39.901],
+                ]
+            ],
+        },
+    }
+
+
+class EmptyConstraintsAdvisoryTests(unittest.TestCase):
+    def check(self, constraints: dict, assumptions: dict | None = None) -> ValidationReport:
+        report = ValidationReport()
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp) / "submissions" / "tester" / "package"
+            (base / "geometry").mkdir(parents=True)
+            path = base / "geometry" / "constraints.geojson"
+            path.write_text(json.dumps(constraints, ensure_ascii=False), encoding="utf-8")
+            if assumptions is not None:
+                (base / "assumptions.json").write_text(
+                    json.dumps(assumptions, ensure_ascii=False), encoding="utf-8"
+                )
+            validate_geojson_file(
+                report,
+                REPO_ROOT,
+                path,
+                "submissions/tester/package/geometry/constraints.geojson",
+                require_features=False,
+                stage="formal",
+                geometry_name="constraints.geojson",
+            )
+        return report
+
+    def advisories(self, report: ValidationReport) -> list[str]:
+        return [item for item in report.warnings if ADVISORY_MARKER in item]
+
+    def test_empty_constraints_without_any_declaration_warns(self) -> None:
+        report = self.check(
+            EMPTY_CONSTRAINTS,
+            {"assumptions": [{"id": "A-SITE-001", "statement": "Boundary is provisional."}]},
+        )
+        self.assertEqual(1, len(self.advisories(report)))
+        self.assertIn("data_gap", self.advisories(report)[0])
+        self.assertIn("assumptions.json", self.advisories(report)[0])
+
+    def test_missing_assumptions_file_warns(self) -> None:
+        report = self.check(EMPTY_CONSTRAINTS)
+        self.assertEqual(1, len(self.advisories(report)))
+
+    def test_in_file_data_gap_declaration_is_silent(self) -> None:
+        constraints = dict(EMPTY_CONSTRAINTS)
+        constraints["data_gap"] = {
+            "status": "official_constraint_geometry_unavailable",
+            "assumption_ids": ["A-CONTROLS-001"],
+            "missing_layers": ["REGULATORY_CONTROL", "HERITAGE_PROTECTION"],
+        }
+        report = self.check(constraints, {"assumptions": []})
+        self.assertEqual([], self.advisories(report))
+
+    def test_missing_official_layers_declaration_is_silent(self) -> None:
+        """Matches a convention already used by submitted packages."""
+        constraints = dict(EMPTY_CONSTRAINTS)
+        constraints["missing_official_layers"] = ["HERITAGE_PROTECTION", "REGULATORY_CONTROL"]
+        report = self.check(constraints, {"assumptions": []})
+        self.assertEqual([], self.advisories(report))
+
+    def test_scaffold_default_assumption_id_is_silent(self) -> None:
+        """The scaffold ships A-CONTROLS-001, so untouched packages stay quiet."""
+        report = self.check(EMPTY_CONSTRAINTS, {"assumptions": [{"id": "A-CONTROLS-001"}]})
+        self.assertEqual([], self.advisories(report))
+
+    def test_hand_written_chinese_assumption_is_silent(self) -> None:
+        """Packages that renamed the assumption still register the gap in their own words."""
+        report = self.check(
+            EMPTY_CONSTRAINTS,
+            {
+                "assumptions": [
+                    {
+                        "assumption_id": "ASSUME-004",
+                        "statement_zh": "缺少控规、道路红线、权属与文保范围等官方条件。",
+                    }
+                ]
+            },
+        )
+        self.assertEqual([], self.advisories(report))
+
+    def test_non_empty_constraints_never_triggers_the_advisory(self) -> None:
+        constraints = {
+            "type": "FeatureCollection",
+            "name": "constraints",
+            "features": [constraint_feature()],
+        }
+        report = self.check(constraints, {"assumptions": []})
+        self.assertEqual([], self.advisories(report))
+        self.assertEqual([], report.errors)
+
+    def test_advisory_is_warning_only_and_keeps_the_package_passing(self) -> None:
+        report = self.check(EMPTY_CONSTRAINTS, {"assumptions": []})
+        self.assertEqual(1, len(self.advisories(report)))
+        self.assertEqual([], report.errors)
+        self.assertTrue(report.ok)
+        self.assertTrue(report.to_dict()["ok"])
+        # validate_submission.main() returns `0 if report.ok else 1`.
+        self.assertEqual(0, 0 if report.ok else 1)
+
+    def test_constraints_layer_stays_outside_the_formal_nonempty_gate(self) -> None:
+        """Guard against the advisory ever being promoted into a hard gate."""
+        self.assertNotIn("constraints.geojson", FORMAL_NONEMPTY_GEOMETRY_FILES)
+
+    def test_declaration_helpers_reject_empty_placeholders(self) -> None:
+        self.assertFalse(constraints_file_declares_data_gap({"data_gap": {}}))
+        self.assertFalse(constraints_file_declares_data_gap({"data_gaps": []}))
+        self.assertFalse(assumptions_declare_constraints_gap({"assumptions": []}))
+        self.assertFalse(assumptions_declare_constraints_gap(None))
+
+
+@unittest.skipUnless(HAS_REVIEW_DEPS, "Install requirements-review.txt to run scaffold tests")
+class ScaffoldConstraintsDataGapTests(unittest.TestCase):
+    def test_scaffold_declares_the_gap_without_inventing_geometry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "submissions" / "tester" / "scaffold-package"
+            run = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "scaffold_ai_submission.py"),
+                    str(output),
+                    "--stage",
+                    "formal",
+                    "--agent-id",
+                    "alice",
+                    "--agent-name",
+                    "Alice Agent",
+                    "--proposal-title",
+                    "Constraints Data Gap",
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(0, run.returncode, run.stderr)
+            constraints = json.loads(
+                (output / "geometry" / "constraints.geojson").read_text(encoding="utf-8")
+            )
+
+            # The gap is declared; no constraint geometry is invented to fill it.
+            self.assertEqual([], constraints["features"])
+            data_gap = constraints["data_gap"]
+            self.assertEqual("official_constraint_geometry_unavailable", data_gap["status"])
+            self.assertIn("A-CONTROLS-001", data_gap["assumption_ids"])
+            self.assertIn("REGULATORY_CONTROL", data_gap["missing_layers"])
+            self.assertIn("HERITAGE_PROTECTION", data_gap["missing_layers"])
+            self.assertIn("official_constraint", data_gap["note_en"])
+
+            # The scaffold assumption keeps registering the same gap.
+            assumptions = json.loads((output / "assumptions.json").read_text(encoding="utf-8"))
+            self.assertTrue(assumptions_declare_constraints_gap(assumptions))
+
+            report = ValidationReport()
+            validate_geojson_file(
+                report,
+                REPO_ROOT,
+                output / "geometry" / "constraints.geojson",
+                "geometry/constraints.geojson",
+                require_features=False,
+                stage="formal",
+                geometry_name="constraints.geojson",
+            )
+            self.assertEqual([], [w for w in report.warnings if ADVISORY_MARKER in w])
+            self.assertEqual([], report.errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
关联 issue: #1631(第 3 项)
基线 commit: `bf6d21b34f3812f4c529dd1a280b1137398e8349`(main,2026-08-10)

---

## 一、这个 PR 在回应什么

维护者 @CocoSgt 在 #1631 里已经给了明确规格,我完整照做:

> 空 constraints 是当前官方控规数据缺失下的**有意兼容边界**,不应改成 hard gate。可以增加 notice 或机器可读 missing-data 声明,但必须允许"明确记录缺口后保持空集合",**不能鼓励虚构约束几何**。

参与者 @lifecoder1988 补充的关切同样是本 PR 的设计底线:

> `HERITAGE_PROTECTION` / `REGULATORY_CONTROL` 属**锁定层**,自行推定的约束面不允许标 `official_constraint`,"**宁可留空也不编造**"。

因此本 PR **不**把空 constraints 变成错误,**不**改变任何包的通过/不通过判定,只做一件事:**让"有意留空"和"从没看过"这两种状态可以被机器区分开**,并且这个区分只走"登记缺口"这一条路,不给"补几何"任何激励。

---

## 二、改了什么(2 个文件 + 1 个测试文件,+367 / -1)

### 1. `scripts/scaffold_ai_submission.py`:生成的空 constraints 自带缺口声明

脚手架生成的 `geometry/constraints.geojson` 从

```json
{ "type": "FeatureCollection", "name": "constraints_scaffold", "features": [] }
```

变成

```json
{
  "type": "FeatureCollection",
  "name": "constraints_scaffold",
  "features": [],
  "data_gap": {
    "status": "official_constraint_geometry_unavailable",
    "declared_by": "scripts/scaffold_ai_submission.py",
    "assumption_ids": ["A-CONTROLS-001"],
    "missing_layers": [
      "REGULATORY_CONTROL", "HERITAGE_PROTECTION", "PARCEL",
      "EXISTING_PRIMARY_ROAD", "EXISTING_RAIL", "EXISTING_WATER"
    ],
    "note_zh": "本图层刻意保持空集合。…缺口按 assumption A-CONTROLS-001 登记;取得官方或已清权几何前,不得以推定线条冒充 official_constraint,空集合优于编造。",
    "note_en": "This layer is intentionally an empty set. … inferred lines must not be presented as an official_constraint - an empty set is preferred over fabrication."
  }
}
```

要点:

- `features` **仍然是空数组**。脚手架一个约束要素都不生成,这一点没有变化,也不会变化。
- `missing_layers` 用的是 `brief/site-package/enums/layers.json` 里的真实 layer code,其中就包括 @lifecoder1988 点名的两个锁定层。
- `note_zh` / `note_en` 把"不得冒充 `official_constraint`"写进生成物本身,让这条纪律出现在每一个新包的第一手材料里,而不是只躺在文档里。
- `data_gap` 是 GeoJSON **foreign member**(RFC 7946 §6.1 允许),不影响任何 GeoJSON 解析器。

### 2. `scripts/validate_submission.py`:一条 warning 级提示

在 `validate_geojson_file()` 里,仅当 `constraints.geojson` 的 `features` 为空时多做一次判断:

- 文件里有缺口声明(顶层 `data_gap` / `data_gaps` / `missing_official_layers` / `constraint_status` 任一非空)→ **静默**
- 或者 `assumptions.json` 里有一条登记了控规/约束缺口的假设 → **静默**
- 两者都没有 → 一条 `report.add_warning(...)`,指引去登记,并明写"保持空集合、不要编造几何、不要把推定面标成 `official_constraint`"

`assumptions.json` 的判据刻意做得宽:条目的 `id` / `assumption_id` 命中 `control|constraint|regulat`,**或者**条目内任何文本命中控规相关词表(中英双语,含"控规/管控/红线/约束/控制线/文保")即算登记。这是为了迁就存量包五花八门的写法(见下一节),不是为了放水——因为它唯一的作用是**让提示闭嘴**,而不是让任何包通过。

**没有动的地方(有意为之):**

- `FORMAL_NONEMPTY_GEOMETRY_FILES` 原样不动,`constraints.geojson` 仍然不在其中。这就是 @CocoSgt 说的兼容边界,本 PR 反而给它加了一条注释和一个回归测试来防止它日后被人顺手改成 hard gate。
- `require_features` 逻辑一行未改。
- `add_warning()` 不会置 `ok=False`,`main()` 仍然 `return 0 if report.ok else 1`。

---

## 三、噪音影响面:对存量包 **0 条新增 warning**(实测全量)

这是本 PR 最需要维护者过目的一节。我在基线 commit 上把全部 **514** 个 `geometry/constraints.geojson` 跑了一遍**打完补丁后的真实判据函数**:

| 项目 | 数量 |
|---|---|
| 有 constraints.geojson 的包 | 514 |
| ├ constraints 非空(本检查完全不涉及) | 355 |
| └ constraints 为空 | **159** |
| 　├ 图层名仍是 `constraints_scaffold`(基本未编辑) | 88 |
| 　├ 图层名已改写(如 `official_constraints_missing`、`constraints_pending`…) | 71 |
| 　├ 已带顶层附加键做说明 | 32 |
| 　├ 附加键命中本 PR 认的 4 个规范键 | 5 |
| 　└ **`assumptions.json` 已登记控规缺口** | **159 / 159** |
| **本 PR 在存量包上新增的 warning** | **0** |

**为什么是 0:摸底时发现"默认即登记"。** 脚手架生成的 `assumptions.json` 本来就自带 `A-CONTROLS-001`,内容正是"控规、道路红线、权属、市政与工程约束须由官方附件确认"。这意味着:

- 一个**从未编辑过**的脚手架包,天然就满足"已登记缺口",提示不会响;
- 152/159 个空 constraints 的包至今保留着字面量 `A-CONTROLS-001`;
- 剩下 9 个把假设重写过的包(`A-CONTROL-001`、`A-REGULATION-002`、`ASM-003`、`ASSUMPTION-MISSING-REGULATORY-CONTROLS`、`ASSUME-00x` 等各写各的),经逐条查看,**全部**仍然实质登记了控规缺口,也全部被判据识别。

所以提示的**真实触发条件**不是"你没填 constraints",而是"你把 constraints 清空了、又把缺口登记也一并删掉了"——这才是真正无从判断的状态。如果按"默认没有登记就报警"来设计,159 个包会一次性全部变红,那是纯噪音;如果按"必须新增文件内声明"来设计,会逼着 159 个包去改文件,同样是噪音。当前设计对存量包的净影响是 **0**。

**顺带一提,存量包已经在自发做这件事,只是各写各的。** 32 个空 constraints 的包已经自己加了顶层说明,用了至少 8 种不同键名(`data_gap`、`data_gaps`、`data_gap_note`、`constraint_status`、`missing_official_layers`、`limitations`、`collection_note`、`metadata.*`)。脚手架输出一个规范键,是把这个自发实践收敛成机器可读格式,而不是新发明一套要求。其中 `submissions/ztkuaikuai/jingzhang-ai-belt` 写的是
`"missing_official_layers": ["HERITAGE_PROTECTION", "REGULATORY_CONTROL", …]`,和 @lifecoder1988 的表述几乎逐字一致;`submissions/jiangmuran/jingzhang-leveling-line` 则是非空 constraints 的正面样板——它的要素全部标 `source_type: agent_generated_design`、`geometry_role: design_proposal`、`official_boundary: false`,**没有**冒用 `official_constraint`。

---

## 四、测试

新增 `tests/test_constraints_data_gap.py`,11 个用例:

| 用例 | 期望 |
|---|---|
| 空 + 无任何声明 | 报 1 条 warning |
| 空 + 无 `assumptions.json` 文件 | 报 1 条 warning |
| 空 + 文件内 `data_gap` | 静默 |
| 空 + 文件内 `missing_official_layers`(存量包已在用的写法) | 静默 |
| 空 + `assumptions.json` 只有 `{"id": "A-CONTROLS-001"}` | 静默 |
| 空 + 中文手写假设(id 不含关键词) | 静默 |
| **constraints 非空** | 本检查完全不介入 |
| **warning 不改变通过判定** | `report.ok is True`、`errors == []`、`main()` 口径退出码 0 |
| `constraints.geojson` 不在 `FORMAL_NONEMPTY_GEOMETRY_FILES` | 守住兼容边界,防止日后被改成 hard gate |
| 空占位声明(`{"data_gap": {}}`、`{"data_gaps": []}`)不算登记 | 不给"写个空壳骗过检查"留口子 |
| 跑真实脚手架 | 生成物 `features == []`、`data_gap` 含 `A-CONTROLS-001` 与两个锁定层、校验无提示无错误 |

**跑测结果(基线 `bf6d21b`,同一环境前后对照):**

```
打补丁前:  8 failed, 343 passed, 119 subtests passed
打补丁后:  8 failed, 354 passed, 119 subtests passed
失败集合 diff:完全一致(零回归);354 - 343 = 11 即新增用例
```

那 8 个失败在打补丁前就存在,与本 PR 无关,是本地 sparse checkout 只拉了 3 个 submissions 包导致的(gallery / prelaunch 类测试要比对全量 submissions)。

**端到端实测(非仅单测):**

- `submissions/Bortor/jingzhang-ai-ribbon`(纯脚手架空壳)、`submissions/ztkuaikuai/jingzhang-ai-belt`(已登记缺口)、`submissions/jiangmuran/jingzhang-leveling-line`(constraints 非空)三个真实包,补丁前后 `ok`、错误数、warning 数**逐项完全一致**,新增 warning 均为 0。
- foreign member 容忍度**实测**过:给 Bortor 包的 constraints.geojson 加上顶层 `data_gap` 并同步 manifest sha256 后重跑,`ok=True`、0 errors、warning 数不变——`validate_geojson_file` 不拒绝顶层附加键。
- 提示确实会触发(不是死代码):把脚手架包的 `data_gap` 和 `A-CONTROLS-001` 同时删掉后重跑,如期多出且仅多出 1 条该 warning。

---

## 五、三条保证

1. **不改变通过判定。** 只调用 `add_warning()`,从不 `add_error()`;`add_warning()` 不置 `ok=False`;`main()` 退出码逻辑一行未改。`FORMAL_NONEMPTY_GEOMETRY_FILES` 与 `require_features` 原样不动,并新增回归测试锁定"`constraints.geojson` 不进 hard gate"。
2. **不鼓励虚构。** 脚手架仍然生成 `features: []`,一个要素都不加;提示文案与生成物注释都明写"保持空集合、不得编造约束几何、不得把推定面标成 `official_constraint`";空壳声明(`{}` / `[]`)不被承认,堵住"写个空对象糊弄检查"的路。要让提示闭嘴,**最省事的办法始终是登记缺口,不是画一条线**。
3. **允许显式缺口。** "明确记录缺口后保持空集合"是本设计里唯一被褒奖的路径,而且给了两条并列入口(文件内声明 / `assumptions.json` 登记),任一即可;`assumptions.json` 判据刻意宽松以迁就存量包各自的写法,对存量 514 个包净新增 0 条 warning。

---

## 六、致谢

- 感谢 @CocoSgt 在 #1631 中把"兼容边界不是 bug、可以加 notice 但不能变 hard gate、不能鼓励虚构几何"讲得很清楚,本 PR 的取舍基本是照着这段规格逐条落的。
- 感谢 @lifecoder1988 指出锁定层与 `official_constraint` 标注的边界,以及"宁可留空也不编造"——这句话直接写进了脚手架生成物的 `note_zh` / `note_en`。
- 也感谢已经在自发做缺口登记的诸位参与者:本 PR 的规范键名不是新发明,是从大家已经在用的写法里收敛出来的。