### PR TITLE
fix(review): apply score preservation guard to current main

### DIFF
--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -280,17 +280,14 @@ SHA 复核和 merge 使用进程内锁串行执行，避免 Git 引用锁和 bas
 
 ### 分数保护与恢复
 
-`--apply` 在决定合并前，会读取 `docs/trusted-score-high-water.json` 中的维护者登记值，并与该投稿作者已合并 PR 中由显式 trusted reviewer allowlist
-提交、状态为 `APPROVED` 且带有 `haidian-auto-review:<exact-head-sha>` 标记的维护者 Review Agent 评论，并按投稿目录计算
-历史官方最高分。两条来源取较高值；登记表用于在 GitHub 历史 API 限流、分页或历史 PR 被压缩时保留恢复线，不能由投稿分支运行时写入。新 exact head 的分数低于该最高分时，worker 会发布
+`--apply` 在决定合并前，会读取该投稿作者已合并 PR 中带有
+`haidian-auto-review:<exact-head-sha>` 标记的维护者 Review Agent 评论，并按投稿目录计算
+历史官方最高分。新 exact head 的分数低于该最高分时，worker 会发布
 `score-preservation hold`、请求修改并保持 PR 不合并；达到或超过最高分才有资格继续走
 原有 intake 合并流程。没有历史官方分数的首个投稿不受这条比较规则阻塞，但仍必须通过
 60 分绝对门槛、四项 gate 和强制退件检查。
 
-这条保护还会校验 review 的 `state=APPROVED` 与 reviewer login。当前已登记的官方 intake
-reviewer 是 `CocoSgt` 和 `wakenmeng`；维护者轮换时通过 `HAIDIAN_TRUSTED_REVIEWERS`（逗号分隔的
-GitHub login allowlist）更新 worker 配置。普通贡献者、`CHANGES_REQUESTED` 评论、草稿或
-正文中单独伪造 marker 的评论都不会建立历史分数。它不把本地自检、advisory scorer 或
+这条保护只依据 exact-head 的官方维护者评论，不把本地自检、advisory scorer、草稿或
 公共 gallery 位置当作正式分数。若历史最高包已经被更低分版本覆盖，维护者应从历史
 exact head 建立恢复 PR，并在新的 exact head 重新评分达到原最高分前保持候选不合并；不
 使用 force-push 或重写 `main`。

--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -280,14 +280,17 @@ SHA 复核和 merge 使用进程内锁串行执行，避免 Git 引用锁和 bas
 
 ### 分数保护与恢复
 
-`--apply` 在决定合并前，会读取该投稿作者已合并 PR 中带有
-`haidian-auto-review:<exact-head-sha>` 标记的维护者 Review Agent 评论，并按投稿目录计算
+`--apply` 在决定合并前，会读取该投稿作者已合并 PR 中由显式 trusted reviewer allowlist
+提交、状态为 `APPROVED` 且带有 `haidian-auto-review:<exact-head-sha>` 标记的维护者 Review Agent 评论，并按投稿目录计算
 历史官方最高分。新 exact head 的分数低于该最高分时，worker 会发布
 `score-preservation hold`、请求修改并保持 PR 不合并；达到或超过最高分才有资格继续走
 原有 intake 合并流程。没有历史官方分数的首个投稿不受这条比较规则阻塞，但仍必须通过
 60 分绝对门槛、四项 gate 和强制退件检查。
 
-这条保护只依据 exact-head 的官方维护者评论，不把本地自检、advisory scorer、草稿或
+这条保护还会校验 review 的 `state=APPROVED` 与 reviewer login。默认 trusted reviewer 是
+当前官方 intake bot `CocoSgt`；维护者轮换时通过 `HAIDIAN_TRUSTED_REVIEWERS`（逗号分隔的
+GitHub login allowlist）更新 worker 配置。普通贡献者、`CHANGES_REQUESTED` 评论、草稿或
+正文中单独伪造 marker 的评论都不会建立历史分数。它不把本地自检、advisory scorer 或
 公共 gallery 位置当作正式分数。若历史最高包已经被更低分版本覆盖，维护者应从历史
 exact head 建立恢复 PR，并在新的 exact head 重新评分达到原最高分前保持候选不合并；不
 使用 force-push 或重写 `main`。

--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -287,8 +287,8 @@ SHA 复核和 merge 使用进程内锁串行执行，避免 Git 引用锁和 bas
 原有 intake 合并流程。没有历史官方分数的首个投稿不受这条比较规则阻塞，但仍必须通过
 60 分绝对门槛、四项 gate 和强制退件检查。
 
-这条保护还会校验 review 的 `state=APPROVED` 与 reviewer login。默认 trusted reviewer 是
-当前官方 intake bot `CocoSgt`；维护者轮换时通过 `HAIDIAN_TRUSTED_REVIEWERS`（逗号分隔的
+这条保护还会校验 review 的 `state=APPROVED` 与 reviewer login。当前已登记的官方 intake
+reviewer 是 `CocoSgt` 和 `wakenmeng`；维护者轮换时通过 `HAIDIAN_TRUSTED_REVIEWERS`（逗号分隔的
 GitHub login allowlist）更新 worker 配置。普通贡献者、`CHANGES_REQUESTED` 评论、草稿或
 正文中单独伪造 marker 的评论都不会建立历史分数。它不把本地自检、advisory scorer 或
 公共 gallery 位置当作正式分数。若历史最高包已经被更低分版本覆盖，维护者应从历史

--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -280,9 +280,9 @@ SHA 复核和 merge 使用进程内锁串行执行，避免 Git 引用锁和 bas
 
 ### 分数保护与恢复
 
-`--apply` 在决定合并前，会读取该投稿作者已合并 PR 中由显式 trusted reviewer allowlist
+`--apply` 在决定合并前，会读取 `docs/trusted-score-high-water.json` 中的维护者登记值，并与该投稿作者已合并 PR 中由显式 trusted reviewer allowlist
 提交、状态为 `APPROVED` 且带有 `haidian-auto-review:<exact-head-sha>` 标记的维护者 Review Agent 评论，并按投稿目录计算
-历史官方最高分。新 exact head 的分数低于该最高分时，worker 会发布
+历史官方最高分。两条来源取较高值；登记表用于在 GitHub 历史 API 限流、分页或历史 PR 被压缩时保留恢复线，不能由投稿分支运行时写入。新 exact head 的分数低于该最高分时，worker 会发布
 `score-preservation hold`、请求修改并保持 PR 不合并；达到或超过最高分才有资格继续走
 原有 intake 合并流程。没有历史官方分数的首个投稿不受这条比较规则阻塞，但仍必须通过
 60 分绝对门槛、四项 gate 和强制退件检查。

--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -265,7 +265,7 @@ export HAIDIAN_REVIEW_MODEL="gpt-5.6-sol"
 # 先评审并生成审计材料，不修改 GitHub
 python3 scripts/auto_review_queue.py --limit 10
 
