### PR TITLE
fix(review): prevent score regressions from replacing high-water versions

### DIFF
--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -265,7 +265,7 @@ export HAIDIAN_REVIEW_MODEL="gpt-5.6-sol"
 # 先评审并生成审计材料，不修改 GitHub
 python3 scripts/auto_review_queue.py --limit 10
 
-# 正式回写 review/label；同时满足分数、四项 gate 和审核准入状态的 PR 自动合并
+# 正式回写 review/label；同时满足 60 分、四项 gate、审核准入状态和目录高水位规则的 PR 自动合并
 python3 scripts/auto_review_queue.py --limit 10 --concurrency 3 --apply --admin-merge
 ```
 
@@ -281,6 +281,33 @@ PR 不调用模型；draft 不进入队列。合并仅表示仓库 intake，展�
 worker 每轮按 PR 编号从旧到新处理，避免持续新增投稿使早期稿件饥饿。
 模型调用和本地视觉检查默认三路并行；worktree 创建/清理以及 GitHub review、标签、
 SHA 复核和 merge 使用进程内锁串行执行，避免 Git 引用锁和 base-branch merge 竞态。
+
+### 分数保护与恢复
+
+`--apply` 在决定合并前，会读取 `docs/trusted-score-high-water.json` 中的维护者登记值，并与该投稿作者已合并 PR 中由显式 trusted reviewer allowlist
+提交、状态为 `APPROVED` 且带有 `haidian-auto-review:<exact-head-sha>` 标记的维护者 Review Agent 评论，并按投稿目录计算
+历史官方最高分。两条来源取较高值；登记表用于在 GitHub 历史 API 限流、分页或历史 PR 被压缩时保留恢复线，不能由投稿分支运行时写入。新 exact head 的分数不严格高于该最高分时，worker 会发布
+`score-preservation hold`、请求修改并保持 PR 不合并；只有严格高于最高分才有资格继续走
+原有 intake 合并流程。同分版本只有在投稿目录 Git subtree 精确匹配受信任历史快照时，才能走 `restore-high-water` 恢复路径。没有历史官方分数的首个投稿不受这条比较规则阻塞，但仍必须通过
+60 分绝对门槛、四项 gate 和强制退件检查。
+
+回滚或恢复 PR 不得把回滚提交本身的模型分数当作新方案分数。只有在四项 gate 和 60
+分绝对门槛仍通过、且候选投稿目录的 Git subtree 与维护者登记或历史可信 Review Agent
+exact head 的高水位 subtree 完全一致时，worker 才能将其标记为
+`restore-high-water` 并合并；这表示恢复已验证的既有快照，不是给低分新内容开例外。
+subtree 不一致时仍按普通候选执行高水位比较，低分继续 `score-preservation hold`。
+
+这条保护还会校验 review 的 `state=APPROVED` 与 reviewer login。当前已登记的官方 intake
+reviewer 是 `CocoSgt` 和 `wakenmeng`；维护者轮换时通过 `HAIDIAN_TRUSTED_REVIEWERS`（逗号分隔的
+GitHub login allowlist）更新 worker 配置。普通贡献者、`CHANGES_REQUESTED` 评论、草稿或
+正文中单独伪造 marker 的评论都不会建立历史分数。它不把本地自检、advisory scorer 或
+公共 gallery 位置当作正式分数。若历史最高包已经被更低分版本覆盖，维护者应从历史
+exact head 建立恢复 PR，并在新的 exact head 重新评分达到原最高分前保持候选不合并；不
+使用 force-push 或重写 `main`。
+
+当前登记表还为近期已合并的 `commute-co-benefit-jingzhang`（PR #1466，67/100）和
+`enterprise-resident-flow-commons`（PR #1897，76/100）建立了同一投稿目录的可信基线。
+这两个分数只是后续候选的保留线，不是当前版本的新评分、公开榜单名次或图库发布证明。
 
 `submission-validation` 成功时会自动清除旧的 CI/修改/低质量标签并添加
 `review/queued`；投稿人推送修订后无需维护者手动重新排队。CI 失败时 workflow

--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -265,8 +265,12 @@ export HAIDIAN_REVIEW_MODEL="gpt-5.6-sol"
 # 先评审并生成审计材料，不修改 GitHub
 python3 scripts/auto_review_queue.py --limit 10
 
-# 正式回写 review/label；同时满足 60 分、四项 gate、审核准入状态和目录高水位规则的 PR 自动合并
+# 正式回写 review/label；满足 60 分、四项 gate 和审核准入状态的 PR 进入合并流程
 python3 scripts/auto_review_queue.py --limit 10 --concurrency 3 --apply --admin-merge
+
+# 只有维护政策正式批准后，才从受控主机加载独立政策文件启用目录高水位
+python3 scripts/auto_review_queue.py --limit 10 --concurrency 3 --apply --admin-merge \
+  --score-guard-policy-file /etc/haidian/score-guard-policy.json
 ```
 
 固定顺序为：required CI → 单一作者目录 → 固定 head SHA worktree → 本地四项 gate →
@@ -278,18 +282,53 @@ PR 不调用模型；draft 不进入队列。合并仅表示仓库 intake，展�
 自动合并还要求 `recommendation=formal-review-ready`、`can_enter_formal_review=true`、
 参与者 `required_next_actions_zh` 为空；否则 fail closed 为修改请求。
 `publication_recommendation` 是独立的展示建议，不改变 60 分 repository intake 门槛。
-worker 每轮按 PR 编号从旧到新处理，避免持续新增投稿使早期稿件饥饿。
-模型调用和本地视觉检查默认三路并行；worktree 创建/清理以及 GitHub review、标签、
-SHA 复核和 merge 使用进程内锁串行执行，避免 Git 引用锁和 base-branch merge 竞态。
+worker 先按 `submission_dir` 分组，组内按 PR 编号从旧到新处理，目录之间并行，避免普通互斥锁
+抢占导致同一方案的新稿跑到旧稿前面。
+模型调用和本地视觉检查默认三路并行，但同一 `submission_dir` 的候选从历史读取到最终写入
+全程串行。不同目录可以并行审查；worktree 创建/清理以及 GitHub review、标签、SHA 复核和
+merge 仍使用进程内锁串行。真正发布 review 或 merge 前，worker 会在 GitHub 写锁内重新拉取
+该作者的已合并 PR，重算目录高水位与候选 subtree，再做最终决定。前一候选刚合并后，后一候选
+不得复用写入前的 `history_cache`。所有缺失 commit 的 `git fetch` 也进入同一个 Git/worktree
+串行区。这同时避免 Git 引用锁、base-branch merge 和同目录高水位竞态。
 
 ### 分数保护与恢复
 
-`--apply` 在决定合并前，会读取 `docs/trusted-score-high-water.json` 中的维护者登记值，并与该投稿作者已合并 PR 中由显式 trusted reviewer allowlist
+只有提供已批准的 `--score-guard-policy-file` 时，`--apply` 才会在决定合并前读取
+`docs/trusted-score-high-water.json` 中的维护者登记值，并与该投稿作者已合并 PR 中由显式 trusted reviewer allowlist
 提交、状态为 `APPROVED` 且带有 `haidian-auto-review:<exact-head-sha>` 标记的维护者 Review Agent 评论，并按投稿目录计算
 历史官方最高分。两条来源取较高值；登记表用于在 GitHub 历史 API 限流、分页或历史 PR 被压缩时保留恢复线，不能由投稿分支运行时写入。新 exact head 的分数不严格高于该最高分时，worker 会发布
 `score-preservation hold`、请求修改并保持 PR 不合并；只有严格高于最高分才有资格继续走
 原有 intake 合并流程。同分版本只有在投稿目录 Git subtree 精确匹配受信任历史快照时，才能走 `restore-high-water` 恢复路径。没有历史官方分数的首个投稿不受这条比较规则阻塞，但仍必须通过
 60 分绝对门槛、四项 gate 和强制退件检查。
+
+本机制涉及既有投稿的准入语义，默认关闭，不能仅凭局部登记表追溯生效。维护者在生产 worker
+启用这段高水位逻辑前，必须另行确认适用范围、生效时间、全体投稿的历史回填与迁移方法、已有
+投稿兼容性和回滚步骤，并通过 `--score-guard-policy-file` 提供受控主机上的独立 JSON 配置。
+配置必须明确 `status=approved`、UTC `effective_at`、`history_scope=all-merged-history`、
+`submission_dirs`（单独的 `*` 或具体目录）、`ledger_migration=complete`、
+`compatibility_decision=approved`、非空 `rollback_plan` 和 trusted `approved_by`；缺项、未生效、
+身份不可信都 fail closed。不传该参数时，worker 不读取登记表、不查询历史分数，也不执行高水位
+比较。`docs/trusted-score-high-water.json` 在政策决定前只作为可审计迁移候选，不自行代表仓库
+政策已经批准。代码合并也不改写既有 Git 历史或过去的 intake 决定。
+
+无论高水位政策是否启用，worker 都会在发出 merge 请求和 approval 前先写入由当前 trusted
+运行账号签发、绑定 exact head 的
+`haidian-auto-review-merge-pending` 预约，再依次确保 exact-head approval 与 merge request；三步都
+通过 GitHub 全量回读实现幂等恢复。若 GitHub 把候选送入 merge queue，则不添加
+`review/intake-accepted`。同一 exact head 下次轮询不会重复已有的 approve 或 enqueue；worker 会
+通过外层 `pullRequest.headRefOid` 绑定投稿 head，并用 GraphQL `isMergeQueueEnabled`、
+`mergeQueueEntry` 与 `autoMergeRequest` 区分分支策略和等待状态（queue entry 的 `headCommit` 是合成
+提交，不能拿来与 PR head 比较）。已有 `autoMergeRequest` 没有 expected-head 字段，不能单独证明
+exact-head；worker 必须在写 approval 前先禁用并回读确认它已消失。之后，启用 merge queue 的
+分支只调用带 `expectedHeadOid` 的 `enqueuePullRequest`，其他分支只调用带 `expectedHeadOid` 的
+`mergePullRequest`，不再通过 CLI 隐式开启 auto-merge。两个 mutation 的成功结果本身就是原子化的
+“已排队”或“已合并”凭证，因此即使调用返回后进程立刻退出，下一轮也只会恢复安全状态。如果某一步
+尚不存在，下一轮只补这一操作；其他同目录候选始终 fail closed。
+PR 异步合并并离开 open 列表后，worker 还会从 closed `review/queued` PR 中回收 trusted 预约，
+同时核对 trusted exact-head approval 后才补上 intake 标签并纳入已启用政策的历史高水位；关闭
+但未合并、只有预约没有批准的 PR 都不处理。新建预约使用 REST
+返回的具体 comment ID、正文和实际作者当场验签，后续扫描再完整分页回读。这样任一步附近退出，
+都不会把“已预约”永久误报成“已排队”，或在 merge queue 窗口里同时放行两个候选。
 
 回滚或恢复 PR 不得把回滚提交本身的模型分数当作新方案分数。只有在四项 gate 和 60
 分绝对门槛仍通过、且候选投稿目录的 Git subtree 与维护者登记或历史可信 Review Agent
@@ -298,8 +337,13 @@ exact head 的高水位 subtree 完全一致时，worker 才能将其标记为
 subtree 不一致时仍按普通候选执行高水位比较，低分继续 `score-preservation hold`。
 
 这条保护还会校验 review 的 `state=APPROVED` 与 reviewer login。当前已登记的官方 intake
-reviewer 是 `CocoSgt` 和 `wakenmeng`；维护者轮换时通过 `HAIDIAN_TRUSTED_REVIEWERS`（逗号分隔的
-GitHub login allowlist）更新 worker 配置。普通贡献者、`CHANGES_REQUESTED` 评论、草稿或
+reviewer 是 `CocoSgt` 和 `wakenmeng`。未设置 `HAIDIAN_TRUSTED_REVIEWERS` 时使用这两个默认值；
+一旦设置，该环境变量就是逗号分隔的完整替换集合，不是追加集合。空值、空项、重复项、非法
+GitHub login 或无法由 GitHub 公共用户 API 精确解析的身份都会 fail closed，worker 不会静默
+退回默认值；GitHub App 的 `app-slug[bot]` 也可显式登记。worker 不依赖 installation token 不支持
+的 `GET /user`，而是在预约发布后回读评论的实际作者并要求其属于 trusted 集合。环境变量只能由
+受控的维护运行账号修改；身份存在性校验不等于仓库权限授权，替换
+集合仍须纳入同一次维护配置审计。普通贡献者、`CHANGES_REQUESTED` 评论、草稿或
 正文中单独伪造 marker 的评论都不会建立历史分数。它不把本地自检、advisory scorer 或
 公共 gallery 位置当作正式分数。若历史最高包已经被更低分版本覆盖，维护者应从历史
 exact head 建立恢复 PR，并在新的 exact head 重新评分达到原最高分前保持候选不合并；不
@@ -316,8 +360,10 @@ exact head 建立恢复 PR，并在新的 exact head 重新评分达到原最高
 审计材料保存在 `.maintainer-review/queue/pr-<number>/<head-sha>/`，worktree 默认在
 `.pr-worktree/auto-review/` 并在单稿完成后删除。建议用 launchd/systemd timer 每
 5–10 分钟运行一次，并以进程锁保证同一时间只有一个 worker。执行账号应使用
-fine-grained token 或 GitHub App，只授予本仓库 Contents/PR 所需权限；若 ruleset
-限定管理员合并，则将该 App/账号加入 bypass list 后使用 `--admin-merge`。
+fine-grained token 或 GitHub App。除 Contents write、Pull requests write 外，还需 Issues read
+来分页发现已关闭的 queued PR；预约评论由 Pull requests write 授权，不要求 Issues write。
+GitHub App 若要读取启用了 merge queue 的分支，还需 Merge queues read。若 ruleset 限定管理员
+合并，则将该 App/账号加入 bypass list 后使用 `--admin-merge`。
 
 ## Quick Reference (English)
 

--- a/docs/trusted-score-high-water.json
+++ b/docs/trusted-score-high-water.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": 1,
+  "description": "Maintainer-curated trusted Review Agent score high-water marks. Each entry is backed by an approved exact-head intake review on a merged PR; this ledger is a fail-closed recovery aid, not a gallery ranking.",
+  "entries": [
+    {
+      "submission_dir": "submissions/147228/ai-era-human-city",
+      "score": 88,
+      "reviewed_head_sha": "48dda78378820776bf6172bb1fe509431068f71c",
+      "merged_pr": 1280,
+      "reviewer": "CocoSgt"
+    },
+    {
+      "submission_dir": "submissions/147228/zhongzhiyuan-autonomy-commons",
+      "score": 84,
+      "reviewed_head_sha": "a33365832933526cb9d47dfc93efebdd81e02eaf",
+      "merged_pr": 1436,
+      "reviewer": "CocoSgt"
+    },
+    {
+      "submission_dir": "submissions/147228/jingzhang-human-city-os",
+      "score": 85,
+      "reviewed_head_sha": "25e5318d0d107d9e99eb584ab5d75d52a634a95f",
+      "merged_pr": 1662,
+      "reviewer": "CocoSgt"
+    },
+    {
+      "submission_dir": "submissions/147228/jingzhang-open-pulse",
+      "score": 94,
+      "reviewed_head_sha": "62e043024266e148ccdb2a7f78b43a7ece741cba",
+      "merged_pr": 563,
+      "reviewer": "wakenmeng"
+    },
+    {
+      "submission_dir": "submissions/147228/mobility-commons-jingzhang",
+      "score": 69,
+      "reviewed_head_sha": "1630e29c905c2cde02d79d153f2a79b3c8e86313",
+      "merged_pr": 1003,
+      "reviewer": "CocoSgt"
+    },
+    {
+      "submission_dir": "submissions/147228/commute-co-benefit-jingzhang",
+      "score": 67,
+      "reviewed_head_sha": "20f0ba7fb3d4084ce399aadcc1e6fd377ad360f1",
+      "merged_pr": 1466,
+      "reviewer": "CocoSgt"
+    },
+    {
+      "submission_dir": "submissions/147228/enterprise-resident-flow-commons",
+      "score": 76,
+      "reviewed_head_sha": "0e9c8eefc4d9227ea74edfc23c24f8269728efe1",
+      "merged_pr": 1897,
+      "reviewer": "CocoSgt"
+    }
+  ]
+}

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -47,6 +47,7 @@ import argparse
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -68,9 +69,17 @@ from generate_submissions_data import package_sha256
 
 REVIEW_MARKER = "<!-- haidian-auto-review:{head_sha} -->"
 CONFLICT_MARKER = "<!-- haidian-auto-review-conflict:{head_sha} -->"
