### PR TITLE
Fix media-specific size validation

### DIFF
--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -2939,11 +2939,16 @@ def validate_submission(
             and size > MAX_AUDIO_BYTES
         ):
             report.add_error(f"{path}: audio files must be <= {MAX_AUDIO_BYTES} bytes")
-        elif is_under_media(parts) and size > MAX_ASSET_BYTES:
+        elif (
+            is_under_media(parts)
+            and Path(path).suffix.lower() not in ALLOWED_VIDEO_EXTENSIONS
+            and Path(path).suffix.lower() not in ALLOWED_AUDIO_EXTENSIONS
+            and size > MAX_ASSET_BYTES
+        ):
             report.add_error(
                 f"{path}: media sidecars and posters must be <= {MAX_ASSET_BYTES} bytes"
             )
-        elif is_under_assets(parts) and size > MAX_ASSET_BYTES:
+        elif is_under_assets(parts) and not is_under_media(parts) and size > MAX_ASSET_BYTES:
             report.add_error(f"{path}: assets must be <= {MAX_ASSET_BYTES} bytes")
         if is_under_drawings(parts) and size > MAX_DRAWING_BYTES:
             report.add_error(f"{path}: drawings must be <= {MAX_DRAWING_BYTES} bytes")

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -1814,6 +1814,36 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertFalse(report.ok)
             self.assertIn("assets must use", "\n".join(report.errors))
 
+    def test_media_size_limits_distinguish_primary_media_from_sidecars(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            cases = [
+                ("video.mp4", 6 * 1024 * 1024, None),
+                ("audio.mp3", 6 * 1024 * 1024, None),
+                ("poster.webp", 6 * 1024 * 1024, "media sidecars and posters"),
+                ("oversize.mp4", 21 * 1024 * 1024, "video files must be"),
+            ]
+
+            for filename, size, expected_error in cases:
+                with self.subTest(filename=filename):
+                    rel = f"{base}/assets/media/{filename}"
+                    path = root / rel
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    with path.open("wb") as handle:
+                        handle.truncate(size)
+
+                    report = validate_submission(root, "alice", [rel])
+                    size_errors = [error for error in report.errors if "must be <=" in error]
+                    if expected_error is None:
+                        self.assertEqual([], size_errors)
+                    else:
+                        self.assertTrue(
+                            any(expected_error in error for error in size_errors),
+                            size_errors,
+                        )
+                    path.unlink()
+
     def test_proposal_must_embed_required_local_figures(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- keep video and audio files on their dedicated size limits
- keep the 5 MB limit for media sidecars and ordinary assets
- add regression coverage for valid and oversized media files

## Validation
- `python3 -m unittest tests.test_submission_workflow`
- `python3 -m py_compile scripts/validate_submission.py`
- `git diff --check`

Fixes #1827