### PR TITLE
fix(validation): make provisional-boundary warning fail closed

### DIFF
--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1250,7 +1250,9 @@ def validate_geojson_file(
         elif stage == "formal" and official_boundary_features == 0 and provisional_boundary_features > 0:
             report.add_warning(
                 f"{display_path}: uses provisional boundary; do not treat it as an official redline or precise-area basis. "
-                "Organizer data gaps do not block content scoring; recalculate when official geometry is supplied"
+                "Provisional geometry supports only structural/intake review and human reading; "
+                "it does not establish professional scoring, formal acceptance, publication, or merge eligibility. "
+                "Recalculate when official geometry is supplied"
             )
     return len(features)
 

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1252,7 +1252,8 @@ def validate_geojson_file(
                 f"{display_path}: uses provisional boundary; do not treat it as an official redline or precise-area basis. "
                 "Provisional geometry supports only structural/intake review and human reading; "
                 "it does not establish professional scoring, formal acceptance, publication, or merge eligibility. "
-                "Recalculate when official geometry is supplied"
+                "Missing official geometry does not by itself reduce rubric scores; "
+                "recalculate when official geometry is supplied"
             )
     return len(features)
 

--- a/tests/test_constraints_data_gap.py
+++ b/tests/test_constraints_data_gap.py
@@ -62,6 +62,33 @@ def constraint_feature() -> dict:
     }
 
 
+def provisional_boundary_feature() -> dict:
+    return {
+        "type": "Feature",
+        "id": "PROV-SITE-001",
+        "properties": {
+            "id": "PROV-SITE-001",
+            "layer": "SITE_BOUNDARY",
+            "source_type": "agent_inferred_from_public_data",
+            "confidence": "low",
+            "geometry_role": "provisional_constraint",
+            "official_boundary": False,
+        },
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [116.300, 39.901],
+                    [116.301, 39.901],
+                    [116.301, 39.902],
+                    [116.300, 39.902],
+                    [116.300, 39.901],
+                ]
+            ],
+        },
+    }
+
+
 class EmptyConstraintsAdvisoryTests(unittest.TestCase):
     def check(self, constraints: dict, assumptions: dict | None = None) -> ValidationReport:
         report = ValidationReport()
@@ -166,6 +193,41 @@ class EmptyConstraintsAdvisoryTests(unittest.TestCase):
         self.assertFalse(constraints_file_declares_data_gap({"data_gaps": []}))
         self.assertFalse(assumptions_declare_constraints_gap({"assumptions": []}))
         self.assertFalse(assumptions_declare_constraints_gap(None))
+
+    def test_provisional_boundary_warning_is_fail_closed_for_downstream_decisions(self) -> None:
+        report = ValidationReport()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "site_boundary.geojson"
+            path.write_text(
+                json.dumps(
+                    {
+                        "type": "FeatureCollection",
+                        "name": "provisional_site_boundary",
+                        "features": [provisional_boundary_feature()],
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+            validate_geojson_file(
+                report,
+                REPO_ROOT,
+                path,
+                "submissions/tester/package/geometry/site_boundary.geojson",
+                require_features=True,
+                stage="formal",
+                geometry_name="site_boundary.geojson",
+            )
+
+        self.assertEqual([], report.errors)
+        self.assertEqual(1, len(report.warnings))
+        warning = report.warnings[0]
+        self.assertIn("supports only structural/intake review and human reading", warning)
+        self.assertIn(
+            "does not establish professional scoring, formal acceptance, publication, or merge eligibility",
+            warning,
+        )
+        self.assertNotIn("do not block content scoring", warning)
 
 
 @unittest.skipUnless(HAS_REVIEW_DEPS, "Install requirements-review.txt to run scaffold tests")

--- a/tests/test_constraints_data_gap.py
+++ b/tests/test_constraints_data_gap.py
@@ -227,6 +227,10 @@ class EmptyConstraintsAdvisoryTests(unittest.TestCase):
             "does not establish professional scoring, formal acceptance, publication, or merge eligibility",
             warning,
         )
+        self.assertIn(
+            "Missing official geometry does not by itself reduce rubric scores",
+            warning,
+        )
         self.assertNotIn("do not block content scoring", warning)
 
 


### PR DESCRIPTION
## 问题

共享校验器仍把 provisional boundary 的提示写成 “Organizer data gaps do not block content scoring”。#1291 已在 Open Pulse 的持久化自检里改正这条边界，但任何方案再次运行 `--mark-self-checked`，旧提示都会被写回来。这样会把结构/intake 可读性和专业评分、正式接收、发布、合并资格混在一起。

## 修改

- 临时几何只支持结构/intake 复核和人工阅读。
- 明确它不能建立专业评分、正式接收、发布或合并资格。
- 增加 provisional SITE_BOUNDARY 回归测试，同时断言旧的 “do not block content scoring” 不再出现。

本 PR 只改共享校验器和一份测试，不修改任何投稿包、评分台账或公网数据。

## 验证

- `tests.test_constraints_data_gap`: 12 项通过（1 项因本地可选依赖跳过）
- `tests.test_agent_scaffold_and_self_check`: 24 项通过/跳过符合依赖条件
- `tests.test_lightweight_participant_flow`: 8 项通过
- `tests.test_submission_workflow`: 124 项通过
- `git diff --check`: 通过

这些结果只证明警告生成链和现有工作流回归通过，不代表任何方案获得评分、合并或发布资格。