+SCORE_REVIEW_PATTERN = re.compile(
+    r"<!-- haidian-auto-review:(?P<head>[0-9a-f]{40}) -->\s*"
+    r"Maintainer intake decision: Review Agent score (?P<score>[0-9]+(?:\.[0-9]+)?)/100\."
+)
+DEFAULT_TRUSTED_REVIEWERS = frozenset({"cocosgt", "wakenmeng"})
+TRUSTED_REVIEWERS_ENV = "HAIDIAN_TRUSTED_REVIEWERS"
+TRUSTED_SCORE_LEDGER_PATH = Path("docs/trusted-score-high-water.json")
 PASS = "SUCCESS"
 WORKTREE_LOCK = threading.Lock()
 GITHUB_WRITE_LOCK = threading.Lock()
+HISTORY_LOCK = threading.Lock()
 
 
 class WorkerError(RuntimeError):
@@ -188,7 +197,234 @@ def submission_dir_from_files(paths: list[str], author: str) -> str:
     return roots.pop()
 
 
-def decide(review: dict[str, Any], decision: dict[str, Any], threshold: float) -> Decision:
+def trusted_reviewer_logins() -> set[str]:
+    """Return the explicit maintainer/bot reviewer allowlist used for history."""
+    configured = {
+        item.strip().casefold()
+        for item in os.getenv(TRUSTED_REVIEWERS_ENV, "").split(",")
+        if item.strip()
+    }
+    return configured or set(DEFAULT_TRUSTED_REVIEWERS)
+
+
+def load_trusted_score_ledger(
+    repo_root: Path,
+    trusted_reviewers: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Load the maintainer-curated score ledger and fail closed on bad entries."""
+    path = repo_root / TRUSTED_SCORE_LEDGER_PATH
+    if not path.is_file():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise WorkerError(f"invalid trusted score ledger: {path}") from exc
+    if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+        raise WorkerError(f"unsupported trusted score ledger schema: {path}")
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        raise WorkerError(f"trusted score ledger entries must be a list: {path}")
+    allowed = trusted_reviewers or trusted_reviewer_logins()
+    normalized: list[dict[str, Any]] = []
+    for index, item in enumerate(entries):
+        if not isinstance(item, dict):
+            raise WorkerError(f"trusted score ledger entry {index} is not an object")
+        submission_dir = str(item.get("submission_dir", ""))
+        score = item.get("score")
+        head_sha = str(item.get("reviewed_head_sha", ""))
+        reviewer = str(item.get("reviewer", "")).casefold()
+        if (
+            _submission_root_from_paths([f"{submission_dir}/manifest.json"]) != submission_dir
+            or not re.fullmatch(r"[0-9a-f]{40}", head_sha)
+            or not isinstance(score, (int, float))
+            or isinstance(score, bool)
+            or not 0 <= float(score) <= 100
+            or reviewer not in allowed
+        ):
+            raise WorkerError(f"invalid trusted score ledger entry {index}: {submission_dir}")
+        normalized.append(
+            {
+                "submission_dir": submission_dir,
+                "score": float(score),
+                "reviewed_head_sha": head_sha,
+                "merged_pr": item.get("merged_pr"),
+                "reviewer": reviewer,
+            }
+        )
+    return normalized
+
+
+def ledger_best_score(ledger: list[dict[str, Any]], submission_dir: str) -> float | None:
+    scores = [
+        float(item["score"])
+        for item in ledger
+        if str(item.get("submission_dir", "")) == submission_dir
+    ]
+    return max(scores) if scores else None
+
+
+def official_score_from_review(
+    review: dict[str, Any],
+    head_sha: str,
+    trusted_reviewers: set[str] | None = None,
+) -> float | None:
+    """Read only an approved exact-head score from an explicitly trusted reviewer."""
+    if str(review.get("state", "")).upper() != "APPROVED":
+        return None
+    author = review.get("author") or review.get("user") or {}
+    login = str(author.get("login", "")).casefold() if isinstance(author, dict) else ""
+    if login not in (trusted_reviewers or trusted_reviewer_logins()):
+        return None
+    match = SCORE_REVIEW_PATTERN.search(str(review.get("body", "")))
+    if match is None or match.group("head") != head_sha.casefold():
+        return None
+    return float(match.group("score"))
+
+
+def _submission_root_from_paths(paths: list[str]) -> str | None:
+    if not paths:
+        return None
+    if any(
+        len(path.split("/")) < 4 or path.split("/")[0] != "submissions"
+        for path in paths
+    ):
+        return None
+    roots = {
+        "/".join(path.split("/")[:3])
+        for path in paths
+    }
+    return next(iter(roots)) if len(roots) == 1 else None
+
+
+def _review_commit_sha(review: dict[str, Any]) -> str:
+    """Return the commit reviewed by a GitHub REST or GraphQL review object."""
+    commit_id = review.get("commit_id")
+    if commit_id:
+        return str(commit_id)
+    commit = review.get("commit")
+    if isinstance(commit, dict):
+        return str(commit.get("oid", ""))
+    return ""
+
+
+def trusted_score_records(
+    merged_prs: list[dict[str, Any]],
+    submission_dir: str,
+    trusted_reviewers: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Return trusted score/head pairs for one package directory."""
+    records: list[dict[str, Any]] = []
+    for pr in merged_prs:
+        if _submission_root_from_paths([str(item.get("path", "")) for item in pr.get("files", [])]) != submission_dir:
+            continue
+        final_head_sha = str(pr.get("headRefOid", ""))
+        for review in pr.get("reviews", []):
+            # A merged PR can have several reviewed revisions. The final PR
+            # head is not necessarily the revision that earned the score.
+            review_sha = _review_commit_sha(review) or final_head_sha
+            if not review_sha:
+                continue
+            score = official_score_from_review(review, review_sha, trusted_reviewers)
+            if score is not None:
+                records.append({"score": float(score), "head_sha": review_sha})
+    return records
+
+
+def ledger_score_records(
+    ledger: list[dict[str, Any]], submission_dir: str
+) -> list[dict[str, Any]]:
+    """Normalize trusted ledger entries for snapshot-equivalence checks."""
+    return [
+        {"score": float(item["score"]), "head_sha": str(item["reviewed_head_sha"])}
+        for item in ledger
+        if str(item.get("submission_dir", "")) == submission_dir
+    ]
+
+
+def _package_tree_oid(
+    commit: str,
+    submission_dir: str,
+    cwd: Path,
+    *,
+    fetch_missing: bool = False,
+) -> str | None:
+    """Resolve a package subtree, optionally hydrating one trusted exact commit."""
+    command = ["git", "rev-parse", f"{commit}:{submission_dir}"]
+    try:
+        tree = run(command, cwd=cwd).stdout.strip()
+    except WorkerError:
+        if (
+            not fetch_missing
+            or not re.fullmatch(r"[0-9a-f]{40}", commit)
+        ):
+            return None
+        try:
+            # A shallow/blobless maintainer checkout may not contain a
+            # non-final reviewed head even though it is a trusted record.
+            run(["git", "fetch", "--no-tags", "--quiet", "origin", commit], cwd=cwd)
+            tree = run(command, cwd=cwd).stdout.strip()
+        except WorkerError:
+            return None
+    return tree or None
+
+
+def trusted_snapshot_score(
+    repo_root: Path,
+    candidate_worktree: Path,
+    submission_dir: str,
+    records: list[dict[str, Any]],
+) -> float | None:
+    """Return a trusted score when the candidate package tree is identical to it."""
+    candidate_tree = _package_tree_oid("HEAD", submission_dir, candidate_worktree)
+    if candidate_tree is None:
+        return None
+    matching_scores: list[float] = []
+    for record in records:
+        trusted_tree = _package_tree_oid(
+            str(record["head_sha"]), submission_dir, repo_root, fetch_missing=True
+        )
+        if trusted_tree == candidate_tree:
+            matching_scores.append(float(record["score"]))
+    return max(matching_scores, default=None)
+
+
+def historical_best_score(
+    merged_prs: list[dict[str, Any]],
+    submission_dir: str,
+    trusted_reviewers: set[str] | None = None,
+) -> float | None:
+    """Return the highest trusted score for one package across merged PRs."""
+    records = trusted_score_records(merged_prs, submission_dir, trusted_reviewers)
+    return max((float(item["score"]) for item in records), default=None)
+
+
+def merged_prs_for_author(repo: str, author: str, cwd: Path) -> list[dict[str, Any]]:
+    """Fetch merged package PRs once per author for score-preservation checks."""
+    return gh_json(
+        repo,
+        [
+            "pr",
+            "list",
+            "--state",
+            "merged",
+            "--author",
+            author,
+            "--limit",
+            "1000",
+            "--json",
+            "headRefOid,files,reviews",
+        ],
+        cwd=cwd,
+    )
+
+
+def decide(
+    review: dict[str, Any],
+    decision: dict[str, Any],
+    threshold: float,
+    historical_best: float | None = None,
+    restored_snapshot_score: float | None = None,
+) -> Decision:
     mandatory = review.get("mandatory_rejection", {})
     if mandatory.get("result") != "pass":
         return Decision("request-changes", decision.get("weighted_score_100"), "mandatory rejection hit")
@@ -220,7 +456,26 @@ def decide(review: dict[str, Any], decision: dict[str, Any], threshold: float) -
             float(score),
             f"intake blocked by review fields: {', '.join(intake_blocks)}",
         )
-    return Decision("accept", float(score), "threshold, gates, and intake readiness passed")
+    if historical_best is not None and float(score) <= historical_best:
+        if (
+            restored_snapshot_score is not None
+            and restored_snapshot_score >= historical_best
+        ):
+            return Decision(
+                "restore-high-water",
+                float(score),
+                f"package tree exactly matches trusted retained snapshot {restored_snapshot_score:g}/100",
+            )
+        return Decision(
+            "score-regression",
+            float(score),
+            f"score is not strictly above historical exact-head best {historical_best:g}",
+        )
+    return Decision(
+        "accept",
+        float(score),
+        "threshold, gates, intake readiness, and score high-water passed",
+    )
 
 
 def pr_meta(repo: str, number: int, cwd: Path) -> dict[str, Any]:
@@ -286,6 +541,8 @@ def load_cached_review(
     submission_dir: str,
     checkout_root: Path,
     threshold: float,
+    historical_best: float | None = None,
+    restored_snapshot_score: float | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any], Decision] | None:
     try:
         review = json.loads((audit_dir / "ai-review.json").read_text(encoding="utf-8"))