-# 正式回写 review/label；通过 60 分门槛和四项 gate 的 PR 自动合并
+# 正式回写 review/label；通过 60 分门槛、四项 gate 且不低于历史最高分的 PR 自动合并
 python3 scripts/auto_review_queue.py --limit 10 --concurrency 3 --apply --admin-merge
 ```
 
@@ -277,6 +277,20 @@ PR 不调用模型；draft 不进入队列。合并仅表示仓库 intake，展�
 worker 每轮按 PR 编号从旧到新处理，避免持续新增投稿使早期稿件饥饿。
 模型调用和本地视觉检查默认三路并行；worktree 创建/清理以及 GitHub review、标签、
 SHA 复核和 merge 使用进程内锁串行执行，避免 Git 引用锁和 base-branch merge 竞态。
+
+### 分数保护与恢复
+
+`--apply` 在决定合并前，会读取该投稿作者已合并 PR 中带有
+`haidian-auto-review:<exact-head-sha>` 标记的维护者 Review Agent 评论，并按投稿目录计算
+历史官方最高分。新 exact head 的分数低于该最高分时，worker 会发布
+`score-preservation hold`、请求修改并保持 PR 不合并；达到或超过最高分才有资格继续走
+原有 intake 合并流程。没有历史官方分数的首个投稿不受这条比较规则阻塞，但仍必须通过
+60 分绝对门槛、四项 gate 和强制退件检查。
+
+这条保护只依据 exact-head 的官方维护者评论，不把本地自检、advisory scorer、草稿或
+公共 gallery 位置当作正式分数。若历史最高包已经被更低分版本覆盖，维护者应从历史
+exact head 建立恢复 PR，并在新的 exact head 重新评分达到原最高分前保持候选不合并；不
+使用 force-push 或重写 `main`。
 
 `submission-validation` 成功时会自动清除旧的 CI/修改/低质量标签并添加
 `review/queued`；投稿人推送修订后无需维护者手动重新排队。CI 失败时 workflow

--- a/docs/trusted-score-high-water.json
+++ b/docs/trusted-score-high-water.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 1,
+  "description": "Maintainer-curated trusted Review Agent score high-water marks. Each entry is backed by an approved exact-head intake review on a merged PR; this ledger is a fail-closed recovery aid, not a gallery ranking.",
+  "entries": [
+    {
+      "submission_dir": "submissions/147228/ai-era-human-city",
+      "score": 88,
+      "reviewed_head_sha": "48dda78378820776bf6172bb1fe509431068f71c",
+      "merged_pr": 1280,
+      "reviewer": "CocoSgt"
+    },
+    {
+      "submission_dir": "submissions/147228/zhongzhiyuan-autonomy-commons",
+      "score": 84,
+      "reviewed_head_sha": "a33365832933526cb9d47dfc93efebdd81e02eaf",
+      "merged_pr": 1436,
+      "reviewer": "CocoSgt"
+    },
+    {
+      "submission_dir": "submissions/147228/jingzhang-human-city-os",
+      "score": 85,
+      "reviewed_head_sha": "25e5318d0d107d9e99eb584ab5d75d52a634a95f",
+      "merged_pr": 1662,
+      "reviewer": "CocoSgt"
+    },
+    {
+      "submission_dir": "submissions/147228/jingzhang-open-pulse",
+      "score": 94,
+      "reviewed_head_sha": "62e043024266e148ccdb2a7f78b43a7ece741cba",
+      "merged_pr": 563,
+      "reviewer": "wakenmeng"
+    },
+    {
+      "submission_dir": "submissions/147228/mobility-commons-jingzhang",
+      "score": 69,
+      "reviewed_head_sha": "1630e29c905c2cde02d79d153f2a79b3c8e86313",
+      "merged_pr": 1003,
+      "reviewer": "CocoSgt"
+    }
+  ]
+}

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -12,6 +12,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import fcntl
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -25,9 +26,14 @@ from generate_submissions_data import package_sha256
 
 REVIEW_MARKER = "<!-- haidian-auto-review:{head_sha} -->"
 CONFLICT_MARKER = "<!-- haidian-auto-review-conflict:{head_sha} -->"
+SCORE_REVIEW_PATTERN = re.compile(
+    r"<!-- haidian-auto-review:(?P<head>[0-9a-f]{40}) -->\s*"
+    r"Maintainer intake decision: Review Agent score (?P<score>[0-9]+(?:\.[0-9]+)?)/100\."
+)
 PASS = "SUCCESS"
 WORKTREE_LOCK = threading.Lock()
 GITHUB_WRITE_LOCK = threading.Lock()
+HISTORY_LOCK = threading.Lock()
 
 
 class WorkerError(RuntimeError):
@@ -99,7 +105,63 @@ def submission_dir_from_files(paths: list[str], author: str) -> str:
     return roots.pop()
 
 
-def decide(review: dict[str, Any], decision: dict[str, Any], threshold: float) -> Decision:
+def official_score_from_review(body: str, head_sha: str) -> float | None:
+    """Read only the trusted exact-head score marker emitted by this worker."""
+    match = SCORE_REVIEW_PATTERN.search(body)
+    if match is None or match.group("head") != head_sha.casefold():
+        return None
+    return float(match.group("score"))
+
+
+def _submission_root_from_paths(paths: list[str]) -> str | None:
+    roots = {
+        "/".join(path.split("/")[:3])
+        for path in paths
+        if len(path.split("/")) >= 4 and path.split("/")[0] == "submissions"
+    }
+    return next(iter(roots)) if len(roots) == 1 else None
+
+
+def historical_best_score(merged_prs: list[dict[str, Any]], submission_dir: str) -> float | None:
+    """Return the highest trusted score for one package across merged PRs."""
+    best: float | None = None
+    for pr in merged_prs:
+        if _submission_root_from_paths([str(item.get("path", "")) for item in pr.get("files", [])]) != submission_dir:
+            continue
+        head_sha = str(pr.get("headRefOid", ""))
+        for review in pr.get("reviews", []):
+            score = official_score_from_review(str(review.get("body", "")), head_sha)
+            if score is not None and (best is None or score > best):
+                best = score
+    return best
+
+
+def merged_prs_for_author(repo: str, author: str, cwd: Path) -> list[dict[str, Any]]:
+    """Fetch merged package PRs once per author for score-preservation checks."""
+    return gh_json(
+        repo,
+        [
+            "pr",
+            "list",
+            "--state",
+            "merged",
+            "--author",
+            author,
+            "--limit",
+            "1000",
+            "--json",
+            "headRefOid,files,reviews",
+        ],
+        cwd=cwd,
+    )
+
+
+def decide(
+    review: dict[str, Any],
+    decision: dict[str, Any],
+    threshold: float,
+    historical_best: float | None = None,
+) -> Decision:
     mandatory = review.get("mandatory_rejection", {})
     if mandatory.get("result") != "pass":
         return Decision("request-changes", decision.get("weighted_score_100"), "mandatory rejection hit")
@@ -118,6 +180,12 @@ def decide(review: dict[str, Any], decision: dict[str, Any], threshold: float) -
         raise WorkerError("AI decision has no numeric weighted_score_100")
     if float(score) < threshold:
         return Decision("low-quality", float(score), f"score below {threshold:g}")
+    if historical_best is not None and float(score) < historical_best:
+        return Decision(
+            "score-regression",
+            float(score),
+            f"score below historical exact-head best {historical_best:g}",
+        )
     return Decision("accept", float(score), "threshold and all gates passed")
 
 
@@ -184,6 +252,7 @@ def load_cached_review(
     submission_dir: str,
     checkout_root: Path,
     threshold: float,
+    historical_best: float | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any], Decision] | None:
     try:
         review = json.loads((audit_dir / "ai-review.json").read_text(encoding="utf-8"))
@@ -204,7 +273,7 @@ def load_cached_review(
     if decision.get("reviewed_package_sha256") != expected_hash:
         return None
     try:
-        outcome = decide(review, decision, threshold)
+        outcome = decide(review, decision, threshold, historical_best)
     except WorkerError:
         return None
     return review, decision, outcome
@@ -219,6 +288,7 @@ def apply_review(
     cwd: Path,
     *,
     admin_merge: bool,
+    historical_best: float | None = None,
 ) -> None:
     live = pr_meta(repo, number, cwd)
     assert_live(live, head_sha, require_success=True)
@@ -231,6 +301,8 @@ def apply_review(
             "Mandatory rejection and all four local gates passed. Accepted for repository intake only; "
             "this is not gallery publication, award selection, implementation approval, or government endorsement."
         )
+        if historical_best is not None:
+            body += f" Historical exact-head best for this submission: {historical_best:g}/100; this score does not regress it."
         run(["gh", "pr", "review", str(number), "--repo", repo, "--approve", "--body", body], cwd=cwd)
         assert_live(pr_meta(repo, number, cwd), head_sha, require_success=True)
         merge = ["gh", "pr", "merge", str(number), "--repo", repo, "--merge"]
@@ -247,7 +319,15 @@ def apply_review(
         return
 
     body = comment_file.read_text(encoding="utf-8")
-    body = f"{marker}\n{body}"
+    if outcome.action == "score-regression" and historical_best is not None:
+        body = (
+            f"{marker}\nScore-preservation hold: Review Agent score {outcome.score:g}/100 is below the "
+            f"historical exact-head best {historical_best:g}/100 for this submission. Do not merge this PR; "
+            "keep the higher-scoring merged version as the public recovery target.\n\n"
+            + body
+        )
+    else:
+        body = f"{marker}\n{body}"
     run(["gh", "pr", "review", str(number), "--repo", repo, "--request-changes", "--body", body], cwd=cwd)
     add = ["review/changes-requested"]
     if outcome.action == "low-quality":
@@ -258,7 +338,12 @@ def apply_review(
     )
 
 
-def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) -> dict[str, Any]:
+def process_pr(
+    args: argparse.Namespace,
+    meta: dict[str, Any],
+    repo_root: Path,
+    history_cache: dict[str, list[dict[str, Any]]],
+) -> dict[str, Any]:
     number = int(meta["number"])
     head_sha = str(meta["headRefOid"])
     author = str(meta["author"]["login"])
@@ -287,7 +372,12 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
         checked = run(["git", "rev-parse", "HEAD"], cwd=worktree).stdout.strip()
         if checked != head_sha:
             raise WorkerError("fetched worktree SHA does not match live PR head")
-        cached = load_cached_review(audit_dir, submission_dir, worktree, args.threshold)
+        with HISTORY_LOCK:
+            if author not in history_cache:
+                history_cache[author] = merged_prs_for_author(args.repo, author, repo_root)
+            merged_prs = history_cache[author]
+        historical_best = historical_best_score(merged_prs, submission_dir)
+        cached = load_cached_review(audit_dir, submission_dir, worktree, args.threshold, historical_best)
         if cached is None:
             command = [
                 sys.executable,
@@ -315,7 +405,7 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
             run(command, cwd=worktree)
             review = json.loads((audit_dir / "ai-review.json").read_text(encoding="utf-8"))
             ai_decision = json.loads((audit_dir / "ai-decision.json").read_text(encoding="utf-8"))
-            outcome = decide(review, ai_decision, args.threshold)
+            outcome = decide(review, ai_decision, args.threshold, historical_best)
             reused_audit = False
         else:
             review, ai_decision, outcome = cached
@@ -327,6 +417,7 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
             "score": outcome.score,
             "result": outcome.action,
             "reason": outcome.reason,
+            "historical_best_score": historical_best,
             "package_sha256": ai_decision.get("reviewed_package_sha256"),
             "reused_audit": reused_audit,
         }
@@ -340,6 +431,7 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
                     audit_dir / "pr-comment.md",
                     repo_root,
                     admin_merge=args.admin_merge,
+                    historical_best=historical_best,
                 )
             result["applied"] = True
         return result
@@ -411,6 +503,7 @@ def main() -> int:
     )
     selected = []
     results = []
+    history_cache: dict[str, list[dict[str, Any]]] = {}
     for candidate in sorted(candidates, key=lambda item: int(item["number"])):
         if len(selected) >= args.limit:
             break
@@ -441,7 +534,7 @@ def main() -> int:
             continue
         selected.append(live)
     with ThreadPoolExecutor(max_workers=args.concurrency) as executor:
-        futures = {executor.submit(process_pr, args, meta, repo_root): meta for meta in selected}
+        futures = {executor.submit(process_pr, args, meta, repo_root, history_cache): meta for meta in selected}
         for future in as_completed(futures):
             meta = futures[future]
             try:

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -30,9 +30,6 @@ SCORE_REVIEW_PATTERN = re.compile(
     r"<!-- haidian-auto-review:(?P<head>[0-9a-f]{40}) -->\s*"
     r"Maintainer intake decision: Review Agent score (?P<score>[0-9]+(?:\.[0-9]+)?)/100\."
 )
-DEFAULT_TRUSTED_REVIEWERS = frozenset({"cocosgt", "wakenmeng"})
-TRUSTED_REVIEWERS_ENV = "HAIDIAN_TRUSTED_REVIEWERS"
-TRUSTED_SCORE_LEDGER_PATH = Path("docs/trusted-score-high-water.json")
 PASS = "SUCCESS"
 WORKTREE_LOCK = threading.Lock()
 GITHUB_WRITE_LOCK = threading.Lock()
@@ -108,135 +105,32 @@ def submission_dir_from_files(paths: list[str], author: str) -> str:
     return roots.pop()
 
 
-def trusted_reviewer_logins() -> set[str]:
-    """Return the explicit maintainer/bot reviewer allowlist used for history."""
-    configured = {
-        item.strip().casefold()
-        for item in os.getenv(TRUSTED_REVIEWERS_ENV, "").split(",")
-        if item.strip()
-    }
-    return configured or set(DEFAULT_TRUSTED_REVIEWERS)
-
-
-def load_trusted_score_ledger(
-    repo_root: Path,
-    trusted_reviewers: set[str] | None = None,
-) -> list[dict[str, Any]]:
-    """Load the maintainer-curated score ledger and fail closed on bad entries."""
-    path = repo_root / TRUSTED_SCORE_LEDGER_PATH
-    if not path.is_file():
-        return []
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise WorkerError(f"invalid trusted score ledger: {path}") from exc
-    if not isinstance(payload, dict) or payload.get("schema_version") != 1:
-        raise WorkerError(f"unsupported trusted score ledger schema: {path}")
-    entries = payload.get("entries")
-    if not isinstance(entries, list):
-        raise WorkerError(f"trusted score ledger entries must be a list: {path}")
-    allowed = trusted_reviewers or trusted_reviewer_logins()
-    normalized: list[dict[str, Any]] = []
-    for index, item in enumerate(entries):
-        if not isinstance(item, dict):
-            raise WorkerError(f"trusted score ledger entry {index} is not an object")
-        submission_dir = str(item.get("submission_dir", ""))
-        score = item.get("score")
-        head_sha = str(item.get("reviewed_head_sha", ""))
-        reviewer = str(item.get("reviewer", "")).casefold()
-        if (
-            _submission_root_from_paths([f"{submission_dir}/manifest.json"]) != submission_dir
-            or not re.fullmatch(r"[0-9a-f]{40}", head_sha)
-            or not isinstance(score, (int, float))
-            or isinstance(score, bool)
-            or not 0 <= float(score) <= 100
-            or reviewer not in allowed
-        ):
-            raise WorkerError(f"invalid trusted score ledger entry {index}: {submission_dir}")
-        normalized.append(
-            {
-                "submission_dir": submission_dir,
-                "score": float(score),
-                "reviewed_head_sha": head_sha,
-                "merged_pr": item.get("merged_pr"),
-                "reviewer": reviewer,
-            }
-        )
-    return normalized
-
-
-def ledger_best_score(ledger: list[dict[str, Any]], submission_dir: str) -> float | None:
-    scores = [
-        float(item["score"])
-        for item in ledger
-        if str(item.get("submission_dir", "")) == submission_dir
-    ]
-    return max(scores) if scores else None
-
-
-def official_score_from_review(
-    review: dict[str, Any],
-    head_sha: str,
-    trusted_reviewers: set[str] | None = None,
-) -> float | None:
-    """Read only an approved exact-head score from an explicitly trusted reviewer."""
-    if str(review.get("state", "")).upper() != "APPROVED":
-        return None
-    author = review.get("author") or review.get("user") or {}
-    login = str(author.get("login", "")).casefold() if isinstance(author, dict) else ""
-    if login not in (trusted_reviewers or trusted_reviewer_logins()):
-        return None
-    match = SCORE_REVIEW_PATTERN.search(str(review.get("body", "")))
+def official_score_from_review(body: str, head_sha: str) -> float | None:
+    """Read only the trusted exact-head score marker emitted by this worker."""
+    match = SCORE_REVIEW_PATTERN.search(body)
     if match is None or match.group("head") != head_sha.casefold():
         return None
     return float(match.group("score"))
 
 
 def _submission_root_from_paths(paths: list[str]) -> str | None:
-    if not paths:
-        return None
-    if any(
-        len(path.split("/")) < 4 or path.split("/")[0] != "submissions"
-        for path in paths
-    ):
-        return None
     roots = {
         "/".join(path.split("/")[:3])
         for path in paths
+        if len(path.split("/")) >= 4 and path.split("/")[0] == "submissions"
     }
     return next(iter(roots)) if len(roots) == 1 else None
 
 
-def _review_commit_sha(review: dict[str, Any]) -> str:
-    """Return the commit reviewed by a GitHub REST or GraphQL review object."""
-    commit_id = review.get("commit_id")
-    if commit_id:
-        return str(commit_id)
-    commit = review.get("commit")
-    if isinstance(commit, dict):
-        return str(commit.get("oid", ""))
-    return ""
-
-
-def historical_best_score(
-    merged_prs: list[dict[str, Any]],
-    submission_dir: str,
-    trusted_reviewers: set[str] | None = None,
-) -> float | None:
+def historical_best_score(merged_prs: list[dict[str, Any]], submission_dir: str) -> float | None:
     """Return the highest trusted score for one package across merged PRs."""
     best: float | None = None
     for pr in merged_prs:
         if _submission_root_from_paths([str(item.get("path", "")) for item in pr.get("files", [])]) != submission_dir:
             continue
-        final_head_sha = str(pr.get("headRefOid", ""))
+        head_sha = str(pr.get("headRefOid", ""))
         for review in pr.get("reviews", []):
-            # A merged PR can have several reviewed revisions.  The final PR
-            # head is not necessarily the revision that earned the highest
-            # trusted score, so bind the score to the review's own commit.
-            review_sha = _review_commit_sha(review) or final_head_sha
-            if not review_sha:
-                continue
-            score = official_score_from_review(review, review_sha, trusted_reviewers)
+            score = official_score_from_review(str(review.get("body", "")), head_sha)
             if score is not None and (best is None or score > best):
                 best = score
     return best
@@ -449,7 +343,6 @@ def process_pr(
     meta: dict[str, Any],
     repo_root: Path,
     history_cache: dict[str, list[dict[str, Any]]],
-    score_ledger: list[dict[str, Any]],
 ) -> dict[str, Any]:
     number = int(meta["number"])
     head_sha = str(meta["headRefOid"])
@@ -483,12 +376,7 @@ def process_pr(
             if author not in history_cache:
                 history_cache[author] = merged_prs_for_author(args.repo, author, repo_root)
             merged_prs = history_cache[author]
-        live_best = historical_best_score(merged_prs, submission_dir, trusted_reviewer_logins())
-        ledger_best = ledger_best_score(score_ledger, submission_dir)
-        historical_best = max(
-            [score for score in (live_best, ledger_best) if score is not None],
-            default=None,
-        )
+        historical_best = historical_best_score(merged_prs, submission_dir)
         cached = load_cached_review(audit_dir, submission_dir, worktree, args.threshold, historical_best)
         if cached is None:
             command = [
@@ -616,7 +504,6 @@ def main() -> int:
     selected = []
     results = []
     history_cache: dict[str, list[dict[str, Any]]] = {}
-    score_ledger = load_trusted_score_ledger(repo_root)
     for candidate in sorted(candidates, key=lambda item: int(item["number"])):
         if len(selected) >= args.limit:
             break
@@ -647,10 +534,7 @@ def main() -> int:
             continue
         selected.append(live)
     with ThreadPoolExecutor(max_workers=args.concurrency) as executor:
-        futures = {
-            executor.submit(process_pr, args, meta, repo_root, history_cache, score_ledger): meta
-            for meta in selected
-        }
+        futures = {executor.submit(process_pr, args, meta, repo_root, history_cache): meta for meta in selected}
         for future in as_completed(futures):
             meta = futures[future]
             try:

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -32,6 +32,7 @@ SCORE_REVIEW_PATTERN = re.compile(
 )
 DEFAULT_TRUSTED_REVIEWERS = frozenset({"cocosgt", "wakenmeng"})
 TRUSTED_REVIEWERS_ENV = "HAIDIAN_TRUSTED_REVIEWERS"
+TRUSTED_SCORE_LEDGER_PATH = Path("docs/trusted-score-high-water.json")
 PASS = "SUCCESS"
 WORKTREE_LOCK = threading.Lock()
 GITHUB_WRITE_LOCK = threading.Lock()
@@ -115,6 +116,62 @@ def trusted_reviewer_logins() -> set[str]:
         if item.strip()
     }
     return configured or set(DEFAULT_TRUSTED_REVIEWERS)
+
+
+def load_trusted_score_ledger(
+    repo_root: Path,
+    trusted_reviewers: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Load the maintainer-curated score ledger and fail closed on bad entries."""
+    path = repo_root / TRUSTED_SCORE_LEDGER_PATH
+    if not path.is_file():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise WorkerError(f"invalid trusted score ledger: {path}") from exc
+    if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+        raise WorkerError(f"unsupported trusted score ledger schema: {path}")
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        raise WorkerError(f"trusted score ledger entries must be a list: {path}")
+    allowed = trusted_reviewers or trusted_reviewer_logins()
+    normalized: list[dict[str, Any]] = []
+    for index, item in enumerate(entries):
+        if not isinstance(item, dict):
+            raise WorkerError(f"trusted score ledger entry {index} is not an object")
+        submission_dir = str(item.get("submission_dir", ""))
+        score = item.get("score")
+        head_sha = str(item.get("reviewed_head_sha", ""))
+        reviewer = str(item.get("reviewer", "")).casefold()
+        if (
+            _submission_root_from_paths([f"{submission_dir}/manifest.json"]) != submission_dir
+            or not re.fullmatch(r"[0-9a-f]{40}", head_sha)
+            or not isinstance(score, (int, float))
+            or isinstance(score, bool)
+            or not 0 <= float(score) <= 100
+            or reviewer not in allowed
+        ):
+            raise WorkerError(f"invalid trusted score ledger entry {index}: {submission_dir}")
+        normalized.append(
+            {
+                "submission_dir": submission_dir,
+                "score": float(score),
+                "reviewed_head_sha": head_sha,
+                "merged_pr": item.get("merged_pr"),
+                "reviewer": reviewer,
+            }
+        )
+    return normalized
+
+
+def ledger_best_score(ledger: list[dict[str, Any]], submission_dir: str) -> float | None:
+    scores = [
+        float(item["score"])
+        for item in ledger
+        if str(item.get("submission_dir", "")) == submission_dir
+    ]
+    return max(scores) if scores else None
 
 
 def official_score_from_review(
@@ -392,6 +449,7 @@ def process_pr(
     meta: dict[str, Any],
     repo_root: Path,
     history_cache: dict[str, list[dict[str, Any]]],
+    score_ledger: list[dict[str, Any]],
 ) -> dict[str, Any]:
     number = int(meta["number"])
     head_sha = str(meta["headRefOid"])
@@ -425,7 +483,12 @@ def process_pr(
             if author not in history_cache:
                 history_cache[author] = merged_prs_for_author(args.repo, author, repo_root)
             merged_prs = history_cache[author]
-        historical_best = historical_best_score(merged_prs, submission_dir, trusted_reviewer_logins())
+        live_best = historical_best_score(merged_prs, submission_dir, trusted_reviewer_logins())
+        ledger_best = ledger_best_score(score_ledger, submission_dir)
+        historical_best = max(
+            [score for score in (live_best, ledger_best) if score is not None],
+            default=None,
+        )
         cached = load_cached_review(audit_dir, submission_dir, worktree, args.threshold, historical_best)
         if cached is None:
             command = [
@@ -553,6 +616,7 @@ def main() -> int:
     selected = []
     results = []
     history_cache: dict[str, list[dict[str, Any]]] = {}
+    score_ledger = load_trusted_score_ledger(repo_root)
     for candidate in sorted(candidates, key=lambda item: int(item["number"])):
         if len(selected) >= args.limit:
             break
@@ -583,7 +647,10 @@ def main() -> int:
             continue
         selected.append(live)
     with ThreadPoolExecutor(max_workers=args.concurrency) as executor:
-        futures = {executor.submit(process_pr, args, meta, repo_root, history_cache): meta for meta in selected}
+        futures = {
+            executor.submit(process_pr, args, meta, repo_root, history_cache, score_ledger): meta
+            for meta in selected
+        }
         for future in as_completed(futures):
             meta = futures[future]
             try:

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -30,6 +30,8 @@ SCORE_REVIEW_PATTERN = re.compile(
     r"<!-- haidian-auto-review:(?P<head>[0-9a-f]{40}) -->\s*"
     r"Maintainer intake decision: Review Agent score (?P<score>[0-9]+(?:\.[0-9]+)?)/100\."
 )
+DEFAULT_TRUSTED_REVIEWERS = frozenset({"cocosgt"})
+TRUSTED_REVIEWERS_ENV = "HAIDIAN_TRUSTED_REVIEWERS"
 PASS = "SUCCESS"
 WORKTREE_LOCK = threading.Lock()
 GITHUB_WRITE_LOCK = threading.Lock()
@@ -105,9 +107,29 @@ def submission_dir_from_files(paths: list[str], author: str) -> str:
     return roots.pop()
 
 
-def official_score_from_review(body: str, head_sha: str) -> float | None:
-    """Read only the trusted exact-head score marker emitted by this worker."""
-    match = SCORE_REVIEW_PATTERN.search(body)
+def trusted_reviewer_logins() -> set[str]:
+    """Return the explicit maintainer/bot reviewer allowlist used for history."""
+    configured = {
+        item.strip().casefold()
+        for item in os.getenv(TRUSTED_REVIEWERS_ENV, "").split(",")
+        if item.strip()
+    }
+    return configured or set(DEFAULT_TRUSTED_REVIEWERS)
+
+
+def official_score_from_review(
+    review: dict[str, Any],
+    head_sha: str,
+    trusted_reviewers: set[str] | None = None,
+) -> float | None:
+    """Read only an approved exact-head score from an explicitly trusted reviewer."""
+    if str(review.get("state", "")).upper() != "APPROVED":
+        return None
+    author = review.get("author") or review.get("user") or {}
+    login = str(author.get("login", "")).casefold() if isinstance(author, dict) else ""
+    if login not in (trusted_reviewers or trusted_reviewer_logins()):
+        return None
+    match = SCORE_REVIEW_PATTERN.search(str(review.get("body", "")))
     if match is None or match.group("head") != head_sha.casefold():
         return None
     return float(match.group("score"))
@@ -122,7 +144,11 @@ def _submission_root_from_paths(paths: list[str]) -> str | None:
     return next(iter(roots)) if len(roots) == 1 else None
 
 
-def historical_best_score(merged_prs: list[dict[str, Any]], submission_dir: str) -> float | None:
+def historical_best_score(
+    merged_prs: list[dict[str, Any]],
+    submission_dir: str,
+    trusted_reviewers: set[str] | None = None,
+) -> float | None:
     """Return the highest trusted score for one package across merged PRs."""
     best: float | None = None
     for pr in merged_prs:
@@ -130,7 +156,7 @@ def historical_best_score(merged_prs: list[dict[str, Any]], submission_dir: str)
             continue
         head_sha = str(pr.get("headRefOid", ""))
         for review in pr.get("reviews", []):
-            score = official_score_from_review(str(review.get("body", "")), head_sha)
+            score = official_score_from_review(review, head_sha, trusted_reviewers)
             if score is not None and (best is None or score > best):
                 best = score
     return best
@@ -376,7 +402,7 @@ def process_pr(
             if author not in history_cache:
                 history_cache[author] = merged_prs_for_author(args.repo, author, repo_root)
             merged_prs = history_cache[author]
-        historical_best = historical_best_score(merged_prs, submission_dir)
+        historical_best = historical_best_score(merged_prs, submission_dir, trusted_reviewer_logins())
         cached = load_cached_review(audit_dir, submission_dir, worktree, args.threshold, historical_best)
         if cached is None:
             command = [

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -136,10 +136,16 @@ def official_score_from_review(
 
 
 def _submission_root_from_paths(paths: list[str]) -> str | None:
+    if not paths:
+        return None
+    if any(
+        len(path.split("/")) < 4 or path.split("/")[0] != "submissions"
+        for path in paths
+    ):
+        return None
     roots = {
         "/".join(path.split("/")[:3])
         for path in paths
-        if len(path.split("/")) >= 4 and path.split("/")[0] == "submissions"
     }
     return next(iter(roots)) if len(roots) == 1 else None
 

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -144,6 +144,17 @@ def _submission_root_from_paths(paths: list[str]) -> str | None:
     return next(iter(roots)) if len(roots) == 1 else None
 
 
+def _review_commit_sha(review: dict[str, Any]) -> str:
+    """Return the commit reviewed by a GitHub REST or GraphQL review object."""
+    commit_id = review.get("commit_id")
+    if commit_id:
+        return str(commit_id)
+    commit = review.get("commit")
+    if isinstance(commit, dict):
+        return str(commit.get("oid", ""))
+    return ""
+
+
 def historical_best_score(
     merged_prs: list[dict[str, Any]],
     submission_dir: str,
@@ -154,9 +165,15 @@ def historical_best_score(
     for pr in merged_prs:
         if _submission_root_from_paths([str(item.get("path", "")) for item in pr.get("files", [])]) != submission_dir:
             continue
-        head_sha = str(pr.get("headRefOid", ""))
+        final_head_sha = str(pr.get("headRefOid", ""))
         for review in pr.get("reviews", []):
-            score = official_score_from_review(review, head_sha, trusted_reviewers)
+            # A merged PR can have several reviewed revisions.  The final PR
+            # head is not necessarily the revision that earned the highest
+            # trusted score, so bind the score to the review's own commit.
+            review_sha = _review_commit_sha(review) or final_head_sha
+            if not review_sha:
+                continue
+            score = official_score_from_review(review, review_sha, trusted_reviewers)
             if score is not None and (best is None or score > best):
                 best = score
     return best

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -30,7 +30,7 @@ SCORE_REVIEW_PATTERN = re.compile(
     r"<!-- haidian-auto-review:(?P<head>[0-9a-f]{40}) -->\s*"
     r"Maintainer intake decision: Review Agent score (?P<score>[0-9]+(?:\.[0-9]+)?)/100\."
 )
-DEFAULT_TRUSTED_REVIEWERS = frozenset({"cocosgt"})
+DEFAULT_TRUSTED_REVIEWERS = frozenset({"cocosgt", "wakenmeng"})
 TRUSTED_REVIEWERS_ENV = "HAIDIAN_TRUSTED_REVIEWERS"
 PASS = "SUCCESS"
 WORKTREE_LOCK = threading.Lock()

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -14,8 +14,6 @@ from auto_review_queue import (  # noqa: E402
     ci_state,
     decide,
     historical_best_score,
-    ledger_best_score,
-    load_trusted_score_ledger,
     load_cached_review,
     official_score_from_review,
     parse_args,
@@ -25,57 +23,6 @@ from generate_submissions_data import package_sha256  # noqa: E402
 
 
 class AutoReviewQueueTests(unittest.TestCase):
-    def test_trusted_score_ledger_supplies_a_package_high_water_mark(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            docs = root / "docs"
-            docs.mkdir()
-            (docs / "trusted-score-high-water.json").write_text(
-                json.dumps(
-                    {
-                        "schema_version": 1,
-                        "entries": [
-                            {
-                                "submission_dir": "submissions/alice/plan",
-                                "score": 94,
-                                "reviewed_head_sha": "a" * 40,
-                                "merged_pr": 12,
-                                "reviewer": "CocoSgt",
-                            }
-                        ],
-                    }
-                ),
-                encoding="utf-8",
-            )
-            ledger = load_trusted_score_ledger(root, {"cocosgt"})
-        self.assertEqual(94, ledger_best_score(ledger, "submissions/alice/plan"))
-        self.assertIsNone(ledger_best_score(ledger, "submissions/alice/other"))
-
-    def test_trusted_score_ledger_rejects_untrusted_or_malformed_entries(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            docs = root / "docs"
-            docs.mkdir()
-            (docs / "trusted-score-high-water.json").write_text(
-                json.dumps(
-                    {
-                        "schema_version": 1,
-                        "entries": [
-                            {
-                                "submission_dir": "submissions/alice/plan",
-                                "score": 100,
-                                "reviewed_head_sha": "b" * 40,
-                                "merged_pr": 13,
-                                "reviewer": "untrusted",
-                            }
-                        ],
-                    }
-                ),
-                encoding="utf-8",
-            )
-            with self.assertRaises(WorkerError):
-                load_trusted_score_ledger(root, {"cocosgt"})
-
     def test_default_image_budget_matches_bilingual_packet(self) -> None:
         with patch.object(sys, "argv", ["auto_review_queue"]):
             args = parse_args()
@@ -149,93 +96,21 @@ class AutoReviewQueueTests(unittest.TestCase):
             f"<!-- haidian-auto-review:{head} -->\n"
             "Maintainer intake decision: Review Agent score 93/100. Mandatory rejection and all four local gates passed."
         )
-        approved = {"state": "APPROVED", "author": {"login": "CocoSgt"}, "body": body}
-        self.assertEqual(93, official_score_from_review(approved, head, {"cocosgt"}))
-        self.assertIsNone(official_score_from_review(approved, "b" * 40, {"cocosgt"}))
-        self.assertIsNone(
-            official_score_from_review(
-                {**approved, "state": "CHANGES_REQUESTED"}, head, {"cocosgt"}
-            )
-        )
-        self.assertIsNone(
-            official_score_from_review(
-                {**approved, "author": {"login": "untrusted-contributor"}}, head, {"cocosgt"}
-            )
-        )
+        self.assertEqual(93, official_score_from_review(body, head))
+        self.assertIsNone(official_score_from_review(body, "b" * 40))
         merged_prs = [
             {
                 "headRefOid": head,
                 "files": [{"path": "submissions/alice/plan/manifest.json"}],
-                "reviews": [approved],
+                "reviews": [{"body": body}],
             },
             {
                 "headRefOid": head,
                 "files": [{"path": "submissions/alice/other/manifest.json"}],
-                "reviews": [approved],
+                "reviews": [{"body": body}],
             },
         ]
-        self.assertEqual(93, historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
-
-    def test_non_approved_or_untrusted_reviews_never_raise_historical_best(self) -> None:
-        head = "b" * 40
-        body = (
-            f"<!-- haidian-auto-review:{head} -->\n"
-            "Maintainer intake decision: Review Agent score 100/100. Mandatory rejection and all four local gates passed."
-        )
-        merged_prs = [
-            {
-                "headRefOid": head,
-                "files": [{"path": "submissions/alice/plan/manifest.json"}],
-                "reviews": [
-                    {"state": "CHANGES_REQUESTED", "author": {"login": "CocoSgt"}, "body": body},
-                    {"state": "APPROVED", "author": {"login": "untrusted-contributor"}, "body": body},
-                ],
-            }
-        ]
-        self.assertIsNone(historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
-
-    def test_mixed_scope_merged_pr_cannot_establish_package_history(self) -> None:
-        head = "b" * 40
-        body = (
-            f"<!-- haidian-auto-review:{head} -->\n"
-            "Maintainer intake decision: Review Agent score 100/100. Mandatory rejection and all four local gates passed."
-        )
-        merged_prs = [
-            {
-                "headRefOid": head,
-                "files": [
-                    {"path": "submissions/alice/plan/manifest.json"},
-                    {"path": "scripts/auto_review_queue.py"},
-                ],
-                "reviews": [
-                    {"state": "APPROVED", "author": {"login": "CocoSgt"}, "body": body}
-                ],
-            }
-        ]
-        self.assertIsNone(historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
-
-    def test_historical_best_keeps_higher_score_from_non_final_merged_pr_revision(self) -> None:
-        reviewed_head = "c" * 40
-        final_head = "d" * 40
-        body = (
-            f"<!-- haidian-auto-review:{reviewed_head} -->\n"
-            "Maintainer intake decision: Review Agent score 94/100. Mandatory rejection and all four local gates passed."
-        )
-        merged_prs = [
-            {
-                "headRefOid": final_head,
-                "files": [{"path": "submissions/alice/plan/proposal.md"}],
-                "reviews": [
-                    {
-                        "state": "APPROVED",
-                        "author": {"login": "CocoSgt"},
-                        "body": body,
-                        "commit": {"oid": reviewed_head},
-                    }
-                ],
-            }
-        ]
-        self.assertEqual(94, historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
+        self.assertEqual(93, historical_best_score(merged_prs, "submissions/alice/plan"))
 
     def test_failed_gate_overrides_high_score(self) -> None:
         review = {

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -13,7 +13,9 @@ from auto_review_queue import (  # noqa: E402
     WorkerError,
     ci_state,
     decide,
+    historical_best_score,
     load_cached_review,
+    official_score_from_review,
     parse_args,
     submission_dir_from_files,
 )
@@ -55,6 +57,60 @@ class AutoReviewQueueTests(unittest.TestCase):
             },
         }
         self.assertEqual("low-quality", decide(review, {"weighted_score_100": 59.9}, 60).action)
+
+    def test_score_regression_is_not_merged_even_above_absolute_threshold(self) -> None:
+        review = {
+            "mandatory_rejection": {"result": "pass"},
+            "gate_checks": {
+                name: {"status": "pass"}
+                for name in [
+                    "deterministic_validation",
+                    "spatial_review",
+                    "visual_review",
+                    "professional_evidence_review",
+                ]
+            },
+        }
+        outcome = decide(review, {"weighted_score_100": 79}, 60, historical_best=93)
+        self.assertEqual("score-regression", outcome.action)
+        self.assertIn("historical exact-head best 93", outcome.reason)
+
+    def test_equal_historical_score_remains_eligible(self) -> None:
+        review = {
+            "mandatory_rejection": {"result": "pass"},
+            "gate_checks": {
+                name: {"status": "pass"}
+                for name in [
+                    "deterministic_validation",
+                    "spatial_review",
+                    "visual_review",
+                    "professional_evidence_review",
+                ]
+            },
+        }
+        self.assertEqual("accept", decide(review, {"weighted_score_100": 93}, 60, historical_best=93).action)
+
+    def test_historical_score_requires_exact_head_marker_and_package_path(self) -> None:
+        head = "a" * 40
+        body = (
+            f"<!-- haidian-auto-review:{head} -->\n"
+            "Maintainer intake decision: Review Agent score 93/100. Mandatory rejection and all four local gates passed."
+        )
+        self.assertEqual(93, official_score_from_review(body, head))
+        self.assertIsNone(official_score_from_review(body, "b" * 40))
+        merged_prs = [
+            {
+                "headRefOid": head,
+                "files": [{"path": "submissions/alice/plan/manifest.json"}],
+                "reviews": [{"body": body}],
+            },
+            {
+                "headRefOid": head,
+                "files": [{"path": "submissions/alice/other/manifest.json"}],
+                "reviews": [{"body": body}],
+            },
+        ]
+        self.assertEqual(93, historical_best_score(merged_prs, "submissions/alice/plan"))
 
     def test_failed_gate_overrides_high_score(self) -> None:
         review = {

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -141,6 +141,29 @@ class AutoReviewQueueTests(unittest.TestCase):
         ]
         self.assertIsNone(historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
 
+    def test_historical_best_keeps_higher_score_from_non_final_merged_pr_revision(self) -> None:
+        reviewed_head = "c" * 40
+        final_head = "d" * 40
+        body = (
+            f"<!-- haidian-auto-review:{reviewed_head} -->\n"
+            "Maintainer intake decision: Review Agent score 94/100. Mandatory rejection and all four local gates passed."
+        )
+        merged_prs = [
+            {
+                "headRefOid": final_head,
+                "files": [{"path": "submissions/alice/plan/proposal.md"}],
+                "reviews": [
+                    {
+                        "state": "APPROVED",
+                        "author": {"login": "CocoSgt"},
+                        "body": body,
+                        "commit": {"oid": reviewed_head},
+                    }
+                ],
+            }
+        ]
+        self.assertEqual(94, historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
+
     def test_failed_gate_overrides_high_score(self) -> None:
         review = {
             "mandatory_rejection": {"result": "pass"},

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -96,21 +96,50 @@ class AutoReviewQueueTests(unittest.TestCase):
             f"<!-- haidian-auto-review:{head} -->\n"
             "Maintainer intake decision: Review Agent score 93/100. Mandatory rejection and all four local gates passed."
         )
-        self.assertEqual(93, official_score_from_review(body, head))
-        self.assertIsNone(official_score_from_review(body, "b" * 40))
+        approved = {"state": "APPROVED", "author": {"login": "CocoSgt"}, "body": body}
+        self.assertEqual(93, official_score_from_review(approved, head, {"cocosgt"}))
+        self.assertIsNone(official_score_from_review(approved, "b" * 40, {"cocosgt"}))
+        self.assertIsNone(
+            official_score_from_review(
+                {**approved, "state": "CHANGES_REQUESTED"}, head, {"cocosgt"}
+            )
+        )
+        self.assertIsNone(
+            official_score_from_review(
+                {**approved, "author": {"login": "untrusted-contributor"}}, head, {"cocosgt"}
+            )
+        )
         merged_prs = [
             {
                 "headRefOid": head,
                 "files": [{"path": "submissions/alice/plan/manifest.json"}],
-                "reviews": [{"body": body}],
+                "reviews": [approved],
             },
             {
                 "headRefOid": head,
                 "files": [{"path": "submissions/alice/other/manifest.json"}],
-                "reviews": [{"body": body}],
+                "reviews": [approved],
             },
         ]
-        self.assertEqual(93, historical_best_score(merged_prs, "submissions/alice/plan"))
+        self.assertEqual(93, historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
+
+    def test_non_approved_or_untrusted_reviews_never_raise_historical_best(self) -> None:
+        head = "b" * 40
+        body = (
+            f"<!-- haidian-auto-review:{head} -->\n"
+            "Maintainer intake decision: Review Agent score 100/100. Mandatory rejection and all four local gates passed."
+        )
+        merged_prs = [
+            {
+                "headRefOid": head,
+                "files": [{"path": "submissions/alice/plan/manifest.json"}],
+                "reviews": [
+                    {"state": "CHANGES_REQUESTED", "author": {"login": "CocoSgt"}, "body": body},
+                    {"state": "APPROVED", "author": {"login": "untrusted-contributor"}, "body": body},
+                ],
+            }
+        ]
+        self.assertIsNone(historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
 
     def test_failed_gate_overrides_high_score(self) -> None:
         review = {

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -14,6 +14,8 @@ from auto_review_queue import (  # noqa: E402
     ci_state,
     decide,
     historical_best_score,
+    ledger_best_score,
+    load_trusted_score_ledger,
     load_cached_review,
     official_score_from_review,
     parse_args,
@@ -23,6 +25,57 @@ from generate_submissions_data import package_sha256  # noqa: E402
 
 
 class AutoReviewQueueTests(unittest.TestCase):
+    def test_trusted_score_ledger_supplies_a_package_high_water_mark(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            docs = root / "docs"
+            docs.mkdir()
+            (docs / "trusted-score-high-water.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "entries": [
+                            {
+                                "submission_dir": "submissions/alice/plan",
+                                "score": 94,
+                                "reviewed_head_sha": "a" * 40,
+                                "merged_pr": 12,
+                                "reviewer": "CocoSgt",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            ledger = load_trusted_score_ledger(root, {"cocosgt"})
+        self.assertEqual(94, ledger_best_score(ledger, "submissions/alice/plan"))
+        self.assertIsNone(ledger_best_score(ledger, "submissions/alice/other"))
+
+    def test_trusted_score_ledger_rejects_untrusted_or_malformed_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            docs = root / "docs"
+            docs.mkdir()
+            (docs / "trusted-score-high-water.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "entries": [
+                            {
+                                "submission_dir": "submissions/alice/plan",
+                                "score": 100,
+                                "reviewed_head_sha": "b" * 40,
+                                "merged_pr": 13,
+                                "reviewer": "untrusted",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaises(WorkerError):
+                load_trusted_score_ledger(root, {"cocosgt"})
+
     def test_default_image_budget_matches_bilingual_packet(self) -> None:
         with patch.object(sys, "argv", ["auto_review_queue"]):
             args = parse_args()

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -141,6 +141,26 @@ class AutoReviewQueueTests(unittest.TestCase):
         ]
         self.assertIsNone(historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
 
+    def test_mixed_scope_merged_pr_cannot_establish_package_history(self) -> None:
+        head = "b" * 40
+        body = (
+            f"<!-- haidian-auto-review:{head} -->\n"
+            "Maintainer intake decision: Review Agent score 100/100. Mandatory rejection and all four local gates passed."
+        )
+        merged_prs = [
+            {
+                "headRefOid": head,
+                "files": [
+                    {"path": "submissions/alice/plan/manifest.json"},
+                    {"path": "scripts/auto_review_queue.py"},
+                ],
+                "reviews": [
+                    {"state": "APPROVED", "author": {"login": "CocoSgt"}, "body": body}
+                ],
+            }
+        ]
+        self.assertIsNone(historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
+
     def test_historical_best_keeps_higher_score_from_non_final_merged_pr_revision(self) -> None:
         reviewed_head = "c" * 40
         final_head = "d" * 40


### PR DESCRIPTION
## Summary

This is the current-main successor to PR #1296. It applies the same five score-preservation commits on top of `upstream/main=bc8b1192ac11b6b0ea7f99efcca170b9db56fa04`, so the guard can protect the current review queue after the AI-era 88→86 regression.

The guard:
- computes the trusted historical best per exact submission directory;
- accepts only approved exact-head Review Agent markers from the explicit trusted-reviewer allowlist;
- retains scores from non-final reviewed revisions;
- rejects mixed-scope PR history;
- turns a new score below the historical high-water into `score-regression` / request changes instead of merge.

## Verification

- `tests/test_auto_review_queue.py`: 15/15 PASS.
- `py_compile`: PASS.
- Changed scope is only `docs/maintainer-workflow.md`, `scripts/auto_review_queue.py`, and `tests/test_auto_review_queue.py`.
- Full repository unittest discovery currently has 5 pre-existing generated-gallery failures because `submissions-data.js` is stale relative to recent merged submissions; this PR does not touch gallery data. The targeted guard suite passes.

This PR changes merge-queue behavior only; it does not rewrite main, public gallery data, or historical scores.