### PR TITLE
Fix Unicode paths in review queue

### DIFF
--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -57,6 +57,18 @@ def gh_json(repo: str, args: list[str], *, cwd: Path) -> Any:
         raise WorkerError(f"invalid JSON from gh {' '.join(args)}") from exc
 
 
+def pr_file_paths(repo: str, number: int, cwd: Path) -> list[str]:
+    completed = run(
+        ["gh", "api", "--paginate", "--slurp", f"repos/{repo}/pulls/{number}/files"],
+        cwd=cwd,
+    )
+    try:
+        pages = json.loads(completed.stdout)
+        return [str(item["filename"]) for page in pages for item in page]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise WorkerError(f"invalid file list from gh api for PR #{number}") from exc
+
+
 def latest_validation_check(meta: dict[str, Any]) -> dict[str, Any] | None:
     checks = [
         (index, item)
@@ -270,11 +282,7 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
     if meta.get("mergeable") == "CONFLICTING":
         return {"number": number, "head_sha": head_sha, "result": "skipped-conflicting"}
 
-    paths_text = run(
-        ["gh", "pr", "diff", str(number), "--repo", args.repo, "--name-only"],
-        cwd=repo_root,
-    ).stdout
-    submission_dir = submission_dir_from_files([line for line in paths_text.splitlines() if line], author)
+    submission_dir = submission_dir_from_files(pr_file_paths(args.repo, number, repo_root), author)
     worktree = args.worktree_root / f"pr-{number}-{head_sha[:12]}"
     audit_dir = args.audit_root / f"pr-{number}" / head_sha
     ref = f"refs/codex-auto-review/pr-{number}-{head_sha[:12]}"

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -15,6 +15,7 @@ from auto_review_queue import (  # noqa: E402
     decide,
     load_cached_review,
     parse_args,
+    pr_file_paths,
     submission_dir_from_files,
 )
 from generate_submissions_data import package_sha256  # noqa: E402
@@ -77,6 +78,28 @@ class AutoReviewQueueTests(unittest.TestCase):
         self.assertEqual("submissions/Alice/plan", submission_dir_from_files(paths, "alice"))
         with self.assertRaises(WorkerError):
             submission_dir_from_files(paths + ["README.md"], "alice")
+
+    def test_pr_file_paths_preserve_unicode_from_paginated_json(self) -> None:
+        payload = [[
+            {"filename": "submissions/alice/plan/proposal.md"},
+            {"filename": "submissions/alice/plan/visual/assets/01-总体方案图.png"},
+        ]]
+        with patch("auto_review_queue.run") as mocked_run:
+            mocked_run.return_value.stdout = json.dumps(payload, ensure_ascii=False)
+            paths = pr_file_paths("open-city-ai/haidian", 999, ROOT)
+
+        self.assertEqual(payload[0][1]["filename"], paths[1])
+        self.assertEqual("submissions/alice/plan", submission_dir_from_files(paths, "alice"))
+        mocked_run.assert_called_once_with(
+            [
+                "gh",
+                "api",
+                "--paginate",
+                "--slurp",
+                "repos/open-city-ai/haidian/pulls/999/files",
+            ],
+            cwd=ROOT,
+        )
 
     def test_ci_state(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
## Summary
- read PR file names from the paginated structured GitHub API
- avoid parsing Git-quoted human diff output
- add Unicode path regression coverage

## Validation
- `python3 -m unittest tests.test_auto_review_queue`
- `python3 -m py_compile scripts/auto_review_queue.py`
- `git diff --check`
- live #999 file list resolves to `submissions/jiang16789-ai/maomao-agent`

Fixes #1847