@@ -306,7 +563,13 @@ def load_cached_review(
     if decision.get("reviewed_package_sha256") != expected_hash:
         return None
     try:
-        outcome = decide(review, decision, threshold)
+        outcome = decide(
+            review,
+            decision,
+            threshold,
+            historical_best,
+            restored_snapshot_score,
+        )
     except WorkerError:
         return None
     return review, decision, outcome
@@ -321,19 +584,35 @@ def apply_review(
     cwd: Path,
     *,
     admin_merge: bool,
+    historical_best: float | None = None,
+    restored_snapshot_score: float | None = None,
 ) -> None:
     live = pr_meta(repo, number, cwd)
     assert_live(live, head_sha, require_success=True)
     marker = REVIEW_MARKER.format(head_sha=head_sha)
-    if outcome.action == "accept":
+    if outcome.action in {"accept", "restore-high-water"}:
         if live.get("mergeable") == "CONFLICTING":
             raise WorkerError("PR became conflicting before merge")
-        body = (
-            f"{marker}\nMaintainer intake decision: Review Agent score {outcome.score:g}/100. "
-            "Mandatory rejection, all four local gates, and review readiness passed. "
-            "Accepted for repository intake only; "
-            "this is not gallery publication, award selection, implementation approval, or government endorsement."
-        )
+        if outcome.action == "restore-high-water":
+            if restored_snapshot_score is None:
+                raise WorkerError("restoration decision has no trusted snapshot score")
+            body = (
+                f"{marker}\nScore-preservation restoration: the candidate package tree exactly matches "
+                f"a trusted retained snapshot at {restored_snapshot_score:g}/100. The candidate Review Agent "
+                f"score was {outcome.score:g}/100, but this rollback does not replace the trusted package score. "
+                "Mandatory rejection, all four local gates, and review readiness passed; "
+                "accepted for repository intake only, "
+                "not gallery publication, award selection, implementation approval, or government endorsement."
+            )
+        else:
+            body = (
+                f"{marker}\nMaintainer intake decision: Review Agent score {outcome.score:g}/100. "
+                "Mandatory rejection, all four local gates, and review readiness passed. "
+                "Accepted for repository intake only; "
+                "this is not gallery publication, award selection, implementation approval, or government endorsement."
+            )
+            if historical_best is not None:
+                body += f" Historical exact-head best for this submission: {historical_best:g}/100; this score does not regress it."
         run(["gh", "pr", "review", str(number), "--repo", repo, "--approve", "--body", body], cwd=cwd)
         assert_live(pr_meta(repo, number, cwd), head_sha, require_success=True)
         merge = [
@@ -360,7 +639,16 @@ def apply_review(
         return
 
     body = comment_file.read_text(encoding="utf-8")
-    body = f"{marker}\n{body}"
+    if outcome.action == "score-regression" and historical_best is not None:
+        body = (
+            f"{marker}\nScore-preservation hold: Review Agent score {outcome.score:g}/100 does not strictly exceed the "
+            f"historical exact-head best {historical_best:g}/100 for this submission, and the package tree is not "
+            "an exact trusted snapshot restoration. Do not merge this PR; "
+            "keep the higher-scoring merged version as the public recovery target.\n\n"
+            + body
+        )
+    else:
+        body = f"{marker}\n{body}"
     run(["gh", "pr", "review", str(number), "--repo", repo, "--request-changes", "--body", body], cwd=cwd)
     add = ["review/changes-requested"]
     if outcome.action == "low-quality":
@@ -371,7 +659,13 @@ def apply_review(
     )
 
 
-def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) -> dict[str, Any]:
+def process_pr(
+    args: argparse.Namespace,
+    meta: dict[str, Any],
+    repo_root: Path,
+    history_cache: dict[str, list[dict[str, Any]]],
+    score_ledger: list[dict[str, Any]],
+) -> dict[str, Any]:
     number = int(meta["number"])
     head_sha = str(meta["headRefOid"])
     author = str(meta["author"]["login"])
@@ -396,7 +690,30 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
         checked = run(["git", "rev-parse", "HEAD"], cwd=worktree).stdout.strip()
         if checked != head_sha:
             raise WorkerError("fetched worktree SHA does not match live PR head")
-        cached = load_cached_review(audit_dir, submission_dir, worktree, args.threshold)
+        with HISTORY_LOCK:
+            if author not in history_cache:
+                history_cache[author] = merged_prs_for_author(args.repo, author, repo_root)
+            merged_prs = history_cache[author]
+        live_best = historical_best_score(merged_prs, submission_dir, trusted_reviewer_logins())
+        ledger_best = ledger_best_score(score_ledger, submission_dir)
+        trusted_records = trusted_score_records(
+            merged_prs, submission_dir, trusted_reviewer_logins()
+        ) + ledger_score_records(score_ledger, submission_dir)
+        historical_best = max(
+            [score for score in (live_best, ledger_best) if score is not None],
+            default=None,
+        )
+        restored_snapshot_score = trusted_snapshot_score(
+            repo_root, worktree, submission_dir, trusted_records
+        )
+        cached = load_cached_review(
+            audit_dir,
+            submission_dir,
+            worktree,
+            args.threshold,
+            historical_best,
+            restored_snapshot_score,
+        )
         if cached is None:
             command = [
                 sys.executable,
@@ -424,7 +741,13 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
             run(command, cwd=worktree)
             review = json.loads((audit_dir / "ai-review.json").read_text(encoding="utf-8"))
             ai_decision = json.loads((audit_dir / "ai-decision.json").read_text(encoding="utf-8"))
-            outcome = decide(review, ai_decision, args.threshold)
+            outcome = decide(
+                review,
+                ai_decision,
+                args.threshold,
+                historical_best,
+                restored_snapshot_score,
+            )
             reused_audit = False
         else:
             review, ai_decision, outcome = cached
@@ -436,6 +759,8 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
             "score": outcome.score,
             "result": outcome.action,
             "reason": outcome.reason,
+            "historical_best_score": historical_best,
+            "restored_snapshot_score": restored_snapshot_score,
             "package_sha256": ai_decision.get("reviewed_package_sha256"),
             "reused_audit": reused_audit,
         }
@@ -449,6 +774,8 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
                     audit_dir / "pr-comment.md",
                     repo_root,
                     admin_merge=args.admin_merge,
+                    historical_best=historical_best,
+                    restored_snapshot_score=restored_snapshot_score,
                 )
             result["applied"] = True
         return result
@@ -532,6 +859,8 @@ def main() -> int:
     candidates = queued_prs(args.repo, args.label, repo_root)
     selected = []
     results = []
+    history_cache: dict[str, list[dict[str, Any]]] = {}
+    score_ledger = load_trusted_score_ledger(repo_root)
     for candidate in sorted(candidates, key=lambda item: int(item["number"])):
         if len(selected) >= args.limit:
             break
@@ -562,7 +891,10 @@ def main() -> int:
             continue
         selected.append(live)
     with ThreadPoolExecutor(max_workers=args.concurrency) as executor:
-        futures = {executor.submit(process_pr, args, meta, repo_root): meta for meta in selected}
+        futures = {
+            executor.submit(process_pr, args, meta, repo_root, history_cache, score_ledger): meta
+            for meta in selected
+        }
         for future in as_completed(futures):
             meta = futures[future]
             try:

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -20,8 +20,9 @@ Security model
 
 Environment variables
 ---------------------
-- ``GITHUB_TOKEN`` — required; needs ``pull-requests: write`` and
-  ``contents: read`` permissions.
+- ``GITHUB_TOKEN`` — required; needs ``pull-requests: write``,
+  ``contents: write``, and ``issues: read`` permissions. GitHub Apps also
+  need ``merge-queues: read`` when the base branch uses a merge queue.
 - ``GITHUB_REPOSITORY`` — required; ``owner/repo`` format.
 - ``OPENAI_API_KEY`` or ``AI_REVIEW_API_KEY`` — required for AI review.
 
@@ -45,6 +46,7 @@ from __future__ import annotations
 
 import argparse
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
 import json
 import os
 import re
@@ -68,6 +70,7 @@ from generate_submissions_data import package_sha256
 
 
 REVIEW_MARKER = "<!-- haidian-auto-review:{head_sha} -->"
+MERGE_PENDING_MARKER = "<!-- haidian-auto-review-merge-pending:{head_sha} -->"
 CONFLICT_MARKER = "<!-- haidian-auto-review-conflict:{head_sha} -->"
 SCORE_REVIEW_PATTERN = re.compile(
     r"<!-- haidian-auto-review:(?P<head>[0-9a-f]{40}) -->\s*"
@@ -75,11 +78,17 @@ SCORE_REVIEW_PATTERN = re.compile(
 )
 DEFAULT_TRUSTED_REVIEWERS = frozenset({"cocosgt", "wakenmeng"})
 TRUSTED_REVIEWERS_ENV = "HAIDIAN_TRUSTED_REVIEWERS"
+GITHUB_LOGIN_PATTERN = re.compile(
+    r"[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?(?:\[bot\])?"
+)
 TRUSTED_SCORE_LEDGER_PATH = Path("docs/trusted-score-high-water.json")
+SCORE_GUARD_POLICY_SCHEMA_VERSION = 1
 PASS = "SUCCESS"
 WORKTREE_LOCK = threading.Lock()
 GITHUB_WRITE_LOCK = threading.Lock()
 HISTORY_LOCK = threading.Lock()
+SUBMISSION_LOCKS_LOCK = threading.Lock()
+SUBMISSION_LOCKS: dict[str, threading.Lock] = {}
 
 
 class WorkerError(RuntimeError):
@@ -91,6 +100,23 @@ class Decision:
     action: str
     score: float | None
     reason: str
+
+
+@dataclass(frozen=True)
+class ScoreGuardPolicy:
+    """One explicit maintainer approval for score-high-water enforcement."""
+
+    enabled: bool
+    effective_at: datetime | None
+    submission_dirs: frozenset[str]
+
+    def applies_to(self, submission_dir: str) -> bool:
+        return self.enabled and (
+            "*" in self.submission_dirs or submission_dir in self.submission_dirs
+        )
+
+
+DISABLED_SCORE_GUARD_POLICY = ScoreGuardPolicy(False, None, frozenset())
 
 
 def run(command: list[str], *, cwd: Path, capture: bool = True) -> subprocess.CompletedProcess[str]:
@@ -143,6 +169,38 @@ def queued_prs(repo: str, label: str, cwd: Path) -> list[dict[str, Any]]:
     ]
 
 
+def closed_queued_pull_numbers(repo: str, label: str, cwd: Path) -> list[int]:
+    """Read closed queued PRs from the paginated Issues endpoint, not search."""
+    completed = run(
+        [
+            "gh",
+            "api",
+            "--method",
+            "GET",
+            "--paginate",
+            "--slurp",
+            f"repos/{repo}/issues",
+            "-f",
+            "state=closed",
+            "-f",
+            f"labels={label}",
+            "-f",
+            "per_page=100",
+        ],
+        cwd=cwd,
+    )
+    try:
+        pages = json.loads(completed.stdout)
+        return [
+            int(item["number"])
+            for page in pages
+            for item in page
+            if isinstance(item, dict) and item.get("pull_request")
+        ]
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        raise WorkerError("invalid closed queued PR list from GitHub") from exc
+
+
 def pr_file_paths(repo: str, number: int, cwd: Path) -> list[str]:
     completed = run(
         ["gh", "api", "--paginate", "--slurp", f"repos/{repo}/pulls/{number}/files"],
@@ -153,6 +211,44 @@ def pr_file_paths(repo: str, number: int, cwd: Path) -> list[str]:
         return [str(item["filename"]) for page in pages for item in page]
     except (json.JSONDecodeError, KeyError, TypeError) as exc:
         raise WorkerError(f"invalid file list from gh api for PR #{number}") from exc
+
+
+def pr_comments(repo: str, number: int, cwd: Path) -> list[dict[str, Any]]:
+    """Fetch every issue comment for a PR; pending markers must not be page-limited."""
+    completed = run(
+        [
+            "gh",
+            "api",
+            "--paginate",
+            "--slurp",
+            f"repos/{repo}/issues/{number}/comments",
+        ],
+        cwd=cwd,
+    )
+    try:
+        pages = json.loads(completed.stdout)
+        return [item for page in pages for item in page]
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise WorkerError(f"invalid comment list from gh api for PR #{number}") from exc
+
+
+def pr_reviews(repo: str, number: int, cwd: Path) -> list[dict[str, Any]]:
+    """Fetch every submitted review for exact-head approval reconciliation."""
+    completed = run(
+        [
+            "gh",
+            "api",
+            "--paginate",
+            "--slurp",
+            f"repos/{repo}/pulls/{number}/reviews",
+        ],
+        cwd=cwd,
+    )
+    try:
+        pages = json.loads(completed.stdout)
+        return [item for page in pages for item in page]
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise WorkerError(f"invalid review list from gh api for PR #{number}") from exc
 
 
 def latest_validation_check(meta: dict[str, Any]) -> dict[str, Any] | None:
@@ -198,13 +294,114 @@ def submission_dir_from_files(paths: list[str], author: str) -> str:
 
 
 def trusted_reviewer_logins() -> set[str]:
-    """Return the explicit maintainer/bot reviewer allowlist used for history."""
-    configured = {
-        item.strip().casefold()
-        for item in os.getenv(TRUSTED_REVIEWERS_ENV, "").split(",")
-        if item.strip()
-    }
-    return configured or set(DEFAULT_TRUSTED_REVIEWERS)
+    """Return one validated full trusted-reviewer set.
+
+    An absent environment variable selects the repository defaults. A present
+    variable is an explicit full replacement; blank entries, duplicates and
+    malformed GitHub logins fail closed instead of silently falling back.
+    """
+    raw = os.getenv(TRUSTED_REVIEWERS_ENV)
+    if raw is None:
+        return set(DEFAULT_TRUSTED_REVIEWERS)
+    items = [item.strip().casefold() for item in raw.split(",")]
+    if not items or any(not item for item in items):
+        raise WorkerError(f"{TRUSTED_REVIEWERS_ENV} must be a non-empty full reviewer list")
+    if len(set(items)) != len(items):
+        raise WorkerError(f"{TRUSTED_REVIEWERS_ENV} contains duplicate reviewer logins")
+    for item in items:
+        if GITHUB_LOGIN_PATTERN.fullmatch(item) is None or "--" in item:
+            raise WorkerError(f"{TRUSTED_REVIEWERS_ENV} contains invalid GitHub login: {item}")
+    return set(items)
+
+
+def validate_trusted_reviewer_identities(reviewers: set[str], cwd: Path) -> None:
+    """Fail closed unless every configured reviewer resolves to that GitHub identity."""
+    for reviewer in sorted(reviewers):
+        completed = run(["gh", "api", f"users/{reviewer}"], cwd=cwd)
+        try:
+            identity = json.loads(completed.stdout)
+        except json.JSONDecodeError as exc:
+            raise WorkerError(f"invalid GitHub identity response for trusted reviewer {reviewer}") from exc
+        if (
+            str(identity.get("login", "")).casefold() != reviewer
+            or identity.get("type") not in {"User", "Bot"}
+            or not isinstance(identity.get("id"), int)
+        ):
+            raise WorkerError(f"trusted reviewer identity did not resolve exactly: {reviewer}")
+
+
+def load_score_guard_policy(
+    path: Path | None,
+    trusted_reviewers: set[str],
+    *,
+    now: datetime | None = None,
+) -> ScoreGuardPolicy:
+    """Load an explicit, effective maintainer policy or leave the guard disabled.
+
+    The repository intentionally carries no implicitly approved policy. A
+    maintainer must provide a separate configuration that fixes the scope,
+    effective date, migration status, compatibility decision, and rollback.
+    """
+    if path is None:
+        return DISABLED_SCORE_GUARD_POLICY
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise WorkerError(f"invalid score guard policy: {path}") from exc
+    if not isinstance(payload, dict) or payload.get("schema_version") != SCORE_GUARD_POLICY_SCHEMA_VERSION:
+        raise WorkerError(f"unsupported score guard policy schema: {path}")
+    if payload.get("status") != "approved":
+        raise WorkerError("score guard policy status must be approved")
+    if payload.get("history_scope") != "all-merged-history":
+        raise WorkerError("score guard policy must explicitly select all-merged-history")
+    if payload.get("ledger_migration") != "complete":
+        raise WorkerError("score guard policy must confirm complete ledger migration")
+    if payload.get("compatibility_decision") != "approved":
+        raise WorkerError("score guard policy must record an approved compatibility decision")
+    rollback_plan = payload.get("rollback_plan")
+    if not isinstance(rollback_plan, str) or not rollback_plan.strip():
+        raise WorkerError("score guard policy must include a rollback plan")
+
+    raw_approvers = payload.get("approved_by")
+    if not isinstance(raw_approvers, list) or not raw_approvers:
+        raise WorkerError("score guard policy must name at least one trusted approver")
+    approvers = [str(item).casefold() for item in raw_approvers]
+    if len(set(approvers)) != len(approvers) or any(
+        approver not in trusted_reviewers for approver in approvers
+    ):
+        raise WorkerError("score guard policy approvers must be unique trusted reviewers")
+
+    raw_dirs = payload.get("submission_dirs")
+    if not isinstance(raw_dirs, list) or not raw_dirs:
+        raise WorkerError("score guard policy must define a non-empty submission scope")
+    submission_dirs = [str(item) for item in raw_dirs]
+    if len(set(submission_dirs)) != len(submission_dirs):
+        raise WorkerError("score guard policy contains duplicate submission directories")
+    if "*" in submission_dirs and len(submission_dirs) != 1:
+        raise WorkerError("score guard wildcard scope cannot be combined with directories")
+    for submission_dir in submission_dirs:
+        if submission_dir == "*":
+            continue
+        if _submission_root_from_paths([f"{submission_dir}/manifest.json"]) != submission_dir:
+            raise WorkerError(f"invalid score guard submission scope: {submission_dir}")
+
+    raw_effective_at = payload.get("effective_at")
+    if not isinstance(raw_effective_at, str) or not raw_effective_at.endswith("Z"):
+        raise WorkerError("score guard effective_at must be an RFC3339 UTC timestamp")
+    try:
+        effective_at = datetime.fromisoformat(raw_effective_at[:-1] + "+00:00")
+    except ValueError as exc:
+        raise WorkerError("score guard effective_at must be an RFC3339 UTC timestamp") from exc
+    current_time = now or datetime.now(timezone.utc)
+    if effective_at > current_time:
+        raise WorkerError("score guard policy is approved but not yet effective")
+    return ScoreGuardPolicy(True, effective_at, frozenset(submission_dirs))
+
+
+def submission_dir_lock(submission_dir: str) -> threading.Lock:
+    """Return the process-local lock that serializes one package directory."""
+    with SUBMISSION_LOCKS_LOCK:
+        return SUBMISSION_LOCKS.setdefault(submission_dir, threading.Lock())
 
 
 def load_trusted_score_ledger(
@@ -307,6 +504,27 @@ def _review_commit_sha(review: dict[str, Any]) -> str:
     return ""
 
 
+def has_trusted_exact_head_approval(
+    reviews: list[dict[str, Any]],
+    head_sha: str,
+    trusted_reviewers: set[str],
+) -> bool:
+    """Verify the exact reviewed commit, approval state, marker, and author."""
+    marker = REVIEW_MARKER.format(head_sha=head_sha)
+    for review in reviews:
+        if str(review.get("state", "")).upper() != "APPROVED":
+            continue
+        author = review.get("author") or review.get("user") or {}
+        login = str(author.get("login", "")).casefold() if isinstance(author, dict) else ""
+        if (
+            login in trusted_reviewers
+            and _review_commit_sha(review).casefold() == head_sha.casefold()
+            and str(review.get("body", "")).startswith(marker)
+        ):
+            return True
+    return False
+
+
 def trusted_score_records(
     merged_prs: list[dict[str, Any]],
     submission_dir: str,
@@ -361,8 +579,9 @@ def _package_tree_oid(
         try:
             # A shallow/blobless maintainer checkout may not contain a
             # non-final reviewed head even though it is a trusted record.
-            run(["git", "fetch", "--no-tags", "--quiet", "origin", commit], cwd=cwd)
-            tree = run(command, cwd=cwd).stdout.strip()
+            with WORKTREE_LOCK:
+                run(["git", "fetch", "--no-tags", "--quiet", "origin", commit], cwd=cwd)
+                tree = run(command, cwd=cwd).stdout.strip()
         except WorkerError:
             return None
     return tree or None
@@ -416,6 +635,110 @@ def merged_prs_for_author(repo: str, author: str, cwd: Path) -> list[dict[str, A
         ],
         cwd=cwd,
     )
+
+
+def score_guard_prs_for_author(repo: str, author: str, cwd: Path) -> list[dict[str, Any]]:
+    """Fetch one snapshot containing merged history and open reservations."""
+    return gh_json(
+        repo,
+        [
+            "pr",
+            "list",
+            "--state",
+            "all",
+            "--author",
+            author,
+            "--limit",
+            "1000",
+            "--json",
+            "number,state,headRefOid,files,reviews",
+        ],
+        cwd=cwd,
+    )
+
+
+def merge_reservation_body(head_sha: str) -> str:
+    return (
+        f"{MERGE_PENDING_MARKER.format(head_sha=head_sha)}\n"
+        "Exact-head merge reservation: this package is fail-closed until GitHub confirms "
+        "the PR as MERGED or a maintainer closes the PR."
+    )
+
+
+def has_trusted_merge_reservation(
+    comments: list[dict[str, Any]],
+    head_sha: str,
+    trusted_reviewers: set[str],
+) -> bool:
+    """Verify a reservation by exact marker and its actual GitHub comment author."""
+    expected = merge_reservation_body(head_sha)
+    for comment in comments:
+        author = comment.get("author") or comment.get("user") or {}
+        login = str(author.get("login", "")).casefold() if isinstance(author, dict) else ""
+        if login in trusted_reviewers and str(comment.get("body", "")) == expected:
+            return True
+    return False
+
+
+def create_merge_reservation(
+    repo: str,
+    number: int,
+    head_sha: str,
+    trusted_reviewers: set[str],
+    cwd: Path,
+) -> None:
+    """Create one reservation and verify the exact returned comment identity."""
+    body = merge_reservation_body(head_sha)
+    completed = run(
+        [
+            "gh",
+            "api",
+            "--method",
+            "POST",
+            f"repos/{repo}/issues/{number}/comments",
+            "-f",
+            f"body={body}",
+        ],
+        cwd=cwd,
+    )
+    try:
+        comment = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise WorkerError("invalid merge reservation creation response") from exc
+    if not isinstance(comment, dict) or not isinstance(comment.get("id"), int):
+        raise WorkerError("merge reservation creation did not return an exact comment")
+    if not has_trusted_merge_reservation([comment], head_sha, trusted_reviewers):
+        raise WorkerError("new merge reservation was not authored by a trusted reviewer")
+
+
+def pending_trusted_intake_numbers(
+    prs: list[dict[str, Any]],
+    submission_dir: str,
+    trusted_reviewers: set[str],
+    repo: str,
+    cwd: Path,
+) -> set[int]:
+    """Return open PR numbers carrying a trusted exact-head merge reservation."""
+    pending: set[int] = set()
+    for pr in prs:
+        if str(pr.get("state", "")).upper() != "OPEN":
+            continue
+        number = int(pr.get("number") or 0)
+        if number <= 0:
+            continue
+        paths = [str(item.get("path", "")) for item in pr.get("files", [])]
+        if _submission_root_from_paths(paths) != submission_dir:
+            continue
+        head_sha = str(pr.get("headRefOid", "")).casefold()
+        if not re.fullmatch(r"[0-9a-f]{40}", head_sha):
+            continue
+        if has_trusted_merge_reservation(
+            pr_comments(repo, number, cwd),
+            head_sha,
+            trusted_reviewers,
+        ):
+            pending.add(number)
+    return pending
 
 
 def decide(
@@ -501,6 +824,155 @@ def assert_live(meta: dict[str, Any], expected_sha: str, *, require_success: boo
         raise WorkerError("required CI is no longer successful")
 
 
+def merge_request_snapshot(
+    repo: str, number: int, head_sha: str, cwd: Path
+) -> dict[str, Any]:
+    """Return exact-head merge state and the PR node ID used by atomic mutations."""
+    try:
+        owner, name = repo.split("/", 1)
+    except ValueError as exc:
+        raise WorkerError(f"invalid repository name: {repo}") from exc
+    query = """
+query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$number){
+      id
+      state
+      headRefOid
+      isMergeQueueEnabled
+      autoMergeRequest{enabledAt}
+      mergeQueueEntry{state headCommit{oid}}
+    }
+  }
+}
+""".strip()
+    completed = run(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={name}",
+            "-F",
+            f"number={number}",
+        ],
+        cwd=cwd,
+    )
+    try:
+        pull = json.loads(completed.stdout)["data"]["repository"]["pullRequest"]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise WorkerError(f"invalid merge state response for PR #{number}") from exc
+    if not isinstance(pull, dict):
+        raise WorkerError(f"missing merge state for PR #{number}")
+    if str(pull.get("headRefOid", "")) != head_sha:
+        raise WorkerError("PR head changed while reconciling merge request")
+    if not str(pull.get("id", "")):
+        raise WorkerError(f"missing GraphQL node ID for PR #{number}")
+    return pull
+
+
+def merge_request_status(repo: str, number: int, head_sha: str, cwd: Path) -> str:
+    """Return merged, pending, auto, absent, or closed from GitHub's state."""
+    pull = merge_request_snapshot(repo, number, head_sha, cwd)
+    state = str(pull.get("state", "")).upper()
+    if state == "MERGED":
+        return "merged"
+    if state != "OPEN":
+        return "closed"
+    queue_entry = pull.get("mergeQueueEntry")
+    if isinstance(queue_entry, dict):
+        # mergeQueueEntry.headCommit is GitHub's synthetic queue/merge-group
+        # commit. Exact-head binding comes from pullRequest.headRefOid above.
+        return "pending"
+    if pull.get("autoMergeRequest") is not None:
+        # AutoMergeRequest has no expected-head field and can survive pushes by
+        # write-capable users. It is not a durable exact-head reservation.
+        return "auto"
+    return "absent"
+
+
+def disable_auto_merge(repo: str, number: int, cwd: Path) -> None:
+    run(
+        ["gh", "pr", "merge", str(number), "--repo", repo, "--disable-auto"],
+        cwd=cwd,
+    )
+
+
+def submit_merge_request(
+    repo: str,
+    number: int,
+    head_sha: str,
+    cwd: Path,
+    *,
+    admin_merge: bool,
+) -> str:
+    """Atomically enqueue or merge the exact head without ever enabling auto-merge."""
+    live = pr_meta(repo, number, cwd)
+    assert_live(live, head_sha, require_success=True)
+    pull = merge_request_snapshot(repo, number, head_sha, cwd)
+    if str(pull.get("state", "")).upper() != "OPEN":
+        raise WorkerError("PR is no longer open before merge submission")
+    pull_id = str(pull["id"])
+
+    if bool(pull.get("isMergeQueueEnabled")) and not admin_merge:
+        mutation = """
+mutation($pullRequestId:ID!,$expectedHeadOid:GitObjectID!){
+  enqueuePullRequest(input:{pullRequestId:$pullRequestId,expectedHeadOid:$expectedHeadOid}){
+    mergeQueueEntry{id state}
+  }
+}
+""".strip()
+        operation = "enqueuePullRequest"
+    else:
+        mutation = """
+mutation($pullRequestId:ID!,$expectedHeadOid:GitObjectID!){
+  mergePullRequest(input:{pullRequestId:$pullRequestId,expectedHeadOid:$expectedHeadOid,mergeMethod:MERGE}){
+    pullRequest{state headRefOid}
+  }
+}
+""".strip()
+        operation = "mergePullRequest"
+
+    completed = run(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={mutation}",
+            "-F",
+            f"pullRequestId={pull_id}",
+            "-F",
+            f"expectedHeadOid={head_sha}",
+        ],
+        cwd=cwd,
+    )
+    try:
+        result = json.loads(completed.stdout)["data"][operation]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise WorkerError(f"invalid {operation} response for PR #{number}") from exc
+
+    if operation == "enqueuePullRequest":
+        if not isinstance(result, dict) or not isinstance(
+            result.get("mergeQueueEntry"), dict
+        ):
+            raise WorkerError(f"GitHub did not confirm queue entry for PR #{number}")
+        return "pending"
+
+    merged_pull = result.get("pullRequest") if isinstance(result, dict) else None
+    if (
+        not isinstance(merged_pull, dict)
+        or str(merged_pull.get("headRefOid", "")) != head_sha
+        or str(merged_pull.get("state", "")).upper() != "MERGED"
+    ):
+        raise WorkerError(f"GitHub did not confirm exact-head merge for PR #{number}")
+    return "merged"
+
+
 def label_args(remove: list[str], add: list[str]) -> list[str]:
     args: list[str] = []
     for label in remove:
@@ -508,6 +980,58 @@ def label_args(remove: list[str], add: list[str]) -> list[str]:
     for label in add:
         args.extend(["--add-label", label])
     return args
+
+
+def mark_intake_accepted(repo: str, number: int, cwd: Path) -> None:
+    run(
+        [
+            "gh",
+            "pr",
+            "edit",
+            str(number),
+            "--repo",
+            repo,
+            *label_args(["review/queued"], ["review/intake-accepted"]),
+        ],
+        cwd=cwd,
+    )
+
+
+def reconcile_merged_reservations(
+    repo: str,
+    label: str,
+    trusted_reviewers: set[str],
+    cwd: Path,
+    *,
+    apply: bool,
+) -> list[dict[str, Any]]:
+    """Finalize labels for queue reservations that merged between worker runs."""
+    results: list[dict[str, Any]] = []
+    for number in closed_queued_pull_numbers(repo, label, cwd):
+        meta = pr_meta(repo, number, cwd)
+        if str(meta.get("state", "")).upper() != "MERGED":
+            continue
+        head_sha = str(meta.get("headRefOid", ""))
+        if not re.fullmatch(r"[0-9a-f]{40}", head_sha):
+            raise WorkerError(f"merged reserved PR #{number} has no exact head")
+        if not has_trusted_merge_reservation(
+            pr_comments(repo, number, cwd), head_sha, trusted_reviewers
+        ):
+            continue
+        if not has_trusted_exact_head_approval(
+            pr_reviews(repo, number, cwd), head_sha, trusted_reviewers
+        ):
+            continue
+        if apply:
+            mark_intake_accepted(repo, number, cwd)
+        results.append(
+            {
+                "number": number,
+                "head_sha": head_sha,
+                "result": "reconciled-merged" if apply else "would-reconcile-merged",
+            }
+        )
+    return results
 
 
 def apply_conflict_hold(repo: str, number: int, head_sha: str, cwd: Path) -> None:
@@ -586,7 +1110,8 @@ def apply_review(
     admin_merge: bool,
     historical_best: float | None = None,
     restored_snapshot_score: float | None = None,
-) -> None:
+    trusted_reviewers: set[str] | None = None,
+) -> bool:
     live = pr_meta(repo, number, cwd)
     assert_live(live, head_sha, require_success=True)
     marker = REVIEW_MARKER.format(head_sha=head_sha)
@@ -613,30 +1138,63 @@ def apply_review(
             )
             if historical_best is not None:
                 body += f" Historical exact-head best for this submission: {historical_best:g}/100; this score does not regress it."
-        run(["gh", "pr", "review", str(number), "--repo", repo, "--approve", "--body", body], cwd=cwd)
-        assert_live(pr_meta(repo, number, cwd), head_sha, require_success=True)
-        merge = [
-            "gh",
-            "pr",
-            "merge",
-            str(number),
-            "--repo",
-            repo,
-            "--merge",
-            "--match-head-commit",
-            head_sha,
-        ]
-        if admin_merge:
-            merge.append("--admin")
-        run(merge, cwd=cwd)
-        run(
-            ["gh", "pr", "edit", str(number), "--repo", repo, *label_args(
-                ["review/queued"],
-                ["review/intake-accepted"],
-            )],
-            cwd=cwd,
-        )
-        return
+        allowed = trusted_reviewers or trusted_reviewer_logins()
+        if not has_trusted_merge_reservation(
+            pr_comments(repo, number, cwd), head_sha, allowed
+        ):
+            create_merge_reservation(repo, number, head_sha, allowed, cwd)
+
+        # A pre-existing auto-merge request could consume the approval below
+        # immediately. Remove that unsafe, non-exact-head state before approval
+        # and prove it is gone. Disabling it is safe even if another actor races
+        # a head update; the exact-head reread then fails closed.
+        merge_status = merge_request_status(repo, number, head_sha, cwd)
+        if merge_status == "auto":
+            disable_auto_merge(repo, number, cwd)
+            merge_status = merge_request_status(repo, number, head_sha, cwd)
+            if merge_status == "auto":
+                raise WorkerError(
+                    "pre-existing auto-merge remained enabled; disabled fail closed"
+                )
+        if merge_status == "closed":
+            raise WorkerError("PR closed before exact-head approval")
+
+        if not has_trusted_exact_head_approval(
+            pr_reviews(repo, number, cwd), head_sha, allowed
+        ):
+            if merge_status == "merged":
+                raise WorkerError("PR merged without a trusted exact-head approval")
+            run(
+                ["gh", "pr", "review", str(number), "--repo", repo, "--approve", "--body", body],
+                cwd=cwd,
+            )
+            if not has_trusted_exact_head_approval(
+                pr_reviews(repo, number, cwd), head_sha, allowed
+            ):
+                raise WorkerError("exact-head approval was not written by a trusted reviewer")
+
+        # Approval may immediately advance an existing exact-head queue entry,
+        # so reconcile again before deciding whether an atomic request is needed.
+        merge_status = merge_request_status(repo, number, head_sha, cwd)
+        if merge_status == "auto":
+            disable_auto_merge(repo, number, cwd)
+            raise WorkerError(
+                "auto-merge appeared after approval; disabled fail closed"
+            )
+        if merge_status == "absent":
+            merge_status = submit_merge_request(
+                repo,
+                number,
+                head_sha,
+                cwd,
+                admin_merge=admin_merge,
+            )
+        if merge_status == "pending":
+            return False
+        if merge_status != "merged":
+            raise WorkerError("merge command completed without a confirmed merged PR")
+        mark_intake_accepted(repo, number, cwd)
+        return True
 
     body = comment_file.read_text(encoding="utf-8")
     if outcome.action == "score-regression" and historical_best is not None:
@@ -657,27 +1215,128 @@ def apply_review(
         ["gh", "pr", "edit", str(number), "--repo", repo, *label_args(["review/queued"], add)],
         cwd=cwd,
     )
+    return True
 
 
-def process_pr(
+def score_guard_context(
+    repo_root: Path,
+    candidate_worktree: Path,
+    submission_dir: str,
+    merged_prs: list[dict[str, Any]],
+    score_ledger: list[dict[str, Any]],
+    trusted_reviewers: set[str],
+    score_guard_policy: ScoreGuardPolicy,
+) -> tuple[float | None, float | None]:
+    """Recompute the package high-water and exact-snapshot restoration score."""
+    if not score_guard_policy.applies_to(submission_dir):
+        return None, None
+    live_best = historical_best_score(merged_prs, submission_dir, trusted_reviewers)
+    ledger_best = ledger_best_score(score_ledger, submission_dir)
+    trusted_records = trusted_score_records(
+        merged_prs, submission_dir, trusted_reviewers
+    ) + ledger_score_records(score_ledger, submission_dir)
+    historical_best = max(
+        [score for score in (live_best, ledger_best) if score is not None],
+        default=None,
+    )
+    restored_snapshot_score = trusted_snapshot_score(
+        repo_root, candidate_worktree, submission_dir, trusted_records
+    )
+    return historical_best, restored_snapshot_score
+
+
+def apply_review_with_fresh_score_context(
     args: argparse.Namespace,
-    meta: dict[str, Any],
+    number: int,
+    head_sha: str,
+    author: str,
+    submission_dir: str,
+    worktree: Path,
+    review: dict[str, Any],
+    ai_decision: dict[str, Any],
+    comment_file: Path,
     repo_root: Path,
     history_cache: dict[str, list[dict[str, Any]]],
     score_ledger: list[dict[str, Any]],
-) -> dict[str, Any]:
-    number = int(meta["number"])
-    head_sha = str(meta["headRefOid"])
-    author = str(meta["author"]["login"])
-    state = ci_state(meta)
-    if meta.get("isDraft"):
-        return {"number": number, "result": "skipped-draft"}
-    if state != "success":
-        return {"number": number, "head_sha": head_sha, "result": f"skipped-ci-{state}"}
-    if meta.get("mergeable") == "CONFLICTING":
-        return {"number": number, "head_sha": head_sha, "result": "skipped-conflicting"}
+    trusted_reviewers: set[str],
+    score_guard_policy: ScoreGuardPolicy,
+) -> tuple[Decision, float | None, float | None]:
+    """Refresh history and candidate tree under the actual GitHub write lock."""
+    with GITHUB_WRITE_LOCK:
+        guard_prs = score_guard_prs_for_author(args.repo, author, repo_root)
+        pending_numbers = pending_trusted_intake_numbers(
+            guard_prs,
+            submission_dir,
+            trusted_reviewers,
+            args.repo,
+            repo_root,
+        )
+        other_pending = pending_numbers - {number}
+        if other_pending:
+            pending_list = ", ".join(f"#{item}" for item in sorted(other_pending))
+            raise WorkerError(
+                f"another exact-head merge reservation for {submission_dir} is still open "
+                f"({pending_list}); wait for MERGED or close it before reviewing this candidate"
+            )
+        if score_guard_policy.applies_to(submission_dir):
+            merged_prs = [
+                pr for pr in guard_prs if str(pr.get("state", "")).upper() == "MERGED"
+            ]
+        else:
+            merged_prs = []
+        historical_best, restored_snapshot_score = score_guard_context(
+            repo_root,
+            worktree,
+            submission_dir,
+            merged_prs,
+            score_ledger,
+            trusted_reviewers,
+            score_guard_policy,
+        )
+        outcome = decide(
+            review,
+            ai_decision,
+            args.threshold,
+            historical_best,
+            restored_snapshot_score,
+        )
+        merged_or_written = apply_review(
+            args.repo,
+            number,
+            head_sha,
+            outcome,
+            comment_file,
+            repo_root,
+            admin_merge=args.admin_merge,
+            historical_best=historical_best,
+            restored_snapshot_score=restored_snapshot_score,
+            trusted_reviewers=trusted_reviewers,
+        )
+        if outcome.action in {"accept", "restore-high-water"} and not merged_or_written:
+            outcome = Decision(
+                "merge-pending",
+                outcome.score,
+                "exact-head approval is waiting for GitHub to confirm MERGED",
+            )
+        # The accepted path may just have merged a new score. Never let the
+        # next candidate reuse the pre-write author history snapshot.
+        with HISTORY_LOCK:
+            history_cache.pop(author, None)
+    return outcome, historical_best, restored_snapshot_score
 
-    submission_dir = submission_dir_from_files(pr_file_paths(args.repo, number, repo_root), author)
+
+def _process_submission_pr(
+    args: argparse.Namespace,
+    number: int,
+    head_sha: str,
+    author: str,
+    submission_dir: str,
+    repo_root: Path,
+    history_cache: dict[str, list[dict[str, Any]]],
+    score_ledger: list[dict[str, Any]],
+    trusted_reviewers: set[str],
+    score_guard_policy: ScoreGuardPolicy,
+) -> dict[str, Any]:
     worktree = args.worktree_root / f"pr-{number}-{head_sha[:12]}"
     audit_dir = args.audit_root / f"pr-{number}" / head_sha
     ref = f"refs/codex-auto-review/pr-{number}-{head_sha[:12]}"
@@ -690,21 +1349,21 @@ def process_pr(
         checked = run(["git", "rev-parse", "HEAD"], cwd=worktree).stdout.strip()
         if checked != head_sha:
             raise WorkerError("fetched worktree SHA does not match live PR head")
-        with HISTORY_LOCK:
-            if author not in history_cache:
-                history_cache[author] = merged_prs_for_author(args.repo, author, repo_root)
-            merged_prs = history_cache[author]
-        live_best = historical_best_score(merged_prs, submission_dir, trusted_reviewer_logins())
-        ledger_best = ledger_best_score(score_ledger, submission_dir)
-        trusted_records = trusted_score_records(
-            merged_prs, submission_dir, trusted_reviewer_logins()
-        ) + ledger_score_records(score_ledger, submission_dir)
-        historical_best = max(
-            [score for score in (live_best, ledger_best) if score is not None],
-            default=None,
-        )
-        restored_snapshot_score = trusted_snapshot_score(
-            repo_root, worktree, submission_dir, trusted_records
+        if score_guard_policy.applies_to(submission_dir):
+            with HISTORY_LOCK:
+                if author not in history_cache:
+                    history_cache[author] = merged_prs_for_author(args.repo, author, repo_root)
+                merged_prs = history_cache[author]
+        else:
+            merged_prs = []
+        historical_best, restored_snapshot_score = score_guard_context(
+            repo_root,
+            worktree,
+            submission_dir,
+            merged_prs,
+            score_ledger,
+            trusted_reviewers,
+            score_guard_policy,
         )
         cached = load_cached_review(
             audit_dir,
@@ -765,24 +1424,108 @@ def process_pr(
             "reused_audit": reused_audit,
         }
         if args.apply:
-            with GITHUB_WRITE_LOCK:
-                apply_review(
-                    args.repo,
-                    number,
-                    head_sha,
-                    outcome,
-                    audit_dir / "pr-comment.md",
-                    repo_root,
-                    admin_merge=args.admin_merge,
-                    historical_best=historical_best,
-                    restored_snapshot_score=restored_snapshot_score,
-                )
+            outcome, historical_best, restored_snapshot_score = apply_review_with_fresh_score_context(
+                args,
+                number,
+                head_sha,
+                author,
+                submission_dir,
+                worktree,
+                review,
+                ai_decision,
+                audit_dir / "pr-comment.md",
+                repo_root,
+                history_cache,
+                score_ledger,
+                trusted_reviewers,
+                score_guard_policy,
+            )
+            result.update(
+                {
+                    "score": outcome.score,
+                    "result": outcome.action,
+                    "reason": outcome.reason,
+                    "historical_best_score": historical_best,
+                    "restored_snapshot_score": restored_snapshot_score,
+                }
+            )
             result["applied"] = True
         return result
     finally:
         if worktree.exists() and not args.keep_worktrees:
             with WORKTREE_LOCK:
                 run(["git", "worktree", "remove", "--force", str(worktree)], cwd=repo_root)
+
+
+def process_pr(
+    args: argparse.Namespace,
+    meta: dict[str, Any],
+    repo_root: Path,
+    history_cache: dict[str, list[dict[str, Any]]],
+    score_ledger: list[dict[str, Any]],
+    trusted_reviewers: set[str],
+    score_guard_policy: ScoreGuardPolicy,
+) -> dict[str, Any]:
+    number = int(meta["number"])
+    head_sha = str(meta["headRefOid"])
+    author = str(meta["author"]["login"])
+    state = ci_state(meta)
+    if meta.get("isDraft"):
+        return {"number": number, "result": "skipped-draft"}
+    if state != "success":
+        return {"number": number, "head_sha": head_sha, "result": f"skipped-ci-{state}"}
+    if meta.get("mergeable") == "CONFLICTING":
+        return {"number": number, "head_sha": head_sha, "result": "skipped-conflicting"}
+
+    submission_dir = str(meta.get("_submission_dir") or "")
+    if not submission_dir:
+        submission_dir = submission_dir_from_files(
+            pr_file_paths(args.repo, number, repo_root), author
+        )
+    with submission_dir_lock(submission_dir):
+        return _process_submission_pr(
+            args,
+            number,
+            head_sha,
+            author,
+            submission_dir,
+            repo_root,
+            history_cache,
+            score_ledger,
+            trusted_reviewers,
+            score_guard_policy,
+        )
+
+
+def process_submission_group(
+    args: argparse.Namespace,
+    metas: list[dict[str, Any]],
+    repo_root: Path,
+    history_cache: dict[str, list[dict[str, Any]]],
+    score_ledger: list[dict[str, Any]],
+    trusted_reviewers: set[str],
+    score_guard_policy: ScoreGuardPolicy,
+) -> list[dict[str, Any]]:
+    """Process one package directory in deterministic PR-number order."""
+    results: list[dict[str, Any]] = []
+    for meta in sorted(metas, key=lambda item: int(item["number"])):
+        try:
+            results.append(
+                process_pr(
+                    args,
+                    meta,
+                    repo_root,
+                    history_cache,
+                    score_ledger,
+                    trusted_reviewers,
+                    score_guard_policy,
+                )
+            )
+        except Exception as exc:
+            results.append(
+                {"number": meta.get("number"), "result": "error", "error": str(exc)}
+            )
+    return results
 
 
 def acquire_worker_lock(lock_path: Path) -> Any:
@@ -835,6 +1578,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--worktree-root", type=Path, default=Path(".pr-worktree/auto-review"))
     parser.add_argument("--apply", action="store_true", help="Post reviews, change labels, and merge accepted PRs")
     parser.add_argument("--admin-merge", action="store_true", help="Use the repository ruleset bypass during merge")
+    parser.add_argument(
+        "--score-guard-policy-file",
+        type=Path,
+        help=(
+            "Enable score-high-water enforcement using an explicit maintainer-approved "
+            "scope/effective-date policy; disabled when omitted"
+        ),
+    )
     parser.add_argument("--keep-worktrees", action="store_true")
     return parser.parse_args()
 
@@ -856,11 +1607,28 @@ def main() -> int:
         raise WorkerError("--concurrency must be at least 1")
     args.audit_root.mkdir(parents=True, exist_ok=True)
     lock_file = acquire_worker_lock(args.audit_root / ".worker.lock")
-    candidates = queued_prs(args.repo, args.label, repo_root)
     selected = []
     results = []
     history_cache: dict[str, list[dict[str, Any]]] = {}
-    score_ledger = load_trusted_score_ledger(repo_root)
+    trusted_reviewers = trusted_reviewer_logins()
+    validate_trusted_reviewer_identities(trusted_reviewers, repo_root)
+    if args.score_guard_policy_file is not None:
+        policy_path = args.score_guard_policy_file.expanduser().resolve()
+        score_guard_policy = load_score_guard_policy(policy_path, trusted_reviewers)
+        score_ledger = load_trusted_score_ledger(repo_root, trusted_reviewers)
+    else:
+        score_guard_policy = DISABLED_SCORE_GUARD_POLICY
+        score_ledger = []
+    results.extend(
+        reconcile_merged_reservations(
+            args.repo,
+            args.label,
+            trusted_reviewers,
+            repo_root,
+            apply=args.apply,
+        )
+    )
+    candidates = queued_prs(args.repo, args.label, repo_root)
     for candidate in sorted(candidates, key=lambda item: int(item["number"])):
         if len(selected) >= args.limit:
             break
@@ -889,19 +1657,47 @@ def main() -> int:
                 }
             )
             continue
+        try:
+            submission_dir = submission_dir_from_files(
+                pr_file_paths(args.repo, number, repo_root),
+                str(live["author"]["login"]),
+            )
+        except Exception as exc:
+            results.append({"number": number, "result": "error", "error": str(exc)})
+            continue
+        live = {**live, "_submission_dir": submission_dir}
         selected.append(live)
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for meta in selected:
+        groups.setdefault(str(meta["_submission_dir"]), []).append(meta)
     with ThreadPoolExecutor(max_workers=args.concurrency) as executor:
         futures = {
-            executor.submit(process_pr, args, meta, repo_root, history_cache, score_ledger): meta
-            for meta in selected
+            executor.submit(
+                process_submission_group,
+                args,
+                metas,
+                repo_root,
+                history_cache,
+                score_ledger,
+                trusted_reviewers,
+                score_guard_policy,
+            ): submission_dir
+            for submission_dir, metas in groups.items()
         }
         for future in as_completed(futures):
-            meta = futures[future]
             try:
-                results.append(future.result())
-            except Exception as exc:  # Keep independent PR failures from stopping the queue.
-                results.append({"number": meta.get("number"), "result": "error", "error": str(exc)})
-            print(json.dumps(results[-1], ensure_ascii=False), flush=True)
+                group_results = future.result()
+            except Exception as exc:
+                group_results = [
+                    {
+                        "number": None,
+                        "result": "error",
+                        "error": f"submission group {futures[future]} failed: {exc}",
+                    }
+                ]
+            results.extend(group_results)
+            for result in group_results:
+                print(json.dumps(result, ensure_ascii=False), flush=True)
     results.sort(key=lambda item: int(item.get("number") or 0))
     print(json.dumps(results, ensure_ascii=False, indent=2))
     return 1 if any(item.get("result") == "error" for item in results) else 0

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -1,7 +1,11 @@
 import json
+import os
 import sys
 import tempfile
+import threading
 import unittest
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -11,22 +15,41 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
 from auto_review_queue import (  # noqa: E402
+    DISABLED_SCORE_GUARD_POLICY,
     Decision,
+    MERGE_PENDING_MARKER,
+    REVIEW_MARKER,
+    ScoreGuardPolicy,
+    TRUSTED_REVIEWERS_ENV,
     WorkerError,
     acquire_worker_lock,
+    create_merge_reservation,
+    apply_review_with_fresh_score_context,
     apply_review,
     ci_state,
     decide,
     historical_best_score,
     ledger_best_score,
+    load_score_guard_policy,
     load_trusted_score_ledger,
     load_cached_review,
     official_score_from_review,
+    merge_request_status,
+    merge_reservation_body,
     parse_args,
+    process_submission_group,
+    process_pr,
+    pr_comments,
     pr_file_paths,
+    pr_reviews,
+    reconcile_merged_reservations,
     queued_prs,
     submission_dir_from_files,
+    submission_dir_lock,
+    submit_merge_request,
+    trusted_reviewer_logins,
     trusted_snapshot_score,
+    validate_trusted_reviewer_identities,
 )
 from generate_submissions_data import package_sha256  # noqa: E402
 
@@ -47,9 +70,40 @@ class AutoReviewQueueTests(unittest.TestCase):
             with self.subTest(admin_merge=admin_merge):
                 with (
                     patch("auto_review_queue.pr_meta", return_value=live),
+                    patch(
+                        "auto_review_queue.merge_request_status",
+                        side_effect=["absent", "absent"],
+                    ),
+                    patch(
+                        "auto_review_queue.pr_comments",
+                        return_value=[
+                            {
+                                "user": {"login": "CocoSgt"},
+                                "body": merge_reservation_body(head_sha),
+                            }
+                        ],
+                    ),
+                    patch(
+                        "auto_review_queue.pr_reviews",
+                        side_effect=[
+                            [],
+                            [
+                                {
+                                    "state": "APPROVED",
+                                    "user": {"login": "CocoSgt"},
+                                    "commit_id": head_sha,
+                                    "body": REVIEW_MARKER.format(head_sha=head_sha),
+                                }
+                            ],
+                        ],
+                    ),
+                    patch(
+                        "auto_review_queue.submit_merge_request",
+                        return_value="merged",
+                    ) as submit_mock,
                     patch("auto_review_queue.run") as run_mock,
                 ):
-                    apply_review(
+                    merged = apply_review(
                         "open-city-ai/haidian",
                         42,
                         head_sha,
@@ -59,20 +113,14 @@ class AutoReviewQueueTests(unittest.TestCase):
                         admin_merge=admin_merge,
                     )
 
-                    run_mock.assert_any_call(
-                        [
-                            "gh",
-                            "pr",
-                            "merge",
-                            "42",
-                            "--repo",
-                            "open-city-ai/haidian",
-                            "--merge",
-                            "--match-head-commit",
-                            head_sha,
-                            *(["--admin"] if admin_merge else []),
-                        ],
-                        cwd=ROOT,
+                    self.assertTrue(merged)
+
+                    submit_mock.assert_called_once_with(
+                        "open-city-ai/haidian",
+                        42,
+                        head_sha,
+                        ROOT,
+                        admin_merge=admin_merge,
                     )
                     review_command = next(
                         call.args[0]
@@ -80,6 +128,416 @@ class AutoReviewQueueTests(unittest.TestCase):
                         if call.args[0][:3] == ["gh", "pr", "review"]
                     )
                     self.assertIn("review readiness passed", review_command[-1])
+
+    def test_merge_queue_is_not_reported_as_confirmed_intake(self) -> None:
+        head_sha = "a" * 40
+        live = {
+            "headRefOid": head_sha,
+            "state": "OPEN",
+            "isDraft": False,
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [
+                {"name": "submission-validation", "conclusion": "SUCCESS"}
+            ],
+        }
+        with (
+            patch("auto_review_queue.pr_meta", return_value=live),
+            patch(
+                "auto_review_queue.merge_request_status",
+                side_effect=["absent", "absent"],
+            ),
+            patch(
+                "auto_review_queue.pr_comments",
+                return_value=[
+                    {
+                        "user": {"login": "CocoSgt"},
+                        "body": merge_reservation_body(head_sha),
+                    }
+                ],
+            ),
+            patch(
+                "auto_review_queue.pr_reviews",
+                side_effect=[
+                    [],
+                    [
+                        {
+                            "state": "APPROVED",
+                            "user": {"login": "CocoSgt"},
+                            "commit_id": head_sha,
+                            "body": REVIEW_MARKER.format(head_sha=head_sha),
+                        }
+                    ],
+                ],
+            ),
+            patch(
+                "auto_review_queue.submit_merge_request", return_value="pending"
+            ),
+            patch("auto_review_queue.run") as run_mock,
+        ):
+            merged = apply_review(
+                "open-city-ai/haidian",
+                42,
+                head_sha,
+                Decision("accept", 90, "accepted"),
+                ROOT / "unused-comment.md",
+                ROOT,
+                admin_merge=False,
+            )
+
+        self.assertFalse(merged)
+        self.assertFalse(
+            any(
+                call.args[0][:3] == ["gh", "pr", "edit"]
+                and "review/intake-accepted" in call.args[0]
+                for call in run_mock.call_args_list
+            )
+        )
+
+    def test_merge_request_status_distinguishes_queue_auto_merge_and_absence(self) -> None:
+        head_sha = "a" * 40
+
+        def payload(**fields: object) -> SimpleNamespace:
+            pull = {
+                "id": "PR_node_42",
+                "state": "OPEN",
+                "headRefOid": head_sha,
+                **fields,
+            }
+            return SimpleNamespace(
+                stdout=json.dumps(
+                    {"data": {"repository": {"pullRequest": pull}}}
+                )
+            )
+
+        cases = [
+            (
+                payload(
+                    mergeQueueEntry={
+                        "state": "QUEUED",
+                        "headCommit": {"oid": "b" * 40},
+                    },
+                    autoMergeRequest=None,
+                ),
+                "pending",
+            ),
+            (
+                payload(mergeQueueEntry=None, autoMergeRequest={"enabledAt": "now"}),
+                "auto",
+            ),
+            (
+                payload(mergeQueueEntry=None, autoMergeRequest=None),
+                "absent",
+            ),
+            (
+                SimpleNamespace(
+                    stdout=json.dumps(
+                        {
+                            "data": {
+                                "repository": {
+                                    "pullRequest": {
+                                        "id": "PR_node_42",
+                                        "state": "MERGED",
+                                        "headRefOid": head_sha,
+                                        "mergeQueueEntry": None,
+                                        "autoMergeRequest": None,
+                                    }
+                                }
+                            }
+                        }
+                    )
+                ),
+                "merged",
+            ),
+        ]
+        for response, expected in cases:
+            with self.subTest(expected=expected):
+                with patch("auto_review_queue.run", return_value=response):
+                    self.assertEqual(
+                        expected,
+                        merge_request_status(
+                            "open-city-ai/haidian", 42, head_sha, ROOT
+                        ),
+                    )
+
+    def test_submit_merge_request_uses_atomic_exact_head_graphql(self) -> None:
+        head_sha = "a" * 40
+        live = {
+            "headRefOid": head_sha,
+            "state": "OPEN",
+            "isDraft": False,
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [
+                {"name": "submission-validation", "conclusion": "SUCCESS"}
+            ],
+        }
+        queue_pull = {
+            "id": "PR_node_42",
+            "state": "OPEN",
+            "headRefOid": head_sha,
+            "isMergeQueueEnabled": True,
+        }
+        queue_response = SimpleNamespace(
+            stdout=json.dumps(
+                {
+                    "data": {
+                        "enqueuePullRequest": {
+                            "mergeQueueEntry": {"id": "MQE_42", "state": "QUEUED"}
+                        }
+                    }
+                }
+            )
+        )
+        with (
+            patch("auto_review_queue.pr_meta", return_value=live),
+            patch("auto_review_queue.merge_request_snapshot", return_value=queue_pull),
+            patch("auto_review_queue.run", return_value=queue_response) as run_mock,
+        ):
+            self.assertEqual(
+                "pending",
+                submit_merge_request(
+                    "open-city-ai/haidian",
+                    42,
+                    head_sha,
+                    ROOT,
+                    admin_merge=False,
+                ),
+            )
+        queue_command = run_mock.call_args.args[0]
+        self.assertEqual(["gh", "api", "graphql"], queue_command[:3])
+        self.assertIn("enqueuePullRequest", queue_command[4])
+        self.assertIn(f"expectedHeadOid={head_sha}", queue_command)
+        self.assertNotIn("--auto", queue_command)
+
+        direct_pull = {**queue_pull, "isMergeQueueEnabled": False}
+        direct_response = SimpleNamespace(
+            stdout=json.dumps(
+                {
+                    "data": {
+                        "mergePullRequest": {
+                            "pullRequest": {
+                                "state": "MERGED",
+                                "headRefOid": head_sha,
+                            }
+                        }
+                    }
+                }
+            )
+        )
+        with (
+            patch("auto_review_queue.pr_meta", return_value=live),
+            patch("auto_review_queue.merge_request_snapshot", return_value=direct_pull),
+            patch("auto_review_queue.run", return_value=direct_response) as run_mock,
+        ):
+            self.assertEqual(
+                "merged",
+                submit_merge_request(
+                    "open-city-ai/haidian",
+                    42,
+                    head_sha,
+                    ROOT,
+                    admin_merge=False,
+                ),
+            )
+        direct_command = run_mock.call_args.args[0]
+        self.assertEqual(["gh", "api", "graphql"], direct_command[:3])
+        self.assertIn("mergePullRequest", direct_command[4])
+        self.assertIn(f"expectedHeadOid={head_sha}", direct_command)
+        self.assertNotIn("--auto", direct_command)
+
+    def test_preexisting_auto_merge_is_disabled_before_approval(self) -> None:
+        head_sha = "a" * 40
+        live = {
+            "headRefOid": head_sha,
+            "state": "OPEN",
+            "isDraft": False,
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [
+                {"name": "submission-validation", "conclusion": "SUCCESS"}
+            ],
+        }
+        reservation = [
+            {
+                "user": {"login": "CocoSgt"},
+                "body": merge_reservation_body(head_sha),
+            }
+        ]
+        approval = {
+            "state": "APPROVED",
+            "user": {"login": "CocoSgt"},
+            "commit_id": head_sha,
+            "body": REVIEW_MARKER.format(head_sha=head_sha),
+        }
+        events: list[str] = []
+
+        def record_run(command: list[str], **_: object) -> SimpleNamespace:
+            if command[:3] == ["gh", "pr", "review"]:
+                events.append("approve")
+            return SimpleNamespace(stdout="")
+
+        with (
+            patch("auto_review_queue.pr_meta", return_value=live),
+            patch("auto_review_queue.pr_comments", return_value=reservation),
+            patch("auto_review_queue.pr_reviews", side_effect=[[], [approval]]),
+            patch(
+                "auto_review_queue.merge_request_status",
+                side_effect=["auto", "absent", "absent"],
+            ),
+            patch(
+                "auto_review_queue.disable_auto_merge",
+                side_effect=lambda *_: events.append("disable"),
+            ),
+            patch("auto_review_queue.submit_merge_request", return_value="pending"),
+            patch("auto_review_queue.run", side_effect=record_run),
+        ):
+            self.assertFalse(
+                apply_review(
+                    "open-city-ai/haidian",
+                    42,
+                    head_sha,
+                    Decision("accept", 90, "accepted"),
+                    ROOT / "unused-comment.md",
+                    ROOT,
+                    admin_merge=False,
+                    trusted_reviewers={"cocosgt"},
+                )
+            )
+        self.assertEqual(["disable", "approve"], events)
+
+    def test_acceptance_state_machine_resumes_without_duplicate_writes(self) -> None:
+        head_sha = "a" * 40
+        live = {
+            "headRefOid": head_sha,
+            "state": "OPEN",
+            "isDraft": False,
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [
+                {"name": "submission-validation", "conclusion": "SUCCESS"}
+            ],
+        }
+        reservation = [
+            {
+                "user": {"login": "CocoSgt"},
+                "body": (
+                    f"{MERGE_PENDING_MARKER.format(head_sha=head_sha)}\n"
+                    "Exact-head merge reservation: this package is fail-closed until GitHub confirms "
+                    "the PR as MERGED or a maintainer closes the PR."
+                ),
+            }
+        ]
+        approval = {
+            "state": "APPROVED",
+            "user": {"login": "CocoSgt"},
+            "commit_id": head_sha,
+            "body": REVIEW_MARKER.format(head_sha=head_sha),
+        }
+        with (
+            patch("auto_review_queue.pr_meta", return_value=live),
+            patch("auto_review_queue.pr_comments", return_value=reservation),
+            patch("auto_review_queue.pr_reviews", side_effect=[[], [approval]]),
+            patch("auto_review_queue.merge_request_status", return_value="absent"),
+            patch("auto_review_queue.submit_merge_request", return_value="pending") as submit_mock,
+            patch("auto_review_queue.run") as run_mock,
+        ):
+            result = apply_review(
+                "open-city-ai/haidian",
+                42,
+                head_sha,
+                Decision("accept", 90, "accepted"),
+                ROOT / "unused-comment.md",
+                ROOT,
+                admin_merge=False,
+                trusted_reviewers={"cocosgt"},
+            )
+        self.assertFalse(result)
+        self.assertEqual(
+            1,
+            sum(
+                call.args[0][:3] == ["gh", "pr", "review"]
+                for call in run_mock.call_args_list
+            ),
+        )
+        submit_mock.assert_called_once()
+
+        with (
+            patch("auto_review_queue.pr_meta", return_value=live),
+            patch("auto_review_queue.pr_comments", return_value=reservation),
+            patch("auto_review_queue.pr_reviews", return_value=[approval]),
+            patch("auto_review_queue.merge_request_status", return_value="pending"),
+            patch("auto_review_queue.run") as idempotent_run,
+        ):
+            repeated = apply_review(
+                "open-city-ai/haidian",
+                42,
+                head_sha,
+                Decision("accept", 90, "accepted"),
+                ROOT / "unused-comment.md",
+                ROOT,
+                admin_merge=False,
+                trusted_reviewers={"cocosgt"},
+            )
+        self.assertFalse(repeated)
+        idempotent_run.assert_not_called()
+
+        with (
+            patch("auto_review_queue.pr_meta", return_value=live),
+            patch("auto_review_queue.pr_comments", return_value=reservation),
+            patch("auto_review_queue.pr_reviews", return_value=[approval]),
+            patch("auto_review_queue.merge_request_status", return_value="auto"),
+            patch("auto_review_queue.submit_merge_request") as submit_mock,
+            patch("auto_review_queue.disable_auto_merge") as disable_mock,
+        ):
+            with self.assertRaisesRegex(WorkerError, "disabled fail closed"):
+                apply_review(
+                    "open-city-ai/haidian",
+                    42,
+                    head_sha,
+                    Decision("accept", 90, "accepted"),
+                    ROOT / "unused-comment.md",
+                    ROOT,
+                    admin_merge=False,
+                    trusted_reviewers={"cocosgt"},
+                )
+        self.assertEqual(1, disable_mock.call_count)
+        submit_mock.assert_not_called()
+
+    def test_new_reservation_verifies_the_returned_comment_author(self) -> None:
+        head_sha = "a" * 40
+        trusted = SimpleNamespace(
+            stdout=json.dumps(
+                {
+                    "id": 123,
+                    "user": {"login": "CocoSgt"},
+                    "body": merge_reservation_body(head_sha),
+                }
+            )
+        )
+        with patch("auto_review_queue.run", return_value=trusted):
+            create_merge_reservation(
+                "open-city-ai/haidian",
+                42,
+                head_sha,
+                {"cocosgt"},
+                ROOT,
+            )
+
+        untrusted = SimpleNamespace(
+            stdout=json.dumps(
+                {
+                    "id": 124,
+                    "user": {"login": "someone-else"},
+                    "body": merge_reservation_body(head_sha),
+                }
+            )
+        )
+        with patch("auto_review_queue.run", return_value=untrusted):
+            with self.assertRaisesRegex(WorkerError, "not authored"):
+                create_merge_reservation(
+                    "open-city-ai/haidian",
+                    42,
+                    head_sha,
+                    {"cocosgt"},
+                    ROOT,
+                )
 
     def test_trusted_score_ledger_supplies_a_package_high_water_mark(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -142,6 +600,380 @@ class AutoReviewQueueTests(unittest.TestCase):
             )
             with self.assertRaises(WorkerError):
                 load_trusted_score_ledger(root, {"cocosgt"})
+
+    def test_trusted_reviewer_environment_is_an_explicit_full_replacement(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual({"cocosgt", "wakenmeng"}, trusted_reviewer_logins())
+        with patch.dict(
+            os.environ,
+            {TRUSTED_REVIEWERS_ENV: "Release-Bot,NewMaintainer"},
+            clear=True,
+        ):
+            self.assertEqual(
+                {"release-bot", "newmaintainer"}, trusted_reviewer_logins()
+            )
+        with patch.dict(
+            os.environ,
+            {TRUSTED_REVIEWERS_ENV: "Release-App[bot]"},
+            clear=True,
+        ):
+            self.assertEqual({"release-app[bot]"}, trusted_reviewer_logins())
+        for invalid in ("", "cocosgt,", "cocosgt,,wakenmeng", "-bad", "bad--login", "CocoSgt,cocosgt"):
+            with self.subTest(invalid=invalid):
+                with patch.dict(
+                    os.environ, {TRUSTED_REVIEWERS_ENV: invalid}, clear=True
+                ):
+                    with self.assertRaises(WorkerError):
+                        trusted_reviewer_logins()
+
+    def test_trusted_reviewer_identities_must_resolve_exactly(self) -> None:
+        def identity_response(command: list[str], *, cwd: Path, capture: bool = True) -> SimpleNamespace:
+            login = "cocosgt" if command[-1] == "user" else command[-1].split("/", 1)[1]
+            return SimpleNamespace(
+                stdout=json.dumps({"login": login, "type": "User", "id": 123})
+            )
+
+        with patch("auto_review_queue.run", side_effect=identity_response) as run_mock:
+            validate_trusted_reviewer_identities({"cocosgt", "wakenmeng"}, ROOT)
+        self.assertEqual(2, run_mock.call_count)
+
+        with patch(
+            "auto_review_queue.run",
+            return_value=SimpleNamespace(
+                stdout=json.dumps({"login": "someone-else", "type": "User", "id": 123})
+            ),
+        ):
+            with self.assertRaises(WorkerError):
+                validate_trusted_reviewer_identities({"cocosgt"}, ROOT)
+
+    def test_score_guard_is_disabled_without_an_approved_policy_file(self) -> None:
+        self.assertEqual(
+            DISABLED_SCORE_GUARD_POLICY,
+            load_score_guard_policy(None, {"cocosgt"}),
+        )
+
+    def test_score_guard_policy_fixes_scope_effective_date_and_migration(self) -> None:
+        payload = {
+            "schema_version": 1,
+            "status": "approved",
+            "effective_at": "2026-08-01T00:00:00Z",
+            "history_scope": "all-merged-history",
+            "submission_dirs": ["submissions/alice/plan"],
+            "ledger_migration": "complete",
+            "compatibility_decision": "approved",
+            "rollback_plan": "Stop the worker and omit the policy file on restart.",
+            "approved_by": ["CocoSgt"],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "policy.json"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            policy = load_score_guard_policy(
+                path,
+                {"cocosgt"},
+                now=datetime(2026, 8, 24, tzinfo=timezone.utc),
+            )
+            self.assertTrue(policy.applies_to("submissions/alice/plan"))
+            self.assertFalse(policy.applies_to("submissions/alice/other"))
+
+            payload["ledger_migration"] = "partial"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            with self.assertRaises(WorkerError):
+                load_score_guard_policy(
+                    path,
+                    {"cocosgt"},
+                    now=datetime(2026, 8, 24, tzinfo=timezone.utc),
+                )
+
+    def test_final_write_refresh_blocks_second_concurrent_score_regression(self) -> None:
+        review = {
+            "mandatory_rejection": {"result": "pass"},
+            "gate_checks": {
+                name: {"status": "pass"}
+                for name in [
+                    "deterministic_validation",
+                    "spatial_review",
+                    "visual_review",
+                    "professional_evidence_review",
+                ]
+            },
+            "recommendation": "formal-review-ready",
+            "can_enter_formal_review": True,
+            "required_next_actions_zh": [],
+        }
+        args = SimpleNamespace(
+            repo="open-city-ai/haidian", threshold=60, admin_merge=False
+        )
+        submission_dir = "submissions/alice/plan"
+        merged_state: list[dict[str, object]] = []
+        policy = ScoreGuardPolicy(
+            True,
+            datetime(2026, 8, 1, tzinfo=timezone.utc),
+            frozenset({submission_dir}),
+        )
+        first_in_apply = threading.Event()
+        release_first = threading.Event()
+
+        def fake_merged(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
+            return list(merged_state)
+
+        def fake_apply(
+            _repo: str,
+            number: int,
+            head_sha: str,
+            outcome: Decision,
+            *_args: object,
+            **_kwargs: object,
+        ) -> None:
+            if number == 1:
+                first_in_apply.set()
+                self.assertTrue(release_first.wait(timeout=2))
+            if outcome.action == "accept":
+                merged_state.append(
+                    {
+                        "number": number,
+                        "state": "MERGED",
+                        "headRefOid": head_sha,
+                        "files": [{"path": f"{submission_dir}/manifest.json"}],
+                        "reviews": [
+                            {
+                                "state": "APPROVED",
+                                "author": {"login": "CocoSgt"},
+                                "body": (
+                                    f"<!-- haidian-auto-review:{head_sha} -->\n"
+                                    f"Maintainer intake decision: Review Agent score {outcome.score:g}/100."
+                                ),
+                            }
+                        ],
+                    }
+                )
+            return True
+
+        def finalize(number: int, score: int):
+            return apply_review_with_fresh_score_context(
+                args,
+                number,
+                str(number) * 40,
+                "alice",
+                submission_dir,
+                ROOT,
+                review,
+                {"weighted_score_100": score},
+                ROOT / "unused-comment.md",
+                ROOT,
+                {},
+                [],
+                {"cocosgt"},
+                policy,
+            )
+
+        with (
+            patch("auto_review_queue.score_guard_prs_for_author", side_effect=fake_merged),
+            patch("auto_review_queue.trusted_snapshot_score", return_value=None),
+            patch("auto_review_queue.apply_review", side_effect=fake_apply),
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            first = executor.submit(finalize, 1, 90)
+            self.assertTrue(first_in_apply.wait(timeout=2))
+            second = executor.submit(finalize, 2, 85)
+            release_first.set()
+            first_result = first.result(timeout=2)
+            second_result = second.result(timeout=2)
+
+        self.assertEqual("accept", first_result[0].action)
+        self.assertEqual("score-regression", second_result[0].action)
+        self.assertEqual(90, second_result[1])
+
+    def test_open_merge_queue_approval_reserves_submission_directory(self) -> None:
+        submission_dir = "submissions/alice/plan"
+        first_head = "1" * 40
+        pending_pr = {
+            "number": 1,
+            "state": "OPEN",
+            "headRefOid": first_head,
+            "files": [{"path": f"{submission_dir}/manifest.json"}],
+            "comments": [
+                {
+                    "author": {"login": "CocoSgt"},
+                    "body": merge_reservation_body(first_head),
+                }
+            ],
+        }
+        review = {
+            "mandatory_rejection": {"result": "pass"},
+            "gate_checks": {
+                name: {"status": "pass"}
+                for name in [
+                    "deterministic_validation",
+                    "spatial_review",
+                    "visual_review",
+                    "professional_evidence_review",
+                ]
+            },
+            "recommendation": "formal-review-ready",
+            "can_enter_formal_review": True,
+            "required_next_actions_zh": [],
+        }
+        args = SimpleNamespace(
+            repo="open-city-ai/haidian", threshold=60, admin_merge=False
+        )
+        policy = ScoreGuardPolicy(
+            True,
+            datetime(2026, 8, 1, tzinfo=timezone.utc),
+            frozenset({submission_dir}),
+        )
+        with (
+            patch("auto_review_queue.score_guard_prs_for_author", return_value=[pending_pr]),
+            patch("auto_review_queue.pr_comments", return_value=pending_pr["comments"]),
+            patch("auto_review_queue.apply_review") as apply_mock,
+        ):
+            with self.assertRaisesRegex(WorkerError, "still open"):
+                apply_review_with_fresh_score_context(
+                    args,
+                    2,
+                    "2" * 40,
+                    "alice",
+                    submission_dir,
+                    ROOT,
+                    review,
+                    {"weighted_score_100": 95},
+                    ROOT / "unused-comment.md",
+                    ROOT,
+                    {},
+                    [],
+                    {"cocosgt"},
+                    policy,
+                )
+        apply_mock.assert_not_called()
+
+        pending_pr["number"] = 2
+        with (
+            patch("auto_review_queue.score_guard_prs_for_author", return_value=[pending_pr]),
+            patch("auto_review_queue.pr_comments", return_value=pending_pr["comments"]),
+            patch("auto_review_queue.apply_review", return_value=False) as repeat_apply_mock,
+        ):
+            repeated = apply_review_with_fresh_score_context(
+                args,
+                2,
+                first_head,
+                "alice",
+                submission_dir,
+                ROOT,
+                review,
+                {"weighted_score_100": 95},
+                ROOT / "unused-comment.md",
+                ROOT,
+                {},
+                [],
+                {"cocosgt"},
+                DISABLED_SCORE_GUARD_POLICY,
+            )
+        self.assertEqual("merge-pending", repeated[0].action)
+        repeat_apply_mock.assert_called_once()
+
+    def test_process_pr_serializes_the_complete_same_directory_lifecycle(self) -> None:
+        args = SimpleNamespace(repo="open-city-ai/haidian")
+        first_entered = threading.Event()
+        second_entered = threading.Event()
+        release_first = threading.Event()
+
+        def fake_process(
+            _args: object,
+            number: int,
+            *_rest: object,
+        ) -> dict[str, object]:
+            if number == 1:
+                first_entered.set()
+                self.assertTrue(release_first.wait(timeout=2))
+            else:
+                second_entered.set()
+            return {"number": number, "result": "done"}
+
+        def meta(number: int) -> dict[str, object]:
+            return {
+                "number": number,
+                "headRefOid": str(number) * 40,
+                "author": {"login": "alice"},
+                "isDraft": False,
+                "mergeable": "MERGEABLE",
+                "statusCheckRollup": [
+                    {"name": "submission-validation", "conclusion": "SUCCESS"}
+                ],
+            }
+
+        with (
+            patch(
+                "auto_review_queue.pr_file_paths",
+                return_value=["submissions/alice/plan/manifest.json"],
+            ),
+            patch("auto_review_queue._process_submission_pr", side_effect=fake_process),
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            first = executor.submit(
+                process_pr,
+                args,
+                meta(1),
+                ROOT,
+                {},
+                [],
+                {"cocosgt"},
+                DISABLED_SCORE_GUARD_POLICY,
+            )
+            self.assertTrue(first_entered.wait(timeout=2))
+            second = executor.submit(
+                process_pr,
+                args,
+                meta(2),
+                ROOT,
+                {},
+                [],
+                {"cocosgt"},
+                DISABLED_SCORE_GUARD_POLICY,
+            )
+            self.assertFalse(second_entered.wait(timeout=0.05))
+            release_first.set()
+            self.assertEqual("done", first.result(timeout=2)["result"])
+            self.assertEqual("done", second.result(timeout=2)["result"])
+        self.assertTrue(second_entered.is_set())
+
+    def test_submission_group_processes_prs_oldest_first(self) -> None:
+        observed: list[int] = []
+
+        def fake_process(
+            _args: object,
+            meta: dict[str, object],
+            *_rest: object,
+        ) -> dict[str, object]:
+            number = int(meta["number"])
+            observed.append(number)
+            return {"number": number, "result": "done"}
+
+        metas = [
+            {"number": 9, "_submission_dir": "submissions/alice/plan"},
+            {"number": 2, "_submission_dir": "submissions/alice/plan"},
+            {"number": 5, "_submission_dir": "submissions/alice/plan"},
+        ]
+        with patch("auto_review_queue.process_pr", side_effect=fake_process):
+            results = process_submission_group(
+                SimpleNamespace(),
+                metas,
+                ROOT,
+                {},
+                [],
+                {"cocosgt"},
+                DISABLED_SCORE_GUARD_POLICY,
+            )
+        self.assertEqual([2, 5, 9], observed)
+        self.assertEqual([2, 5, 9], [item["number"] for item in results])
+
+    def test_submission_directory_lock_is_shared_only_within_one_package(self) -> None:
+        self.assertIs(
+            submission_dir_lock("submissions/alice/plan"),
+            submission_dir_lock("submissions/alice/plan"),
+        )
+        self.assertIsNot(
+            submission_dir_lock("submissions/alice/plan"),
+            submission_dir_lock("submissions/alice/other"),
+        )
 
     def test_default_image_budget_matches_bilingual_packet(self) -> None:
         with patch.object(sys, "argv", ["auto_review_queue"]):
@@ -576,6 +1408,89 @@ class AutoReviewQueueTests(unittest.TestCase):
             ],
             cwd=ROOT,
         )
+
+    def test_pr_comments_reads_every_paginated_page(self) -> None:
+        payload = [
+            [{"id": 1, "body": "older"}],
+            [{"id": 2, "body": "merge reservation"}],
+        ]
+        with patch("auto_review_queue.run") as mocked_run:
+            mocked_run.return_value.stdout = json.dumps(payload)
+            comments = pr_comments("open-city-ai/haidian", 999, ROOT)
+        self.assertEqual([1, 2], [item["id"] for item in comments])
+        mocked_run.assert_called_once_with(
+            [
+                "gh",
+                "api",
+                "--paginate",
+                "--slurp",
+                "repos/open-city-ai/haidian/issues/999/comments",
+            ],
+            cwd=ROOT,
+        )
+
+    def test_pr_reviews_reads_every_paginated_page(self) -> None:
+        payload = [[{"id": 1}], [{"id": 2}]]
+        with patch("auto_review_queue.run") as mocked_run:
+            mocked_run.return_value.stdout = json.dumps(payload)
+            reviews = pr_reviews("open-city-ai/haidian", 999, ROOT)
+        self.assertEqual([1, 2], [item["id"] for item in reviews])
+
+    def test_merged_reservation_is_reconciled_after_leaving_open_queue(self) -> None:
+        head_sha = "a" * 40
+        comments = [
+            {
+                "user": {"login": "CocoSgt"},
+                "body": merge_reservation_body(head_sha),
+            }
+        ]
+        approvals = [
+            {
+                "state": "APPROVED",
+                "user": {"login": "CocoSgt"},
+                "commit_id": head_sha,
+                "body": REVIEW_MARKER.format(head_sha=head_sha),
+            }
+        ]
+        with (
+            patch("auto_review_queue.closed_queued_pull_numbers", return_value=[42]),
+            patch(
+                "auto_review_queue.pr_meta",
+                return_value={"state": "MERGED", "headRefOid": head_sha},
+            ),
+            patch("auto_review_queue.pr_comments", return_value=comments),
+            patch("auto_review_queue.pr_reviews", return_value=approvals),
+            patch("auto_review_queue.mark_intake_accepted") as mark_mock,
+        ):
+            results = reconcile_merged_reservations(
+                "open-city-ai/haidian",
+                "review/queued",
+                {"cocosgt"},
+                ROOT,
+                apply=True,
+            )
+        self.assertEqual("reconciled-merged", results[0]["result"])
+        mark_mock.assert_called_once_with("open-city-ai/haidian", 42, ROOT)
+
+        with (
+            patch("auto_review_queue.closed_queued_pull_numbers", return_value=[42]),
+            patch(
+                "auto_review_queue.pr_meta",
+                return_value={"state": "MERGED", "headRefOid": head_sha},
+            ),
+            patch("auto_review_queue.pr_comments", return_value=comments),
+            patch("auto_review_queue.pr_reviews", return_value=[]),
+            patch("auto_review_queue.mark_intake_accepted") as missing_mark,
+        ):
+            skipped = reconcile_merged_reservations(
+                "open-city-ai/haidian",
+                "review/queued",
+                {"cocosgt"},
+                ROOT,
+                apply=True,
+            )
+        self.assertEqual([], skipped)
+        missing_mark.assert_not_called()
 
     def test_queued_prs_filter_object_labels_without_search(self) -> None:
         open_prs = [

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 
@@ -16,11 +17,16 @@ from auto_review_queue import (  # noqa: E402
     apply_review,
     ci_state,
     decide,
+    historical_best_score,
+    ledger_best_score,
+    load_trusted_score_ledger,
     load_cached_review,
+    official_score_from_review,
     parse_args,
     pr_file_paths,
     queued_prs,
     submission_dir_from_files,
+    trusted_snapshot_score,
 )
 from generate_submissions_data import package_sha256  # noqa: E402
 
@@ -74,6 +80,68 @@ class AutoReviewQueueTests(unittest.TestCase):
                         if call.args[0][:3] == ["gh", "pr", "review"]
                     )
                     self.assertIn("review readiness passed", review_command[-1])
+
+    def test_trusted_score_ledger_supplies_a_package_high_water_mark(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            docs = root / "docs"
+            docs.mkdir()
+            (docs / "trusted-score-high-water.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "entries": [
+                            {
+                                "submission_dir": "submissions/alice/plan",
+                                "score": 94,
+                                "reviewed_head_sha": "a" * 40,
+                                "merged_pr": 12,
+                                "reviewer": "CocoSgt",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            ledger = load_trusted_score_ledger(root, {"cocosgt"})
+        self.assertEqual(94, ledger_best_score(ledger, "submissions/alice/plan"))
+        self.assertIsNone(ledger_best_score(ledger, "submissions/alice/other"))
+
+    def test_current_newer_147228_packages_have_explicit_high_water_baselines(self) -> None:
+        ledger = load_trusted_score_ledger(ROOT, {"cocosgt", "wakenmeng"})
+        self.assertEqual(
+            67,
+            ledger_best_score(ledger, "submissions/147228/commute-co-benefit-jingzhang"),
+        )
+        self.assertEqual(
+            76,
+            ledger_best_score(ledger, "submissions/147228/enterprise-resident-flow-commons"),
+        )
+
+    def test_trusted_score_ledger_rejects_untrusted_or_malformed_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            docs = root / "docs"
+            docs.mkdir()
+            (docs / "trusted-score-high-water.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "entries": [
+                            {
+                                "submission_dir": "submissions/alice/plan",
+                                "score": 100,
+                                "reviewed_head_sha": "b" * 40,
+                                "merged_pr": 13,
+                                "reviewer": "untrusted",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaises(WorkerError):
+                load_trusted_score_ledger(root, {"cocosgt"})
 
     def test_default_image_budget_matches_bilingual_packet(self) -> None:
         with patch.object(sys, "argv", ["auto_review_queue"]):
@@ -176,6 +244,282 @@ class AutoReviewQueueTests(unittest.TestCase):
             },
         }
         self.assertEqual("low-quality", decide(review, {"weighted_score_100": 59.9}, 60).action)
+
+    def test_score_regression_is_not_merged_even_above_absolute_threshold(self) -> None:
+        review = {
+            "mandatory_rejection": {"result": "pass"},
+            "gate_checks": {
+                name: {"status": "pass"}
+                for name in [
+                    "deterministic_validation",
+                    "spatial_review",
+                    "visual_review",
+                    "professional_evidence_review",
+                ]
+            },
+            "recommendation": "formal-review-ready",
+            "can_enter_formal_review": True,
+            "required_next_actions_zh": [],
+        }
+        outcome = decide(review, {"weighted_score_100": 79}, 60, historical_best=93)
+        self.assertEqual("score-regression", outcome.action)
+        self.assertIn("historical exact-head best 93", outcome.reason)
+
+    def test_exact_trusted_snapshot_can_be_restored_after_lower_revert_score(self) -> None:
+        review = {
+            "mandatory_rejection": {"result": "pass"},
+            "gate_checks": {
+                name: {"status": "pass"}
+                for name in [
+                    "deterministic_validation",
+                    "spatial_review",
+                    "visual_review",
+                    "professional_evidence_review",
+                ]
+            },
+            "recommendation": "formal-review-ready",
+            "can_enter_formal_review": True,
+            "required_next_actions_zh": [],
+        }
+        outcome = decide(
+            review,
+            {"weighted_score_100": 77},
+            60,
+            historical_best=88,
+            restored_snapshot_score=88,
+        )
+        self.assertEqual("restore-high-water", outcome.action)
+        self.assertIn("trusted retained snapshot 88/100", outcome.reason)
+
+    def test_low_absolute_score_cannot_bypass_restoration_guard(self) -> None:
+        review = {
+            "mandatory_rejection": {"result": "pass"},
+            "gate_checks": {
+                name: {"status": "pass"}
+                for name in [
+                    "deterministic_validation",
+                    "spatial_review",
+                    "visual_review",
+                    "professional_evidence_review",
+                ]
+            },
+        }
+        self.assertEqual(
+            "low-quality",
+            decide(
+                review,
+                {"weighted_score_100": 59.9},
+                60,
+                historical_best=88,
+                restored_snapshot_score=88,
+            ).action,
+        )
+
+    def test_snapshot_match_is_package_tree_scoped(self) -> None:
+        with patch("auto_review_queue.run") as mocked_run:
+            mocked_run.side_effect = [
+                SimpleNamespace(stdout="candidate-tree\n"),
+                SimpleNamespace(stdout="candidate-tree\n"),
+                SimpleNamespace(stdout="different-tree\n"),
+            ]
+            score = trusted_snapshot_score(
+                Path("/repo"),
+                Path("/worktree"),
+                "submissions/alice/plan",
+                [
+                    {"score": 94, "head_sha": "a" * 40},
+                    {"score": 88, "head_sha": "b" * 40},
+                ],
+            )
+        self.assertEqual(94, score)
+
+    def test_snapshot_match_fetches_missing_historical_commit(self) -> None:
+        historical_head = "a" * 40
+        with patch("auto_review_queue.run") as mocked_run:
+            mocked_run.side_effect = [
+                SimpleNamespace(stdout="candidate-tree\n"),
+                WorkerError("historical commit is missing"),
+                SimpleNamespace(stdout=""),
+                SimpleNamespace(stdout="candidate-tree\n"),
+            ]
+            score = trusted_snapshot_score(
+                Path("/repo"),
+                Path("/worktree"),
+                "submissions/alice/plan",
+                [{"score": 94, "head_sha": historical_head}],
+            )
+        self.assertEqual(94, score)
+        self.assertEqual(
+            ["git", "fetch", "--no-tags", "--quiet", "origin", historical_head],
+            mocked_run.call_args_list[2].args[0],
+        )
+
+    def test_equal_historical_score_is_held_without_exact_snapshot(self) -> None:
+        review = {
+            "mandatory_rejection": {"result": "pass"},
+            "gate_checks": {
+                name: {"status": "pass"}
+                for name in [
+                    "deterministic_validation",
+                    "spatial_review",
+                    "visual_review",
+                    "professional_evidence_review",
+                ]
+            },
+            "recommendation": "formal-review-ready",
+            "can_enter_formal_review": True,
+            "required_next_actions_zh": [],
+        }
+        outcome = decide(review, {"weighted_score_100": 93}, 60, historical_best=93)
+        self.assertEqual("score-regression", outcome.action)
+        self.assertIn("not strictly above historical exact-head best 93", outcome.reason)
+
+    def test_equal_historical_score_can_restore_exact_snapshot(self) -> None:
+        review = {
+            "mandatory_rejection": {"result": "pass"},
+            "gate_checks": {
+                name: {"status": "pass"}
+                for name in [
+                    "deterministic_validation",
+                    "spatial_review",
+                    "visual_review",
+                    "professional_evidence_review",
+                ]
+            },
+            "recommendation": "formal-review-ready",
+            "can_enter_formal_review": True,
+            "required_next_actions_zh": [],
+        }
+        self.assertEqual(
+            "restore-high-water",
+            decide(
+                review,
+                {"weighted_score_100": 93},
+                60,
+                historical_best=93,
+                restored_snapshot_score=93,
+            ).action,
+        )
+
+    def test_exact_snapshot_cannot_bypass_intake_readiness(self) -> None:
+        review = {
+            "mandatory_rejection": {"result": "pass"},
+            "gate_checks": {
+                name: {"status": "pass"}
+                for name in [
+                    "deterministic_validation",
+                    "spatial_review",
+                    "visual_review",
+                    "professional_evidence_review",
+                ]
+            },
+            "recommendation": "request-changes",
+            "can_enter_formal_review": False,
+            "required_next_actions_zh": ["补齐评分前内容证据。"],
+        }
+        outcome = decide(
+            review,
+            {"weighted_score_100": 93},
+            60,
+            historical_best=93,
+            restored_snapshot_score=93,
+        )
+        self.assertEqual("request-changes", outcome.action)
+        self.assertIn("intake blocked by review fields", outcome.reason)
+
+    def test_historical_score_requires_exact_head_marker_and_package_path(self) -> None:
+        head = "a" * 40
+        body = (
+            f"<!-- haidian-auto-review:{head} -->\n"
+            "Maintainer intake decision: Review Agent score 93/100. Mandatory rejection and all four local gates passed."
+        )
+        approved = {"state": "APPROVED", "author": {"login": "CocoSgt"}, "body": body}
+        self.assertEqual(93, official_score_from_review(approved, head, {"cocosgt"}))
+        self.assertIsNone(official_score_from_review(approved, "b" * 40, {"cocosgt"}))
+        self.assertIsNone(
+            official_score_from_review(
+                {**approved, "state": "CHANGES_REQUESTED"}, head, {"cocosgt"}
+            )
+        )
+        self.assertIsNone(
+            official_score_from_review(
+                {**approved, "author": {"login": "untrusted-contributor"}}, head, {"cocosgt"}
+            )
+        )
+        merged_prs = [
+            {
+                "headRefOid": head,
+                "files": [{"path": "submissions/alice/plan/manifest.json"}],
+                "reviews": [approved],
+            },
+            {
+                "headRefOid": head,
+                "files": [{"path": "submissions/alice/other/manifest.json"}],
+                "reviews": [approved],
+            },
+        ]
+        self.assertEqual(93, historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
+
+    def test_non_approved_or_untrusted_reviews_never_raise_historical_best(self) -> None:
+        head = "b" * 40
+        body = (
+            f"<!-- haidian-auto-review:{head} -->\n"
+            "Maintainer intake decision: Review Agent score 100/100. Mandatory rejection and all four local gates passed."
+        )
+        merged_prs = [
+            {
+                "headRefOid": head,
+                "files": [{"path": "submissions/alice/plan/manifest.json"}],
+                "reviews": [
+                    {"state": "CHANGES_REQUESTED", "author": {"login": "CocoSgt"}, "body": body},
+                    {"state": "APPROVED", "author": {"login": "untrusted-contributor"}, "body": body},
+                ],
+            }
+        ]
+        self.assertIsNone(historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
+
+    def test_mixed_scope_merged_pr_cannot_establish_package_history(self) -> None:
+        head = "b" * 40
+        body = (
+            f"<!-- haidian-auto-review:{head} -->\n"
+            "Maintainer intake decision: Review Agent score 100/100. Mandatory rejection and all four local gates passed."
+        )
+        merged_prs = [
+            {
+                "headRefOid": head,
+                "files": [
+                    {"path": "submissions/alice/plan/manifest.json"},
+                    {"path": "scripts/auto_review_queue.py"},
+                ],
+                "reviews": [
+                    {"state": "APPROVED", "author": {"login": "CocoSgt"}, "body": body}
+                ],
+            }
+        ]
+        self.assertIsNone(historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
+
+    def test_historical_best_keeps_higher_score_from_non_final_merged_pr_revision(self) -> None:
+        reviewed_head = "c" * 40
+        final_head = "d" * 40
+        body = (
+            f"<!-- haidian-auto-review:{reviewed_head} -->\n"
+            "Maintainer intake decision: Review Agent score 94/100. Mandatory rejection and all four local gates passed."
+        )
+        merged_prs = [
+            {
+                "headRefOid": final_head,
+                "files": [{"path": "submissions/alice/plan/proposal.md"}],
+                "reviews": [
+                    {
+                        "state": "APPROVED",
+                        "author": {"login": "CocoSgt"},
+                        "body": body,
+                        "commit": {"oid": reviewed_head},
+                    }
+                ],
+            }
+        ]
+        self.assertEqual(94, historical_best_score(merged_prs, "submissions/alice/plan", {"cocosgt"}))
 
     def test_failed_gate_overrides_high_score(self) -> None:
         review = {


### PR DESCRIPTION
## Summary\n\n- preserve trusted maintainer Review Agent score high-water marks per submission directory\n- compare the current exact-head score with both merged review history and the fail-closed maintainer ledger\n- request changes for score regressions instead of merging a lower-scoring replacement\n- keep the ledger maintainer-curated and outside participant worktrees\n\n## Safety contract\n\nA pending, missing, stale, mixed-scope, or non-trusted review is not a score and cannot replace the current version. The ledger only accepts approved exact-head reviews from trusted maintainers and rejects malformed or untrusted entries.\n\n## Verification\n\n- python3 -m unittest tests.test_auto_review_queue tests.test_submission_workflow: 138/138 passed\n- python3 -m py_compile scripts/auto_review_queue.py\n- jq empty docs/trusted-score-high-water.json\n- git diff --check\n\nThis PR is based on current upstream/main eaad6dd8f05ee1fcd88f0772e0f52e61d05210a3.