### PR TITLE
feat(contrib): metrics 全场底数扫描工具（issue #1781 认领）

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,83 @@
+# Metrics Field Scan Tool
+
+> 关联 Issue：[#1781 全场 metrics 底数](https://github.com/open-city-ai/haidian/issues/1781)
+> 维护者建议的下一步：提交只读扫描脚本、固定 SHA 的 summary JSON、字段定义与隐私边界。
+
+## 用途与边界
+
+本工具对 `submissions/*/*/metrics.json` 做**只读**描述性统计，回答「全场填了哪些指标、口径是否一致、哪些数值能横向比」：
+
+- **不评价方案优劣**：不含任何排名、评分、推荐或批评。
+- **不点名**：summary 只给计数与匿名聚合，不含作者、路径、slug。
+- **离群值只给计数**：如 `unit_not_in_enum=250`，不指出具体包。
+- **全部标注分母**：每条统计附 `count` 与 `pct`（分母为全场条目总数）。
+- **长表不进仓库**：含作者标识的长表（csv.gz）是本地复现产物，不得提交。
+
+## 复现命令
+
+```bash
+# 1. 取数：blobless sparse，仅拉文本文件（metrics.json / manifest.json / proposal.md，约 25-40 MB）
+D=$HOME/mx_$RANDOM
+git clone --depth 1 --filter=blob:none --no-checkout \
+    https://github.com/open-city-ai/haidian.git $D
+cd $D
+git rev-parse HEAD          # 记录快照 SHA，引用时必须保留
+git sparse-checkout set --no-cone \
+    '/submissions/*/*/metrics.json' '/submissions/*/*/manifest.json' \
+    '/submissions/*/*/proposal.md' '/submissions/*/*/agent.json'
+git checkout
+
+# 2. 扫描
+python3 contrib/tools-metrics-scan.py --repo $D --out-dir contrib \
+    --date YYYYMMDD --sha <commit-sha>
+
+# 3. 产出
+#    contrib/metrics-fullfield-<date>.summary.json   <- 可发布（计数 + 匿名聚合）
+#    contrib/metrics-fullfield-<date>.csv.gz          <- 本地长表（含作者标识，勿提交）
+#    contrib/metrics-scan-<date>.parse-failures.txt   <- 仅解析失败时生成（本地）
+```
+
+## 长表字段字典（28 列）
+
+| 字段 | 说明 |
+| --- | --- |
+| `pkg` | `<author>/<slug>`，本地核对用 |
+| `author` / `slug` | 来源分解 |
+| `metric_key` | `metrics.json` 中的原始 key |
+| `norm_key` | 去掉 `_sqm/_m/_ratio/_count` 等尾缀后的规范化 key |
+| `concept` | 粗粒度概念桶（area/mobility/intensity/green_public/counts/other） |
+| `status` | `known / unknown / not_applicable`（schema 声明枚举） |
+| `value` | 原始值（数值或文本） |
+| `value_is_num` | 是否可解析为数值 |
+| `unit` | 原始单位字符串 |
+| `confidence` | 原始置信度 |
+| `formula` | 计算式文本 |
+| `reason` | 附加理由（如有） |
+| `n_source_files` | `source_files` 数组长度 |
+| `n_assumptions` | `assumptions` 数组长度 |
+| `has_breakdown` / `n_breakdown` | 是否有 breakdown 字典及其长度 |
+| `missing_required` | 缺失的必填字段（status/value/unit/source_files/formula/confidence） |
+| `missing_fields` | 同上（保留列，兼容后续扩展） |
+| `n_extra_fields` | 必填字段之外的额外字段数 |
+| `formula_mentions_epsg` / `formula_mentions_4548` | formula 是否提及投影系 |
+| `schema_version` | metrics.json 根 schema_version |
+| `units_area` / `units_length` | 根 units 声明 |
+| `model_family` | 从 agent.json 优先、manifest.json 兜底读取的模型家族（best-effort，缺失为 null） |
+| `entry_ok` / `entry_problem` | 条目完整性判定 |
+
+## Summary 结构
+
+- `snapshot`：仓库、SHA、日期、包数（目录/含 metrics/含 manifest 三个口径交叉核对）、条目总数、解析失败数。
+- `root_structure`：根容器形状与 schema_version 分布。
+- `field_coverage`：各必填字段缺失计数与占比。
+- `entry_validity`：有效条目占比 + 问题分类（不点名）。
+- `distributions`：status 全分布；unit / confidence 按「声明枚举 + 其他聚合」双段呈现（schema 枚举见 `brief/site-package/schemas/metrics.schema.json`）。
+- `packages`：每包指标数 min/median/max/mean。
+- `coverage`：Top 指标 key、规范化 key、概念桶分布，以及 Top 15 指标 key 的 **status 交叉表**（如 `floor_area_ratio` 全场 540 条中 526 条 `unknown`——组织方控规条件未公布的直接结果）。
+- `outlier_counts_only`：离群值**计数**（ratio/FAR/height sanity 阈值来自 `brief/site-package/ranges/planning_limits.json` 的 `schema_sanity_bounds_not_planning_approval`；面积类指标对照同一文件 `known_official_area_values`，偏差超过 50% 计一次，均不点名）。**口径说明**：0-1 ratio 检查只针对占比/覆盖率语义（green_ratio、coverage 等）；FAR（floor_area_ratio，合法区间 0-12）、绕路率、街墙高宽比等可合法大于 1 的比率不适用 0-1 检查；百分比单位（pct/percent）条目不适用 0-1 检查；FAR 检查排除面积单位条目（如 `phasing_far_area_sqm` 是分期面积而非容积率）。
+
+## 隐私与合规
+
+- 提交内容仅限：扫描脚本、summary JSON（无作者标识）、本文档。
+- 长表与解析失败清单为本地复现产物，禁止提交。
+- summary 中的离群值与覆盖统计不得用作任何扣分或排名依据。

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -71,7 +71,7 @@ python3 contrib/tools-metrics-scan.py --repo $D --out-dir contrib \
 
 - `snapshot`：仓库、SHA、日期、包数（目录/含 metrics/含 manifest 三个口径交叉核对）、条目总数、解析失败数。
 - `root_structure`：根容器形状与 schema_version 分布。
-- `field_coverage`：各必填字段缺失计数与占比。
+- `field_coverage`：各必填字段缺失计数与占比。**口径注**：`field_coverage.<field>.missing_count` 只统计「键不存在」（`REQUIRED_FIELDS` 中缺失的键，见 `scan()` 的 `missing_req`），与 `outlier_counts_only.unit_missing`（键不存在 + 显式 JSON null + 非字符串类型）是两种度量，两者不可直接互读。
 - `entry_validity`：有效条目占比 + 问题分类（不点名）。
 - `distributions`：status 全分布；unit / confidence 按「声明枚举 + 其他聚合」双段呈现（schema 枚举见 `brief/site-package/schemas/metrics.schema.json`）。
 - `packages`：每包指标数 min/median/max/mean。

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -28,6 +28,8 @@ git sparse-checkout set --no-cone \
 git checkout
 
 # 2. 扫描
+# --sha 会与 repo HEAD 校验：不一致时拒绝执行（防快照身份错误）；
+# 确认要扫描非 HEAD 提交时显式加 --allow-sha-mismatch，summary 会记录 sha_verified_against_head=false。
 python3 contrib/tools-metrics-scan.py --repo $D --out-dir contrib \
     --date YYYYMMDD --sha <commit-sha>
 

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -9,7 +9,7 @@
 
 - **不评价方案优劣**：不含任何排名、评分、推荐或批评。
 - **不点名**：summary 只给计数与匿名聚合，不含作者、路径、slug。
-- **离群值只给计数**：如 `unit_not_in_enum=250`，不指出具体包。
+- **离群值只给计数**：如 `unit_missing=31`、`unit_not_in_enum=250`，不指出具体包。`unit_missing`（字段缺失或 JSON null）与 `unit_not_in_enum`（声明了非枚举值）分开计数，口径不混。
 - **全部标注分母**：每条统计附 `count` 与 `pct`（分母为全场条目总数）。
 - **长表不进仓库**：含作者标识的长表（csv.gz）是本地复现产物，不得提交。
 
@@ -76,10 +76,10 @@ python3 contrib/tools-metrics-scan.py --repo $D --out-dir contrib \
 - `distributions`：status 全分布；unit / confidence 按「声明枚举 + 其他聚合」双段呈现（schema 枚举见 `brief/site-package/schemas/metrics.schema.json`）。
 - `packages`：每包指标数 min/median/max/mean。
 - `coverage`：Top 指标 key、规范化 key、概念桶分布，以及 Top 15 指标 key 的 **status 交叉表**（如 `floor_area_ratio` 全场 540 条中 526 条 `unknown`——组织方控规条件未公布的直接结果）。
-- `outlier_counts_only`：离群值**计数**（ratio/FAR/height sanity 阈值来自 `brief/site-package/ranges/planning_limits.json` 的 `schema_sanity_bounds_not_planning_approval`；面积类指标对照同一文件 `known_official_area_values`，偏差超过 50% 计一次，均不点名）。**口径说明**：0-1 ratio 检查只针对占比/覆盖率语义（green_ratio、coverage 等）；FAR（floor_area_ratio，合法区间 0-12）、绕路率、街墙高宽比等可合法大于 1 的比率不适用 0-1 检查；百分比单位（pct/percent）条目不适用 0-1 检查；FAR 检查排除面积单位条目（如 `phasing_far_area_sqm` 是分期面积而非容积率）。
+- `outlier_counts_only`：离群值**计数**（ratio/FAR/height sanity 阈值来自 `brief/site-package/ranges/planning_limits.json` 的 `schema_sanity_bounds_not_planning_approval`；面积类指标对照同一文件 `known_official_area_values`，偏差超过 50% 计一次，均不点名）。**口径说明**：0-1 ratio 检查只针对占比/覆盖率语义（green_ratio、coverage 等）；FAR（floor_area_ratio，合法区间 0-12）、绕路率、街墙高宽比等可合法大于 1 的比率不适用 0-1 检查；百分比单位（pct/percent）条目不适用 0-1 检查；FAR 检查排除面积单位条目（如 `phasing_far_area_sqm` 是分期面积而非容积率）；unit 检查分两档——`unit_missing`（unit 字段缺失或 JSON null）与 `unit_not_in_enum`（声明了 schema 枚举之外的字符串），两者口径互斥、不混计。
 
 ## 隐私与合规
 
-- 提交内容仅限：扫描脚本、summary JSON（无作者标识）、本文档。
+- 提交内容仅限：扫描脚本、summary JSON（无作者标识）、回归测试、本文档。
 - 长表与解析失败清单为本地复现产物，禁止提交。
 - summary 中的离群值与覆盖统计不得用作任何扣分或排名依据。

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -9,9 +9,10 @@
 
 - **不评价方案优劣**：不含任何排名、评分、推荐或批评。
 - **不点名**：summary 只给计数与匿名聚合，不含作者、路径、slug。
+- **自由文本不进 summary**：metric key 只公开受控官方词表（`CONTROLLED_METRIC_KEYS`，见脚本注释）；status/unit/confidence 的非枚举值只报告总数与不同值数，**不回显原文**（防邮箱/路径等未验证字符串泄露）。
 - **离群值只给计数**：如 `unit_missing=31`、`unit_not_in_enum=250`，不指出具体包。`unit_missing`（字段缺失或 JSON null）与 `unit_not_in_enum`（声明了非枚举值）分开计数，口径不混。
 - **全部标注分母**：每条统计附 `count` 与 `pct`（分母为全场条目总数）。
-- **长表不进仓库**：含作者标识的长表（csv.gz）是本地复现产物，不得提交。
+- **长表默认不生成**：含作者标识的长表（csv.gz）需显式 `--write-local-identifiers` 且输出目录必须在仓库外，防止误暂存提交。
 
 ## 复现命令
 
@@ -28,15 +29,20 @@ git sparse-checkout set --no-cone \
 git checkout
 
 # 2. 扫描
-# --sha 会与 repo HEAD 校验：不一致时拒绝执行（防快照身份错误）；
-# 确认要扫描非 HEAD 提交时显式加 --allow-sha-mismatch，summary 会记录 sha_verified_against_head=false。
-python3 contrib/tools-metrics-scan.py --repo $D --out-dir contrib \
+# 前置硬性检查（fail-closed，任何 flag 都不可绕过）：
+#   a) --sha 与 repo HEAD 一致；不一致时拒绝执行（防快照身份错误），
+#      确需扫描非 HEAD 提交时显式加 --allow-sha-mismatch，summary 会记录
+#      sha_verified_against_head=false；
+#   b) 工作树干净：submissions/ 下无 tracked 修改、无 untracked 文件——
+#      脏树意味着统计读的是「非声明 SHA 的字节」，直接拒绝运行。
+# --out-dir 建议放仓库外（summary 是匿名产物，写仓库内也可；含身份长表则必须在外）。
+python3 contrib/tools-metrics-scan.py --repo $D --out-dir $D/../scan-out \
     --date YYYYMMDD --sha <commit-sha>
 
 # 3. 产出
-#    contrib/metrics-fullfield-<date>.summary.json   <- 可发布（计数 + 匿名聚合）
-#    contrib/metrics-fullfield-<date>.csv.gz          <- 本地长表（含作者标识，勿提交）
-#    contrib/metrics-scan-<date>.parse-failures.txt   <- 仅解析失败时生成（本地）
+#    <out-dir>/metrics-fullfield-<date>.summary.json   <- 可发布（计数 + 匿名聚合）
+#    <out-dir>/metrics-fullfield-<date>.csv.gz          <- 仅加 --write-local-identifiers 生成（含作者标识，仓库外）
+#    <out-dir>/metrics-scan-<date>.parse-failures.txt   <- 仅解析失败时生成（本地）
 ```
 
 ## 长表字段字典（28 列）
@@ -73,13 +79,15 @@ python3 contrib/tools-metrics-scan.py --repo $D --out-dir contrib \
 - `root_structure`：根容器形状与 schema_version 分布。
 - `field_coverage`：各必填字段缺失计数与占比。**口径注**：`field_coverage.<field>.missing_count` 只统计「键不存在」（`REQUIRED_FIELDS` 中缺失的键，见 `scan()` 的 `missing_req`），与 `outlier_counts_only.unit_missing`（键不存在 + 显式 JSON null + 非字符串类型）是两种度量，两者不可直接互读。
 - `entry_validity`：有效条目占比 + 问题分类（不点名）。
-- `distributions`：status 全分布；unit / confidence 按「声明枚举 + 其他聚合」双段呈现（schema 枚举见 `brief/site-package/schemas/metrics.schema.json`）。
+- `distributions`：status / unit / confidence 均按「声明枚举 + 其他聚合」双段呈现（schema 枚举见 `brief/site-package/schemas/metrics.schema.json`）。**其他段只含 total_count 与 n_distinct_values，不回显非枚举值原文**（隐私边界）。
 - `packages`：每包指标数 min/median/max/mean。
-- `coverage`：Top 指标 key、规范化 key、概念桶分布，以及 Top 15 指标 key 的 **status 交叉表**（如 `floor_area_ratio` 全场 540 条中 526 条 `unknown`——组织方控规条件未公布的直接结果）。
+- `coverage`：Top 指标 key、规范化 key 只来自**受控官方词表**（`CONTROLLED_METRIC_KEYS`），其余 key 全部聚合进 `other_metric_keys`（只报不同值数与条目数）；另有概念桶分布与 Top 15 受控 key 的 **status 交叉表**（如 `floor_area_ratio` 全场 540 条中 526 条 `unknown`——组织方控规条件未公布的直接结果）。
 - `outlier_counts_only`：离群值**计数**（ratio/FAR/height sanity 阈值来自 `brief/site-package/ranges/planning_limits.json` 的 `schema_sanity_bounds_not_planning_approval`；面积类指标对照同一文件 `known_official_area_values`，偏差超过 50% 计一次，均不点名）。**口径说明**：0-1 ratio 检查只针对占比/覆盖率语义（green_ratio、coverage 等）；FAR（floor_area_ratio，合法区间 0-12）、绕路率、街墙高宽比等可合法大于 1 的比率不适用 0-1 检查；百分比单位（pct/percent）条目不适用 0-1 检查；FAR 检查排除面积单位条目（如 `phasing_far_area_sqm` 是分期面积而非容积率）；unit 检查分两档——`unit_missing`（unit 字段缺失或 JSON null）与 `unit_not_in_enum`（声明了 schema 枚举之外的字符串），两者口径互斥、不混计。
 
 ## 隐私与合规
 
-- 提交内容仅限：扫描脚本、summary JSON（无作者标识）、回归测试、本文档。
-- 长表与解析失败清单为本地复现产物，禁止提交。
+- 提交内容仅限：扫描脚本、summary JSON（无作者标识、无自由文本回显）、回归测试、本文档。
+- summary 的匿名保证：metric key 仅受控词表可见；status/unit/confidence 非枚举值只报计数；离群值只给计数，不指出具体包。
+- 长表（含作者标识）默认不生成，需 `--write-local-identifiers` 且输出目录在仓库外（写入工作树内会被拒绝）。
+- 快照证据链：--sha 与 HEAD 不一致拒绝执行；工作树不干净（tracked 修改 / untracked 文件）一律拒绝，任何 flag 不可绕过，失败时不产出可发布 summary。
 - summary 中的离群值与覆盖统计不得用作任何扣分或排名依据。

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -81,7 +81,7 @@ python3 contrib/tools-metrics-scan.py --repo $D --out-dir $D/../scan-out \
 - `entry_validity`：有效条目占比 + 问题分类（不点名）。
 - `distributions`：status / unit / confidence 均按「声明枚举 + 其他聚合」双段呈现（schema 枚举见 `brief/site-package/schemas/metrics.schema.json`）。**其他段只含 total_count 与 n_distinct_values，不回显非枚举值原文**（隐私边界）。
 - `packages`：每包指标数 min/median/max/mean。
-- `coverage`：Top 指标 key、规范化 key 只来自**受控官方词表**（`CONTROLLED_METRIC_KEYS`），其余 key 全部聚合进 `other_metric_keys`（只报不同值数与条目数）；另有概念桶分布与 Top 15 受控 key 的 **status 交叉表**（如 `floor_area_ratio` 全场 540 条中 526 条 `unknown`——组织方控规条件未公布的直接结果）。
+- `coverage`：指标 key、规范化 key 只来自**受控官方词表**（`CONTROLLED_METRIC_KEYS`，全部列出，无截断），其余 key 全部聚合进 `other_metric_keys`（只报不同值数与条目数）——两者条目之和与 `n_metric_entries` 严格闭合；另有概念桶分布与全部受控 key 的 **status 交叉表**（如 `floor_area_ratio` 全场 630 条中多呈 `unknown`——组织方控规条件未公布的直接结果）。
 - `outlier_counts_only`：离群值**计数**（ratio/FAR/height sanity 阈值来自 `brief/site-package/ranges/planning_limits.json` 的 `schema_sanity_bounds_not_planning_approval`；面积类指标对照同一文件 `known_official_area_values`，偏差超过 50% 计一次，均不点名）。**口径说明**：0-1 ratio 检查只针对占比/覆盖率语义（green_ratio、coverage 等）；FAR（floor_area_ratio，合法区间 0-12）、绕路率、街墙高宽比等可合法大于 1 的比率不适用 0-1 检查；百分比单位（pct/percent）条目不适用 0-1 检查；FAR 检查排除面积单位条目（如 `phasing_far_area_sqm` 是分期面积而非容积率）；unit 检查分两档——`unit_missing`（unit 字段缺失或 JSON null）与 `unit_not_in_enum`（声明了 schema 枚举之外的字符串），两者口径互斥、不混计。
 
 ## 隐私与合规

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -9,10 +9,10 @@
 
 - **不评价方案优劣**：不含任何排名、评分、推荐或批评。
 - **不点名**：summary 只给计数与匿名聚合，不含作者、路径、slug。
-- **自由文本不进 summary**：metric key 只公开受控官方词表（`CONTROLLED_METRIC_KEYS`，见脚本注释）；status/unit/confidence 的非枚举值只报告总数与不同值数，**不回显原文**（防邮箱/路径等未验证字符串泄露）。
+- **自由文本不进 summary**：metric key 只公开受控官方词表（`CONTROLLED_METRIC_KEYS`，见脚本注释）；status/unit/confidence 的非枚举值只报告总数与不同值数，**不回显原文**（防邮箱/路径等未验证字符串泄露）。schema_version 同样按已知版本枚举/匿名 other 桶输出；受控 key 的 status 交叉表只列声明枚举，其他状态匿名聚合。
 - **离群值只给计数**：如 `unit_missing=49`、`unit_not_in_enum=507`（20260812 快照），不指出具体包。`unit_missing`（字段缺失或 JSON null）与 `unit_not_in_enum`（声明了非枚举值）分开计数，口径不混。
 - **全部标注分母**：每条统计附 `count` 与 `pct`（分母为全场条目总数）。
-- **长表默认不生成**：含作者标识的长表（csv.gz）需显式 `--write-local-identifiers` 且输出目录必须在仓库外，防止误暂存提交。
+- **身份产物默认不生成**：含作者标识的长表（csv.gz）与含投稿路径的解析失败明细（parse-failures.txt）均需显式 `--write-local-identifiers` 且输出目录必须在仓库外（相对/绝对路径混写与 symlink 均会被解析后拒绝），防止误暂存提交。
 
 ## 复现命令
 
@@ -43,7 +43,7 @@ python3 contrib/tools-metrics-scan.py --repo $D --out-dir $D/../scan-out \
 # 3. 产出
 #    <out-dir>/metrics-fullfield-<date>.summary.json   <- 可发布（计数 + 匿名聚合）
 #    <out-dir>/metrics-fullfield-<date>.csv.gz          <- 仅加 --write-local-identifiers 生成（含作者标识，仓库外）
-#    <out-dir>/metrics-scan-<date>.parse-failures.txt   <- 仅解析失败时生成（本地）
+#    <out-dir>/metrics-scan-<date>.parse-failures.txt   <- 含投稿路径，同样需 --write-local-identifiers（仓库外）；summary 默认只保留匿名失败计数
 ```
 
 ## 长表字段字典（28 列）
@@ -77,18 +77,18 @@ python3 contrib/tools-metrics-scan.py --repo $D --out-dir $D/../scan-out \
 ## Summary 结构
 
 - `snapshot`：仓库、SHA、日期、包数（目录/含 metrics/含 manifest 三个口径交叉核对）、条目总数、解析失败数。
-- `root_structure`：根容器形状与 schema_version 分布。
+- `root_structure`：根容器形状与 schema_version 分布。schema_version 为开放字符串属性，只发布已知版本枚举（`declared_enum`），未知版本汇总进匿名 `other_values`（总数 + 不同值数，不回显原文）。
 - `field_coverage`：各必填字段缺失计数与占比。**口径注**：`field_coverage.<field>.missing_count` 只统计「键不存在」（`REQUIRED_FIELDS` 中缺失的键，见 `scan()` 的 `missing_req`），与 `outlier_counts_only.unit_missing`（键不存在 + 显式 JSON null + 非字符串类型）是两种度量，两者不可直接互读。
 - `entry_validity`：有效条目占比 + 问题分类（不点名）。
 - `distributions`：status / unit / confidence 均按「声明枚举 + 其他聚合」双段呈现（schema 枚举见 `brief/site-package/schemas/metrics.schema.json`）。**其他段只含 total_count 与 n_distinct_values，不回显非枚举值原文**（隐私边界）。
 - `packages`：每包指标数 min/median/max/mean。
-- `coverage`：指标 key、规范化 key 只来自**受控官方词表**（`CONTROLLED_METRIC_KEYS`，全部列出，无截断），其余 key 全部聚合进 `other_metric_keys`（只报不同值数与条目数）——两者条目之和与 `n_metric_entries` 严格闭合；另有概念桶分布与全部受控 key 的 **status 交叉表**（如 `floor_area_ratio` 全场 861 条中 840 条 `unknown`——组织方控规条件未公布的直接结果）。
+- `coverage`：指标 key、规范化 key 只来自**受控官方词表**（`CONTROLLED_METRIC_KEYS`，全部列出，无截断），其余 key 全部聚合进 `other_metric_keys`（只报不同值数与条目数）——两者条目之和与 `n_metric_entries` 严格闭合；另有概念桶分布与全部受控 key 的 **status 交叉表**（如 `floor_area_ratio` 全场 861 条中 840 条 `unknown`——组织方控规条件未公布的直接结果）。交叉表只列声明枚举（known/unknown/not_applicable），其他状态（自由文本或 JSON null）汇总进匿名 `other` 桶（总数 + 不同值数，不回显原文）。
 - `outlier_counts_only`：离群值**计数**（ratio/FAR/height sanity 阈值来自 `brief/site-package/ranges/planning_limits.json` 的 `schema_sanity_bounds_not_planning_approval`；面积类指标对照同一文件 `known_official_area_values`，偏差超过 50% 计一次，均不点名）。**口径说明**：0-1 ratio 检查只针对占比/覆盖率语义（green_ratio、coverage 等）；FAR（floor_area_ratio，合法区间 0-12）、绕路率、街墙高宽比等可合法大于 1 的比率不适用 0-1 检查；百分比单位（pct/percent）条目不适用 0-1 检查；FAR 检查排除面积单位条目（如 `phasing_far_area_sqm` 是分期面积而非容积率）；unit 检查分两档——`unit_missing`（unit 字段缺失或 JSON null）与 `unit_not_in_enum`（声明了 schema 枚举之外的字符串），两者口径互斥、不混计。
 
 ## 隐私与合规
 
 - 提交内容仅限：扫描脚本、summary JSON（无作者标识、无自由文本回显）、回归测试、本文档。
-- summary 的匿名保证：metric key 仅受控词表可见；status/unit/confidence 非枚举值只报计数；离群值只给计数，不指出具体包。
-- 长表（含作者标识）默认不生成，需 `--write-local-identifiers` 且输出目录在仓库外（写入工作树内会被拒绝）。
+- summary 的匿名保证：metric key 仅受控词表可见；status/unit/confidence 非枚举值只报计数；schema_version 仅已知版本枚举可见；受控 key 的 status 交叉表只列声明枚举；离群值只给计数，不指出具体包。
+- 身份产物（含作者标识的长表、含投稿路径的解析失败明细）默认不生成，需 `--write-local-identifiers` 且输出目录在仓库外——out-dir 经 `resolve()` 规范化后再做包含检查，相对/绝对路径混写与 symlink 指向工作树内均会被拒绝。
 - 快照证据链：--sha 与 HEAD 不一致拒绝执行；工作树不干净（tracked 修改 / untracked 文件）一律拒绝，任何 flag 不可绕过，失败时不产出可发布 summary。
 - summary 中的离群值与覆盖统计不得用作任何扣分或排名依据。

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -10,23 +10,24 @@
 - **不评价方案优劣**：不含任何排名、评分、推荐或批评。
 - **不点名**：summary 只给计数与匿名聚合，不含作者、路径、slug。
 - **自由文本不进 summary**：metric key 只公开受控官方词表（`CONTROLLED_METRIC_KEYS`，见脚本注释）；status/unit/confidence 的非枚举值只报告总数与不同值数，**不回显原文**（防邮箱/路径等未验证字符串泄露）。
-- **离群值只给计数**：如 `unit_missing=31`、`unit_not_in_enum=250`，不指出具体包。`unit_missing`（字段缺失或 JSON null）与 `unit_not_in_enum`（声明了非枚举值）分开计数，口径不混。
+- **离群值只给计数**：如 `unit_missing=49`、`unit_not_in_enum=507`（20260812 快照），不指出具体包。`unit_missing`（字段缺失或 JSON null）与 `unit_not_in_enum`（声明了非枚举值）分开计数，口径不混。
 - **全部标注分母**：每条统计附 `count` 与 `pct`（分母为全场条目总数）。
 - **长表默认不生成**：含作者标识的长表（csv.gz）需显式 `--write-local-identifiers` 且输出目录必须在仓库外，防止误暂存提交。
 
 ## 复现命令
 
 ```bash
-# 1. 取数：blobless sparse，仅拉文本文件（metrics.json / manifest.json / proposal.md，约 25-40 MB）
+# 1. 取数：blobless + --sparse，仅拉文本文件（metrics.json / manifest.json / proposal.md / agent.json）
+#    （--sparse 是 clone 阶段进入 sparse 模式的官方方式；--no-checkout 组合在部分平台
+#      上 sparse-checkout set 后不重建工作树，会让工具误判工作树为脏，勿用）
 D=$HOME/mx_$RANDOM
-git clone --depth 1 --filter=blob:none --no-checkout \
+git clone --depth 1 --filter=blob:none --sparse \
     https://github.com/open-city-ai/haidian.git $D
 cd $D
 git rev-parse HEAD          # 记录快照 SHA，引用时必须保留
 git sparse-checkout set --no-cone \
     '/submissions/*/*/metrics.json' '/submissions/*/*/manifest.json' \
     '/submissions/*/*/proposal.md' '/submissions/*/*/agent.json'
-git checkout
 
 # 2. 扫描
 # 前置硬性检查（fail-closed，任何 flag 都不可绕过）：
@@ -81,7 +82,7 @@ python3 contrib/tools-metrics-scan.py --repo $D --out-dir $D/../scan-out \
 - `entry_validity`：有效条目占比 + 问题分类（不点名）。
 - `distributions`：status / unit / confidence 均按「声明枚举 + 其他聚合」双段呈现（schema 枚举见 `brief/site-package/schemas/metrics.schema.json`）。**其他段只含 total_count 与 n_distinct_values，不回显非枚举值原文**（隐私边界）。
 - `packages`：每包指标数 min/median/max/mean。
-- `coverage`：指标 key、规范化 key 只来自**受控官方词表**（`CONTROLLED_METRIC_KEYS`，全部列出，无截断），其余 key 全部聚合进 `other_metric_keys`（只报不同值数与条目数）——两者条目之和与 `n_metric_entries` 严格闭合；另有概念桶分布与全部受控 key 的 **status 交叉表**（如 `floor_area_ratio` 全场 630 条中多呈 `unknown`——组织方控规条件未公布的直接结果）。
+- `coverage`：指标 key、规范化 key 只来自**受控官方词表**（`CONTROLLED_METRIC_KEYS`，全部列出，无截断），其余 key 全部聚合进 `other_metric_keys`（只报不同值数与条目数）——两者条目之和与 `n_metric_entries` 严格闭合；另有概念桶分布与全部受控 key 的 **status 交叉表**（如 `floor_area_ratio` 全场 861 条中 840 条 `unknown`——组织方控规条件未公布的直接结果）。
 - `outlier_counts_only`：离群值**计数**（ratio/FAR/height sanity 阈值来自 `brief/site-package/ranges/planning_limits.json` 的 `schema_sanity_bounds_not_planning_approval`；面积类指标对照同一文件 `known_official_area_values`，偏差超过 50% 计一次，均不点名）。**口径说明**：0-1 ratio 检查只针对占比/覆盖率语义（green_ratio、coverage 等）；FAR（floor_area_ratio，合法区间 0-12）、绕路率、街墙高宽比等可合法大于 1 的比率不适用 0-1 检查；百分比单位（pct/percent）条目不适用 0-1 检查；FAR 检查排除面积单位条目（如 `phasing_far_area_sqm` 是分期面积而非容积率）；unit 检查分两档——`unit_missing`（unit 字段缺失或 JSON null）与 `unit_not_in_enum`（声明了 schema 枚举之外的字符串），两者口径互斥、不混计。
 
 ## 隐私与合规

--- a/contrib/metrics-fullfield-20260811.summary.json
+++ b/contrib/metrics-fullfield-20260811.summary.json
@@ -2,6 +2,7 @@
   "snapshot": {
     "repository": "open-city-ai/haidian",
     "sha": "6843ad6709e05b6521f25185d476a967fd928305",
+    "sha_verified_against_head": true,
     "date": "20260811",
     "n_packages_total_dirs": 577,
     "n_packages_with_metrics": 577,

--- a/contrib/metrics-fullfield-20260811.summary.json
+++ b/contrib/metrics-fullfield-20260811.summary.json
@@ -1,0 +1,341 @@
+{
+  "snapshot": {
+    "repository": "open-city-ai/haidian",
+    "sha": "6843ad6709e05b6521f25185d476a967fd928305",
+    "date": "20260811",
+    "n_packages_total_dirs": 577,
+    "n_packages_with_metrics": 577,
+    "n_packages_with_manifest": 577,
+    "n_packages_with_proposal": 577,
+    "n_metric_entries": 12972,
+    "n_parse_failures": 0
+  },
+  "root_structure": {
+    "container_shapes": {
+      "metrics,schema_version,units": 577
+    },
+    "schema_versions": {
+      "0.1.0": 573,
+      "0.2.0": 3,
+      "0.1.1": 1
+    }
+  },
+  "field_coverage": {
+    "confidence": {
+      "missing_count": 150,
+      "missing_pct": 1.16
+    },
+    "formula": {
+      "missing_count": 98,
+      "missing_pct": 0.76
+    },
+    "source_files": {
+      "missing_count": 96,
+      "missing_pct": 0.74
+    },
+    "unit": {
+      "missing_count": 20,
+      "missing_pct": 0.15
+    },
+    "value": {
+      "missing_count": 5,
+      "missing_pct": 0.04
+    }
+  },
+  "entry_validity": {
+    "valid_entries": 12799,
+    "valid_pct": 98.67,
+    "problem_breakdown": {
+      "status='known'": {
+        "count": 130,
+        "explanation": "entry has a declared-valid status but is missing one or more required fields (status/value/unit/source_files/formula/confidence)"
+      },
+      "status='unknown'": {
+        "count": 43,
+        "explanation": "entry has a declared-valid status but is missing one or more required fields (status/value/unit/source_files/formula/confidence)"
+      }
+    }
+  },
+  "distributions": {
+    "status": {
+      "known": {
+        "count": 10983,
+        "pct": 84.67
+      },
+      "unknown": {
+        "count": 1976,
+        "pct": 15.23
+      },
+      "not_applicable": {
+        "count": 13,
+        "pct": 0.1
+      }
+    },
+    "unit": {
+      "declared_enum": {
+        "sqm": 5312,
+        "count": 3419,
+        "ratio": 2923,
+        "m": 871,
+        "index": 103,
+        "none": 94
+      },
+      "other_values": {
+        "total_count": 250,
+        "n_distinct_values": 90,
+        "top": {
+          "null": 45,
+          "km": 16,
+          "persons": 14,
+          "far": 10,
+          "n/a": 10,
+          "ha": 8,
+          "normalized_score_0_100": 6,
+          "percent": 5
+        }
+      }
+    },
+    "confidence": {
+      "declared_enum": {
+        "medium": 5981,
+        "high": 3173,
+        "unknown": 1884,
+        "low": 1770
+      },
+      "other_values": {
+        "total_count": 164,
+        "n_distinct_values": 7,
+        "top": {
+          "null": 150,
+          "n/a": 5,
+          "medium_internal_consistency": 4,
+          "concept": 2,
+          "medium_internal_consistency_low_precision": 1,
+          "none": 1,
+          "context_only": 1
+        }
+      }
+    }
+  },
+  "packages": {
+    "metrics_per_pkg": {
+      "min": 6,
+      "median": 21,
+      "max": 86,
+      "mean": 22.48
+    }
+  },
+  "coverage": {
+    "top_metric_keys": [
+      {
+        "site_area_sqm": 577
+      },
+      {
+        "green_ratio": 577
+      },
+      {
+        "public_space_ratio": 577
+      },
+      {
+        "key_area_count": 564
+      },
+      {
+        "building_footprint_area_sqm": 562
+      },
+      {
+        "floor_area_ratio": 540
+      },
+      {
+        "public_space_area_sqm": 381
+      },
+      {
+        "green_space_area_sqm": 376
+      },
+      {
+        "persona_count": 202
+      },
+      {
+        "building_density": 199
+      },
+      {
+        "building_height_m": 193
+      },
+      {
+        "total_floor_area_sqm": 158
+      },
+      {
+        "scenario_node_count": 152
+      },
+      {
+        "renewal_project_count": 148
+      },
+      {
+        "scenario_card_count": 131
+      },
+      {
+        "landmark_count": 110
+      },
+      {
+        "phase_1_area_sqm": 109
+      },
+      {
+        "phase_count": 102
+      },
+      {
+        "phase_2_area_sqm": 100
+      },
+      {
+        "phase_3_area_sqm": 100
+      }
+    ],
+    "top_normalized_keys": [
+      {
+        "site_area": 583
+      },
+      {
+        "public_space": 582
+      },
+      {
+        "green": 577
+      },
+      {
+        "key_area": 565
+      },
+      {
+        "building_footprint_area": 563
+      },
+      {
+        "floor_area": 541
+      },
+      {
+        "public_space_area": 383
+      },
+      {
+        "green_space_area": 377
+      },
+      {
+        "building_density": 210
+      },
+      {
+        "persona": 202
+      },
+      {
+        "building_height": 194
+      },
+      {
+        "total_floor_area": 159
+      },
+      {
+        "scenario_node": 152
+      },
+      {
+        "renewal_project": 148
+      },
+      {
+        "road_area": 145
+      },
+      {
+        "scenario_card": 131
+      },
+      {
+        "landmark": 110
+      },
+      {
+        "phase_1_area": 109
+      },
+      {
+        "phase": 102
+      },
+      {
+        "phase_2_area": 100
+      }
+    ],
+    "concept_buckets": {
+      "area": {
+        "count": 6304,
+        "pct": 48.6
+      },
+      "counts": {
+        "count": 2634,
+        "pct": 20.31
+      },
+      "intensity": {
+        "count": 2413,
+        "pct": 18.6
+      },
+      "other": {
+        "count": 799,
+        "pct": 6.16
+      },
+      "mobility": {
+        "count": 678,
+        "pct": 5.23
+      },
+      "green_public": {
+        "count": 144,
+        "pct": 1.11
+      }
+    },
+    "top_key_status_cross": {
+      "site_area_sqm": {
+        "known": 577
+      },
+      "green_ratio": {
+        "known": 577
+      },
+      "public_space_ratio": {
+        "known": 577
+      },
+      "key_area_count": {
+        "known": 564
+      },
+      "building_footprint_area_sqm": {
+        "known": 560,
+        "unknown": 2
+      },
+      "floor_area_ratio": {
+        "known": 14,
+        "unknown": 526
+      },
+      "public_space_area_sqm": {
+        "known": 381
+      },
+      "green_space_area_sqm": {
+        "known": 376
+      },
+      "persona_count": {
+        "known": 202
+      },
+      "building_density": {
+        "known": 104,
+        "unknown": 95
+      },
+      "building_height_m": {
+        "unknown": 193
+      },
+      "total_floor_area_sqm": {
+        "known": 19,
+        "unknown": 139
+      },
+      "scenario_node_count": {
+        "known": 152
+      },
+      "renewal_project_count": {
+        "known": 148
+      },
+      "scenario_card_count": {
+        "known": 131
+      }
+    }
+  },
+  "outlier_counts_only": {
+    "status_not_in_enum": 0,
+    "unit_not_in_enum": 250,
+    "ratio_outside_0_1": 0,
+    "far_above_12": 0,
+    "height_above_300m": 0,
+    "note": "counts only; no package is named or ranked",
+    "sanity_sources": "bounds from brief/site-package/ranges/planning_limits.json schema_sanity_bounds_not_planning_approval; ratio check applies to share/coverage ratios only (FAR, detour and street-wall height/width ratios have their own legitimate ranges and are excluded; percentage-unit entries are excluded); FAR check excludes area-valued keys (e.g. phasing_far_area_sqm is a phase area, not a floor-area-ratio); area deviation threshold: >50% off the official known area value in the same file (known_official_area_values)"
+  },
+  "privacy_boundary": "This summary contains aggregate counts only. It does not contain package paths, authors, slugs, or any ranking. The long-format table with identifying columns is a local artifact and must not be committed."
+}

--- a/contrib/metrics-fullfield-20260812.summary.json
+++ b/contrib/metrics-fullfield-20260812.summary.json
@@ -1,58 +1,62 @@
 {
   "snapshot": {
     "repository": "open-city-ai/haidian",
-    "sha": "6843ad6709e05b6521f25185d476a967fd928305",
+    "sha": "0f13375fe1a9c8789cf991b336dd5e14b104fcdb",
     "sha_verified_against_head": true,
-    "date": "20260811",
-    "n_packages_total_dirs": 577,
-    "n_packages_with_metrics": 577,
-    "n_packages_with_manifest": 577,
-    "n_packages_with_proposal": 577,
-    "n_metric_entries": 12972,
+    "date": "20260812",
+    "n_packages_total_dirs": 671,
+    "n_packages_with_metrics": 671,
+    "n_packages_with_manifest": 671,
+    "n_packages_with_proposal": 671,
+    "n_metric_entries": 15006,
     "n_parse_failures": 0
   },
   "root_structure": {
     "container_shapes": {
-      "metrics,schema_version,units": 577
+      "metrics,schema_version,units": 671
     },
     "schema_versions": {
-      "0.1.0": 573,
-      "0.2.0": 3,
-      "0.1.1": 1
+      "0.1.0": 665,
+      "0.2.0": 4,
+      "0.1.1": 2
     }
   },
   "field_coverage": {
     "confidence": {
-      "missing_count": 150,
-      "missing_pct": 1.16
+      "missing_count": 158,
+      "missing_pct": 1.05
     },
     "formula": {
-      "missing_count": 98,
-      "missing_pct": 0.76
+      "missing_count": 105,
+      "missing_pct": 0.7
     },
     "source_files": {
-      "missing_count": 96,
-      "missing_pct": 0.74
+      "missing_count": 98,
+      "missing_pct": 0.65
     },
     "unit": {
       "missing_count": 20,
-      "missing_pct": 0.15
+      "missing_pct": 0.13
     },
     "value": {
       "missing_count": 5,
-      "missing_pct": 0.04
+      "missing_pct": 0.03
     }
   },
   "entry_validity": {
-    "valid_entries": 12799,
-    "valid_pct": 98.67,
+    "valid_entries": 14820,
+    "valid_pct": 98.76,
     "problem_breakdown": {
       "status='known'": {
-        "count": 130,
+        "count": 138,
         "explanation": "entry has a declared-valid status but is missing one or more required fields (status/value/unit/source_files/formula/confidence)"
       },
       "status='unknown'": {
-        "count": 43,
+        "count": 45,
+        "explanation": "entry has a declared-valid status but is missing one or more required fields (status/value/unit/source_files/formula/confidence)"
+      },
+      "status='not_applicable'": {
+        "count": 3,
         "explanation": "entry has a declared-valid status but is missing one or more required fields (status/value/unit/source_files/formula/confidence)"
       }
     }
@@ -60,55 +64,56 @@
   "distributions": {
     "status": {
       "known": {
-        "count": 10983,
-        "pct": 84.67
+        "count": 12701,
+        "pct": 84.64
       },
       "unknown": {
-        "count": 1976,
+        "count": 2286,
         "pct": 15.23
       },
       "not_applicable": {
-        "count": 13,
-        "pct": 0.1
+        "count": 19,
+        "pct": 0.13
       }
     },
     "unit": {
       "declared_enum": {
-        "sqm": 5312,
-        "count": 3419,
-        "ratio": 2923,
-        "m": 871,
-        "index": 103,
-        "none": 94
+        "sqm": 6047,
+        "count": 4020,
+        "ratio": 3377,
+        "m": 989,
+        "none": 115,
+        "index": 115
       },
       "other_values": {
-        "total_count": 250,
-        "n_distinct_values": 90,
+        "total_count": 343,
+        "n_distinct_values": 112,
         "top": {
           "null": 45,
-          "km": 16,
-          "persons": 14,
+          "km": 21,
+          "m²": 21,
+          "persons": 16,
+          "ha": 14,
           "far": 10,
           "n/a": 10,
-          "ha": 8,
-          "normalized_score_0_100": 6,
-          "percent": 5
+          "个": 9
         }
       }
     },
     "confidence": {
       "declared_enum": {
-        "medium": 5981,
-        "high": 3173,
-        "unknown": 1884,
-        "low": 1770
+        "medium": 6867,
+        "high": 3747,
+        "unknown": 2172,
+        "low": 2032
       },
       "other_values": {
-        "total_count": 164,
-        "n_distinct_values": 7,
+        "total_count": 188,
+        "n_distinct_values": 8,
         "top": {
-          "null": 150,
-          "n/a": 5,
+          "null": 158,
+          "screening": 11,
+          "n/a": 10,
           "medium_internal_consistency": 4,
           "concept": 2,
           "medium_internal_consistency_low_precision": 1,
@@ -121,217 +126,218 @@
   "packages": {
     "metrics_per_pkg": {
       "min": 6,
-      "median": 21,
-      "max": 86,
-      "mean": 22.48
+      "median": 20,
+      "max": 159,
+      "mean": 22.36
     }
   },
   "coverage": {
     "top_metric_keys": [
       {
-        "site_area_sqm": 577
+        "site_area_sqm": 671
       },
       {
-        "green_ratio": 577
+        "green_ratio": 671
       },
       {
-        "public_space_ratio": 577
+        "public_space_ratio": 671
       },
       {
-        "key_area_count": 564
+        "key_area_count": 657
       },
       {
-        "building_footprint_area_sqm": 562
+        "building_footprint_area_sqm": 655
       },
       {
-        "floor_area_ratio": 540
+        "floor_area_ratio": 630
       },
       {
-        "public_space_area_sqm": 381
+        "public_space_area_sqm": 434
       },
       {
-        "green_space_area_sqm": 376
+        "green_space_area_sqm": 428
       },
       {
-        "persona_count": 202
+        "persona_count": 230
       },
       {
-        "building_density": 199
+        "building_density": 226
       },
       {
-        "building_height_m": 193
+        "building_height_m": 222
       },
       {
-        "total_floor_area_sqm": 158
+        "total_floor_area_sqm": 174
       },
       {
-        "scenario_node_count": 152
+        "scenario_node_count": 173
       },
       {
-        "renewal_project_count": 148
+        "renewal_project_count": 166
       },
       {
-        "scenario_card_count": 131
+        "scenario_card_count": 154
       },
       {
-        "landmark_count": 110
+        "landmark_count": 127
       },
       {
-        "phase_1_area_sqm": 109
+        "phase_count": 122
       },
       {
-        "phase_count": 102
+        "phase_1_area_sqm": 116
       },
       {
-        "phase_2_area_sqm": 100
+        "road_area_sqm": 109
       },
       {
-        "phase_3_area_sqm": 100
+        "phase_2_area_sqm": 107
       }
     ],
     "top_normalized_keys": [
       {
-        "site_area": 583
+        "site_area": 679
       },
       {
-        "public_space": 582
+        "public_space": 679
       },
       {
-        "green": 577
+        "green": 671
       },
       {
-        "key_area": 565
+        "key_area": 658
       },
       {
-        "building_footprint_area": 563
+        "building_footprint_area": 656
       },
       {
-        "floor_area": 541
+        "floor_area": 631
       },
       {
-        "public_space_area": 383
+        "public_space_area": 436
       },
       {
-        "green_space_area": 377
+        "green_space_area": 429
       },
       {
-        "building_density": 210
+        "building_density": 238
       },
       {
-        "persona": 202
+        "persona": 230
       },
       {
-        "building_height": 194
+        "building_height": 223
       },
       {
-        "total_floor_area": 159
+        "total_floor_area": 175
       },
       {
-        "scenario_node": 152
+        "scenario_node": 173
       },
       {
-        "renewal_project": 148
+        "renewal_project": 166
       },
       {
-        "road_area": 145
+        "road_area": 161
       },
       {
-        "scenario_card": 131
+        "scenario_card": 154
       },
       {
-        "landmark": 110
+        "landmark": 127
       },
       {
-        "phase_1_area": 109
+        "phase": 122
       },
       {
-        "phase": 102
+        "phase_1_area": 116
       },
       {
-        "phase_2_area": 100
+        "phase_2_area": 107
       }
     ],
     "concept_buckets": {
       "area": {
-        "count": 6304,
-        "pct": 48.6
+        "count": 7224,
+        "pct": 48.14
       },
       "counts": {
-        "count": 2634,
-        "pct": 20.31
+        "count": 3106,
+        "pct": 20.7
       },
       "intensity": {
-        "count": 2413,
-        "pct": 18.6
+        "count": 2774,
+        "pct": 18.49
       },
       "other": {
-        "count": 799,
-        "pct": 6.16
+        "count": 950,
+        "pct": 6.33
       },
       "mobility": {
-        "count": 678,
-        "pct": 5.23
+        "count": 782,
+        "pct": 5.21
       },
       "green_public": {
-        "count": 144,
-        "pct": 1.11
+        "count": 170,
+        "pct": 1.13
       }
     },
     "top_key_status_cross": {
       "site_area_sqm": {
-        "known": 577
+        "known": 671
       },
       "green_ratio": {
-        "known": 577
+        "known": 671
       },
       "public_space_ratio": {
-        "known": 577
+        "known": 671
       },
       "key_area_count": {
-        "known": 564
+        "known": 657
       },
       "building_footprint_area_sqm": {
-        "known": 560,
-        "unknown": 2
+        "known": 652,
+        "unknown": 3
       },
       "floor_area_ratio": {
-        "known": 14,
-        "unknown": 526
+        "known": 16,
+        "unknown": 614
       },
       "public_space_area_sqm": {
-        "known": 381
+        "known": 434
       },
       "green_space_area_sqm": {
-        "known": 376
+        "known": 428
       },
       "persona_count": {
-        "known": 202
+        "known": 230
       },
       "building_density": {
-        "known": 104,
-        "unknown": 95
+        "known": 118,
+        "unknown": 108
       },
       "building_height_m": {
-        "unknown": 193
+        "unknown": 222
       },
       "total_floor_area_sqm": {
-        "known": 19,
-        "unknown": 139
+        "known": 21,
+        "unknown": 153
       },
       "scenario_node_count": {
-        "known": 152
+        "known": 173
       },
       "renewal_project_count": {
-        "known": 148
+        "known": 166
       },
       "scenario_card_count": {
-        "known": 131
+        "known": 154
       }
     }
   },
   "outlier_counts_only": {
     "status_not_in_enum": 0,
-    "unit_not_in_enum": 250,
+    "unit_missing": 45,
+    "unit_not_in_enum": 298,
     "ratio_outside_0_1": 0,
     "far_above_12": 0,
     "height_above_300m": 0,

--- a/contrib/metrics-fullfield-20260812.summary.json
+++ b/contrib/metrics-fullfield-20260812.summary.json
@@ -1,61 +1,63 @@
 {
   "snapshot": {
     "repository": "open-city-ai/haidian",
-    "sha": "0f13375fe1a9c8789cf991b336dd5e14b104fcdb",
+    "sha": "ce5d8eb6aff44e5a2de367caf416e8849ecc1f31",
     "sha_verified_against_head": true,
     "date": "20260812",
-    "n_packages_total_dirs": 671,
-    "n_packages_with_metrics": 671,
-    "n_packages_with_manifest": 671,
-    "n_packages_with_proposal": 671,
-    "n_metric_entries": 15006,
+    "n_packages_total_dirs": 923,
+    "n_packages_with_metrics": 923,
+    "n_packages_with_manifest": 923,
+    "n_packages_with_proposal": 923,
+    "n_metric_entries": 20980,
     "n_parse_failures": 0
   },
   "root_structure": {
     "container_shapes": {
-      "metrics,schema_version,units": 671
+      "metrics,schema_version,units": 923
     },
     "schema_versions": {
-      "0.1.0": 665,
-      "0.2.0": 4,
-      "0.1.1": 2
+      "0.1.0": 912,
+      "0.2.0": 7,
+      "0.1.1": 2,
+      "1.0": 1,
+      "1.10.0": 1
     }
   },
   "field_coverage": {
     "confidence": {
-      "missing_count": 158,
-      "missing_pct": 1.05
+      "missing_count": 302,
+      "missing_pct": 1.44
     },
     "formula": {
-      "missing_count": 105,
-      "missing_pct": 0.7
+      "missing_count": 159,
+      "missing_pct": 0.76
     },
     "source_files": {
-      "missing_count": 98,
-      "missing_pct": 0.65
+      "missing_count": 150,
+      "missing_pct": 0.71
     },
     "unit": {
-      "missing_count": 20,
-      "missing_pct": 0.13
+      "missing_count": 24,
+      "missing_pct": 0.11
     },
     "value": {
       "missing_count": 5,
-      "missing_pct": 0.03
+      "missing_pct": 0.02
     }
   },
   "entry_validity": {
-    "valid_entries": 14820,
-    "valid_pct": 98.76,
+    "valid_entries": 20643,
+    "valid_pct": 98.39,
     "problem_breakdown": {
-      "status='known'": {
-        "count": 138,
+      "status=known": {
+        "count": 251,
         "explanation": "entry has a declared-valid status but is missing one or more required fields (status/value/unit/source_files/formula/confidence)"
       },
-      "status='unknown'": {
-        "count": 45,
+      "status=unknown": {
+        "count": 83,
         "explanation": "entry has a declared-valid status but is missing one or more required fields (status/value/unit/source_files/formula/confidence)"
       },
-      "status='not_applicable'": {
+      "status=not_applicable": {
         "count": 3,
         "explanation": "entry has a declared-valid status but is missing one or more required fields (status/value/unit/source_files/formula/confidence)"
       }
@@ -63,286 +65,344 @@
   },
   "distributions": {
     "status": {
-      "known": {
-        "count": 12701,
-        "pct": 84.64
+      "declared_enum": {
+        "known": 17720,
+        "unknown": 3220,
+        "not_applicable": 40
       },
-      "unknown": {
-        "count": 2286,
-        "pct": 15.23
-      },
-      "not_applicable": {
-        "count": 19,
-        "pct": 0.13
+      "other_values": {
+        "total_count": 0,
+        "n_distinct_values": 0
       }
     },
     "unit": {
       "declared_enum": {
-        "sqm": 6047,
-        "count": 4020,
-        "ratio": 3377,
-        "m": 989,
-        "none": 115,
-        "index": 115
+        "sqm": 8056,
+        "count": 5871,
+        "ratio": 4780,
+        "m": 1329,
+        "index": 209,
+        "none": 179
       },
       "other_values": {
-        "total_count": 343,
-        "n_distinct_values": 112,
-        "top": {
-          "null": 45,
-          "km": 21,
-          "m²": 21,
-          "persons": 16,
-          "ha": 14,
-          "far": 10,
-          "n/a": 10,
-          "个": 9
-        }
+        "total_count": 556,
+        "n_distinct_values": 171
       }
     },
     "confidence": {
       "declared_enum": {
-        "medium": 6867,
-        "high": 3747,
-        "unknown": 2172,
-        "low": 2032
+        "medium": 8898,
+        "high": 5571,
+        "low": 3148,
+        "unknown": 2981
       },
       "other_values": {
-        "total_count": 188,
-        "n_distinct_values": 8,
-        "top": {
-          "null": 158,
-          "screening": 11,
-          "n/a": 10,
-          "medium_internal_consistency": 4,
-          "concept": 2,
-          "medium_internal_consistency_low_precision": 1,
-          "none": 1,
-          "context_only": 1
-        }
+        "total_count": 382,
+        "n_distinct_values": 13
       }
     }
   },
   "packages": {
     "metrics_per_pkg": {
-      "min": 6,
+      "min": 3,
       "median": 20,
-      "max": 159,
-      "mean": 22.36
+      "max": 245,
+      "mean": 22.73
     }
   },
   "coverage": {
     "top_metric_keys": [
       {
-        "site_area_sqm": 671
+        "site_area_sqm": 923
       },
       {
-        "green_ratio": 671
+        "green_ratio": 923
       },
       {
-        "public_space_ratio": 671
+        "public_space_ratio": 923
       },
       {
-        "key_area_count": 657
+        "building_footprint_area_sqm": 891
       },
       {
-        "building_footprint_area_sqm": 655
+        "key_area_count": 890
       },
       {
-        "floor_area_ratio": 630
+        "floor_area_ratio": 861
       },
       {
-        "public_space_area_sqm": 434
+        "public_space_area_sqm": 580
       },
       {
-        "green_space_area_sqm": 428
+        "green_space_area_sqm": 571
       },
       {
-        "persona_count": 230
+        "building_density": 301
       },
       {
-        "building_density": 226
+        "persona_count": 294
       },
       {
-        "building_height_m": 222
+        "building_height_m": 292
       },
       {
-        "total_floor_area_sqm": 174
+        "scenario_node_count": 223
       },
       {
-        "scenario_node_count": 173
+        "scenario_card_count": 214
       },
       {
-        "renewal_project_count": 166
+        "total_floor_area_sqm": 214
       },
       {
-        "scenario_card_count": 154
+        "renewal_project_count": 199
       },
       {
-        "landmark_count": 127
+        "landmark_count": 162
       },
       {
-        "phase_count": 122
+        "phase_count": 151
       },
       {
-        "phase_1_area_sqm": 116
+        "road_area_sqm": 140
       },
       {
-        "road_area_sqm": 109
+        "phase_1_area_sqm": 138
       },
       {
-        "phase_2_area_sqm": 107
+        "phase_2_area_sqm": 127
+      },
+      {
+        "coordinated_research_area_sqm": 49
+      },
+      {
+        "key_detailed_design_area_sqm": 48
+      },
+      {
+        "overall_design_area_sqm": 16
+      },
+      {
+        "zhongzhiyuan_ai_acceleration_area_sqm": 10
+      },
+      {
+        "beijing_ai_origin_community_sqm": 8
+      },
+      {
+        "dazhongsi_ai_industry_cluster_sqm": 8
       }
     ],
     "top_normalized_keys": [
       {
-        "site_area": 679
+        "site_area": 923
       },
       {
-        "public_space": 679
+        "green": 923
       },
       {
-        "green": 671
+        "public_space": 923
       },
       {
-        "key_area": 658
+        "building_footprint_area": 891
       },
       {
-        "building_footprint_area": 656
+        "key_area": 890
       },
       {
-        "floor_area": 631
+        "floor_area": 861
       },
       {
-        "public_space_area": 436
+        "public_space_area": 580
       },
       {
-        "green_space_area": 429
+        "green_space_area": 571
       },
       {
-        "building_density": 238
+        "building_density": 301
       },
       {
-        "persona": 230
+        "persona": 294
       },
       {
-        "building_height": 223
+        "building_height": 292
       },
       {
-        "total_floor_area": 175
+        "scenario_node": 223
       },
       {
-        "scenario_node": 173
+        "scenario_card": 214
       },
       {
-        "renewal_project": 166
+        "total_floor_area": 214
       },
       {
-        "road_area": 161
+        "renewal_project": 199
       },
       {
-        "scenario_card": 154
+        "landmark": 162
       },
       {
-        "landmark": 127
+        "phase": 151
       },
       {
-        "phase": 122
+        "road_area": 140
       },
       {
-        "phase_1_area": 116
+        "phase_1_area": 138
       },
       {
-        "phase_2_area": 107
+        "phase_2_area": 127
+      },
+      {
+        "coordinated_research_area": 49
+      },
+      {
+        "key_detailed_design_area": 48
+      },
+      {
+        "overall_design_area": 16
+      },
+      {
+        "zhongzhiyuan_ai_acceleration_area": 10
+      },
+      {
+        "beijing_ai_origin_community": 8
+      },
+      {
+        "dazhongsi_ai_industry_cluster": 8
       }
     ],
+    "other_metric_keys": {
+      "n_distinct_keys": 5235,
+      "n_entries": 11824
+    },
     "concept_buckets": {
       "area": {
-        "count": 7224,
-        "pct": 48.14
+        "count": 9664,
+        "pct": 46.06
       },
       "counts": {
-        "count": 3106,
-        "pct": 20.7
+        "count": 4556,
+        "pct": 21.72
       },
       "intensity": {
-        "count": 2774,
-        "pct": 18.49
+        "count": 3807,
+        "pct": 18.15
       },
       "other": {
-        "count": 950,
-        "pct": 6.33
+        "count": 1597,
+        "pct": 7.61
       },
       "mobility": {
-        "count": 782,
-        "pct": 5.21
+        "count": 1066,
+        "pct": 5.08
       },
       "green_public": {
-        "count": 170,
-        "pct": 1.13
+        "count": 290,
+        "pct": 1.38
       }
     },
     "top_key_status_cross": {
       "site_area_sqm": {
-        "known": 671
+        "known": 923
       },
       "green_ratio": {
-        "known": 671
+        "known": 923
       },
       "public_space_ratio": {
-        "known": 671
-      },
-      "key_area_count": {
-        "known": 657
+        "known": 923
       },
       "building_footprint_area_sqm": {
-        "known": 652,
-        "unknown": 3
+        "known": 881,
+        "unknown": 10
+      },
+      "key_area_count": {
+        "known": 890
       },
       "floor_area_ratio": {
-        "known": 16,
-        "unknown": 614
+        "known": 20,
+        "not_applicable": 1,
+        "unknown": 840
       },
       "public_space_area_sqm": {
-        "known": 434
+        "known": 577,
+        "not_applicable": 1,
+        "unknown": 2
       },
       "green_space_area_sqm": {
-        "known": 428
-      },
-      "persona_count": {
-        "known": 230
+        "known": 568,
+        "not_applicable": 1,
+        "unknown": 2
       },
       "building_density": {
-        "known": 118,
-        "unknown": 108
+        "known": 156,
+        "unknown": 145
+      },
+      "persona_count": {
+        "known": 294
       },
       "building_height_m": {
-        "unknown": 222
-      },
-      "total_floor_area_sqm": {
-        "known": 21,
-        "unknown": 153
+        "not_applicable": 1,
+        "unknown": 291
       },
       "scenario_node_count": {
-        "known": 173
-      },
-      "renewal_project_count": {
-        "known": 166
+        "known": 223
       },
       "scenario_card_count": {
-        "known": 154
+        "known": 214
+      },
+      "total_floor_area_sqm": {
+        "known": 31,
+        "unknown": 183
+      },
+      "renewal_project_count": {
+        "known": 199
+      },
+      "landmark_count": {
+        "known": 162
+      },
+      "phase_count": {
+        "known": 150,
+        "not_applicable": 1
+      },
+      "road_area_sqm": {
+        "known": 63,
+        "unknown": 77
+      },
+      "phase_1_area_sqm": {
+        "known": 138
+      },
+      "phase_2_area_sqm": {
+        "known": 127
+      },
+      "coordinated_research_area_sqm": {
+        "known": 49
+      },
+      "key_detailed_design_area_sqm": {
+        "known": 48
+      },
+      "overall_design_area_sqm": {
+        "known": 16
+      },
+      "zhongzhiyuan_ai_acceleration_area_sqm": {
+        "known": 10
+      },
+      "beijing_ai_origin_community_sqm": {
+        "known": 8
+      },
+      "dazhongsi_ai_industry_cluster_sqm": {
+        "known": 8
       }
     }
   },
   "outlier_counts_only": {
     "status_not_in_enum": 0,
-    "unit_missing": 45,
-    "unit_not_in_enum": 298,
+    "unit_missing": 49,
+    "unit_not_in_enum": 507,
     "ratio_outside_0_1": 0,
     "far_above_12": 0,
     "height_above_300m": 0,
     "note": "counts only; no package is named or ranked",
     "sanity_sources": "bounds from brief/site-package/ranges/planning_limits.json schema_sanity_bounds_not_planning_approval; ratio check applies to share/coverage ratios only (FAR, detour and street-wall height/width ratios have their own legitimate ranges and are excluded; percentage-unit entries are excluded); FAR check excludes area-valued keys (e.g. phasing_far_area_sqm is a phase area, not a floor-area-ratio); area deviation threshold: >50% off the official known area value in the same file (known_official_area_values)"
   },
-  "privacy_boundary": "This summary contains aggregate counts only. It does not contain package paths, authors, slugs, or any ranking. The long-format table with identifying columns is a local artifact and must not be committed."
+  "privacy_boundary": "This summary contains aggregate counts only. It does not contain package paths, authors, slugs, or any ranking. Metric keys are published verbatim only when they belong to the controlled official vocabulary (CONTROLLED_METRIC_KEYS); all other keys, and all non-enum status/unit/confidence values, appear only as counts (total and number of distinct values) - never verbatim. The long-format table with identifying columns is a local artifact, written only with --write-local-identifiers to a directory outside the scanned worktree, and must never be committed."
 }

--- a/contrib/metrics-fullfield-20260812.summary.json
+++ b/contrib/metrics-fullfield-20260812.summary.json
@@ -1,14 +1,14 @@
 {
   "snapshot": {
     "repository": "open-city-ai/haidian",
-    "sha": "ce5d8eb6aff44e5a2de367caf416e8849ecc1f31",
+    "sha": "f0d74e446aae8e78bef53345155a82a678f4604f",
     "sha_verified_against_head": true,
     "date": "20260812",
     "n_packages_total_dirs": 923,
     "n_packages_with_metrics": 923,
     "n_packages_with_manifest": 923,
     "n_packages_with_proposal": 923,
-    "n_metric_entries": 20980,
+    "n_metric_entries": 20985,
     "n_parse_failures": 0
   },
   "root_structure": {
@@ -16,11 +16,17 @@
       "metrics,schema_version,units": 923
     },
     "schema_versions": {
-      "0.1.0": 912,
-      "0.2.0": 7,
-      "0.1.1": 2,
-      "1.0": 1,
-      "1.10.0": 1
+      "declared_enum": {
+        "0.1.0": 912,
+        "0.2.0": 7,
+        "0.1.1": 2,
+        "1.0": 1,
+        "1.10.0": 1
+      },
+      "other_values": {
+        "total_count": 0,
+        "n_distinct_values": 0
+      }
     }
   },
   "field_coverage": {
@@ -46,7 +52,7 @@
     }
   },
   "entry_validity": {
-    "valid_entries": 20643,
+    "valid_entries": 20648,
     "valid_pct": 98.39,
     "problem_breakdown": {
       "status=known": {
@@ -66,7 +72,7 @@
   "distributions": {
     "status": {
       "declared_enum": {
-        "known": 17720,
+        "known": 17725,
         "unknown": 3220,
         "not_applicable": 40
       },
@@ -78,8 +84,8 @@
     "unit": {
       "declared_enum": {
         "sqm": 8056,
-        "count": 5871,
-        "ratio": 4780,
+        "count": 5873,
+        "ratio": 4783,
         "m": 1329,
         "index": 209,
         "none": 179
@@ -92,7 +98,7 @@
     "confidence": {
       "declared_enum": {
         "medium": 8898,
-        "high": 5571,
+        "high": 5576,
         "low": 3148,
         "unknown": 2981
       },
@@ -107,7 +113,7 @@
       "min": 3,
       "median": 20,
       "max": 245,
-      "mean": 22.73
+      "mean": 22.74
     }
   },
   "coverage": {
@@ -273,24 +279,24 @@
     ],
     "other_metric_keys": {
       "n_distinct_keys": 5235,
-      "n_entries": 11824
+      "n_entries": 11829
     },
     "concept_buckets": {
       "area": {
         "count": 9664,
-        "pct": 46.06
+        "pct": 46.05
       },
       "counts": {
-        "count": 4556,
+        "count": 4557,
         "pct": 21.72
       },
       "intensity": {
         "count": 3807,
-        "pct": 18.15
+        "pct": 18.14
       },
       "other": {
-        "count": 1597,
-        "pct": 7.61
+        "count": 1601,
+        "pct": 7.63
       },
       "mobility": {
         "count": 1066,
@@ -303,94 +309,198 @@
     },
     "top_key_status_cross": {
       "site_area_sqm": {
-        "known": 923
+        "known": 923,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "green_ratio": {
-        "known": 923
+        "known": 923,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "public_space_ratio": {
-        "known": 923
+        "known": 923,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "building_footprint_area_sqm": {
         "known": 881,
-        "unknown": 10
+        "unknown": 10,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "key_area_count": {
-        "known": 890
+        "known": 890,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "floor_area_ratio": {
         "known": 20,
         "not_applicable": 1,
-        "unknown": 840
+        "unknown": 840,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "public_space_area_sqm": {
         "known": 577,
         "not_applicable": 1,
-        "unknown": 2
+        "unknown": 2,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "green_space_area_sqm": {
         "known": 568,
         "not_applicable": 1,
-        "unknown": 2
+        "unknown": 2,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "building_density": {
         "known": 156,
-        "unknown": 145
+        "unknown": 145,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "persona_count": {
-        "known": 294
+        "known": 294,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "building_height_m": {
         "not_applicable": 1,
-        "unknown": 291
+        "unknown": 291,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "scenario_node_count": {
-        "known": 223
+        "known": 223,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "scenario_card_count": {
-        "known": 214
+        "known": 214,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "total_floor_area_sqm": {
         "known": 31,
-        "unknown": 183
+        "unknown": 183,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "renewal_project_count": {
-        "known": 199
+        "known": 199,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "landmark_count": {
-        "known": 162
+        "known": 162,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "phase_count": {
         "known": 150,
-        "not_applicable": 1
+        "not_applicable": 1,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "road_area_sqm": {
         "known": 63,
-        "unknown": 77
+        "unknown": 77,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "phase_1_area_sqm": {
-        "known": 138
+        "known": 138,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "phase_2_area_sqm": {
-        "known": 127
+        "known": 127,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "coordinated_research_area_sqm": {
-        "known": 49
+        "known": 49,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "key_detailed_design_area_sqm": {
-        "known": 48
+        "known": 48,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "overall_design_area_sqm": {
-        "known": 16
+        "known": 16,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "zhongzhiyuan_ai_acceleration_area_sqm": {
-        "known": 10
+        "known": 10,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "beijing_ai_origin_community_sqm": {
-        "known": 8
+        "known": 8,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       },
       "dazhongsi_ai_industry_cluster_sqm": {
-        "known": 8
+        "known": 8,
+        "other": {
+          "total_count": 0,
+          "n_distinct_values": 0
+        }
       }
     }
   },
@@ -404,5 +514,5 @@
     "note": "counts only; no package is named or ranked",
     "sanity_sources": "bounds from brief/site-package/ranges/planning_limits.json schema_sanity_bounds_not_planning_approval; ratio check applies to share/coverage ratios only (FAR, detour and street-wall height/width ratios have their own legitimate ranges and are excluded; percentage-unit entries are excluded); FAR check excludes area-valued keys (e.g. phasing_far_area_sqm is a phase area, not a floor-area-ratio); area deviation threshold: >50% off the official known area value in the same file (known_official_area_values)"
   },
-  "privacy_boundary": "This summary contains aggregate counts only. It does not contain package paths, authors, slugs, or any ranking. Metric keys are published verbatim only when they belong to the controlled official vocabulary (CONTROLLED_METRIC_KEYS); all other keys, and all non-enum status/unit/confidence values, appear only as counts (total and number of distinct values) - never verbatim. The long-format table with identifying columns is a local artifact, written only with --write-local-identifiers to a directory outside the scanned worktree, and must never be committed."
+  "privacy_boundary": "This summary contains aggregate counts only. It does not contain package paths, authors, slugs, or any ranking. Metric keys are published verbatim only when they belong to the controlled official vocabulary (CONTROLLED_METRIC_KEYS); all other keys, and all non-enum status/unit/confidence values, appear only as counts (total and number of distinct values) - never verbatim. schema_version appears verbatim only for the known versions observed across the field (KNOWN_SCHEMA_VERSIONS); the per-key status cross for controlled keys lists only the declared status enum (known/unknown/not_applicable), any other status collapsing into an anonymous other count. The long-format table and the parse-failure detail carry identifying paths and are local artifacts, written only with --write-local-identifiers to a directory outside the scanned worktree, and must never be committed."
 }

--- a/contrib/test_tools_metrics_scan.py
+++ b/contrib/test_tools_metrics_scan.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Regression tests for tools-metrics-scan.py (stdlib only, no pip deps).
+
+Locks the boundaries discussed in the PR review:
+
+- missing/null unit and non-enum unit are counted separately
+  (`unit_missing` vs `unit_not_in_enum`, mutually exclusive)
+- pct/percent units are excluded from the 0-1 share-ratio sanity check
+- `*_far_area_sqm` phase-area keys are not treated as floor-area-ratio
+- `--sha` mismatch is rejected unless `--allow-sha-mismatch` is passed,
+  and an unverified snapshot is recorded in the summary
+
+Run: python3 contrib/test_tools_metrics_scan.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def load_tool():
+    """Load tools-metrics-scan.py by file path (hyphenated name is not importable)."""
+    spec = importlib.util.spec_from_file_location(
+        "tools_metrics_scan", HERE / "tools-metrics-scan.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def make_metrics(entries: dict) -> dict:
+    return {
+        "schema_version": 1,
+        "units": {"area": "sqm", "length": "m"},
+        "metrics": entries,
+    }
+
+
+def entry(value, unit=None, status="known"):
+    """A valid-shaped metric entry; unit omitted entirely when None is passed
+    explicitly, so a missing field can be distinguished from JSON null."""
+    e = {
+        "status": status,
+        "value": value,
+        "unit": unit,
+        "source_files": [],
+        "formula": "",
+        "confidence": "high",
+    }
+    if unit is None:
+        del e["unit"]
+    return e
+
+
+def run_scan(tmp_dir: Path, metrics: dict) -> dict:
+    """Write a fake repo under tmp_dir, run the scan, return the summary."""
+    pkg = tmp_dir / "submissions" / "author" / "slug"
+    pkg.mkdir(parents=True)
+    (pkg / "metrics.json").write_text(
+        json.dumps(metrics, ensure_ascii=False), encoding="utf-8"
+    )
+    out = tmp_dir / "out"
+    tool = load_tool()
+    tool.scan(tmp_dir, out, "20260812", "deadbeef", sha_verified=True)
+    summary_path = out / "metrics-fullfield-20260812.summary.json"
+    return json.loads(summary_path.read_text(encoding="utf-8"))
+
+
+class UnitEnumSplitTest(unittest.TestCase):
+    def test_missing_and_non_enum_units_are_counted_separately(self):
+        metrics = make_metrics({
+            # valid enum unit: no outlier
+            "site_area_sqm": entry(100, "sqm"),
+            # unit field entirely absent
+            "no_unit_field": entry(1),
+            # unit is JSON null
+            "null_unit": entry(1, None),
+            # declared but invalid enum string
+            "bad_unit": entry(1, "hectare"),
+        })
+        with tempfile.TemporaryDirectory() as td:
+            summary = run_scan(Path(td), metrics)
+        counts = summary["outlier_counts_only"]
+        self.assertEqual(counts["unit_missing"], 2, "absent + null unit")
+        self.assertEqual(counts["unit_not_in_enum"], 1, "declared invalid unit")
+        # distributions must agree: only None and "hectare" fall outside the enum
+        others = summary["distributions"]["unit"]["other_values"]
+        self.assertEqual(others["total_count"], 3, "None x2 + hectare x1")
+        self.assertEqual(others["n_distinct_values"], 2)
+
+    def test_valid_units_do_not_trigger_either_counter(self):
+        metrics = make_metrics({
+            "site_area_sqm": entry(100, "sqm"),
+            "road_length_m": entry(2000, "m"),
+            "node_count": entry(3, "count"),
+        })
+        with tempfile.TemporaryDirectory() as td:
+            summary = run_scan(Path(td), metrics)
+        counts = summary["outlier_counts_only"]
+        self.assertEqual(counts["unit_missing"], 0)
+        self.assertEqual(counts["unit_not_in_enum"], 0)
+
+
+class SanityBoundaryTest(unittest.TestCase):
+    def test_pct_units_excluded_from_share_ratio_check(self):
+        metrics = make_metrics({
+            # 1.5 with pct unit must NOT trip the 0-1 share check
+            "green_coverage_ratio": entry(1.5, "pct"),
+            # same value with ratio unit SHOULD trip it
+            "green_coverage_ratio_ratio": entry(1.5, "ratio"),
+        })
+        with tempfile.TemporaryDirectory() as td:
+            summary = run_scan(Path(td), metrics)
+        self.assertEqual(summary["outlier_counts_only"]["ratio_outside_0_1"], 1)
+
+    def test_phasing_far_area_sqm_is_not_a_far_value(self):
+        metrics = make_metrics({
+            # phase area in sqm: 500k is a legitimate phase area, not FAR
+            "phasing_far_area_sqm": entry(500000, "sqm"),
+            # genuine FAR above the 12.0 sanity max
+            "floor_area_ratio": entry(15.0, "ratio"),
+        })
+        with tempfile.TemporaryDirectory() as td:
+            summary = run_scan(Path(td), metrics)
+        self.assertEqual(summary["outlier_counts_only"]["far_above_12"], 1)
+
+
+class SnapshotShaTest(unittest.TestCase):
+    def test_sha_mismatch_rejected_unless_allow_flag(self):
+        tool = load_tool()
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)  # not a git repo: HEAD cannot resolve
+            ok, detail = tool.verify_snapshot_sha(repo, "deadbeef")
+            self.assertFalse(ok)
+            self.assertIn("cannot resolve HEAD", detail)
+            # no --allow-sha-mismatch: must exit with an error
+            with self.assertRaises(SystemExit):
+                tool.main(["--repo", str(repo), "--out-dir", str(repo / "o"),
+                           "--date", "20260812", "--sha", "deadbeef"])
+            # with the flag: proceeds and records the snapshot as unverified
+            tool.main(["--repo", str(repo), "--out-dir", str(repo / "o"),
+                       "--date", "20260812", "--sha", "deadbeef",
+                       "--allow-sha-mismatch"])
+            summary_path = repo / "o" / "metrics-fullfield-20260812.summary.json"
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            self.assertIs(summary["snapshot"]["sha_verified_against_head"], False)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/contrib/test_tools_metrics_scan.py
+++ b/contrib/test_tools_metrics_scan.py
@@ -312,6 +312,36 @@ class DirtyWorktreeTest(unittest.TestCase):
             import shutil
             shutil.rmtree(repo.parent, ignore_errors=True)
 
+    def test_deleted_non_scannable_file_does_not_block(self):
+        """Sparse-checkout checkouts report unmatched tracked paths as
+        deleted; those files do not feed the statistics and must not block
+        a legitimate scan. A deleted scannable file (metrics.json) MUST."""
+        tool = load_tool()
+        repo = Path(tempfile.mkdtemp()) / "repo"
+        init_repo(repo)
+        try:
+            write_pkg_metrics(repo, "author", "slug",
+                              make_metrics({"site_area_sqm": entry(100, "sqm")}))
+            (repo / "submissions" / "author" / "slug" / "assets").mkdir()
+            (repo / "submissions" / "author" / "slug" / "assets" / "fig.png").write_text("x")
+            sha = commit_all(repo)
+            # delete a NON-scannable tracked file -> scan may proceed
+            (repo / "submissions" / "author" / "slug" / "assets" / "fig.png").unlink()
+            out = repo / "out"
+            tool.main(["--repo", str(repo), "--out-dir", str(out),
+                       "--date", "20260812", "--sha", sha])
+            self.assertTrue((out / "metrics-fullfield-20260812.summary.json").exists())
+            # now delete a SCANNABLE tracked file -> must refuse
+            (repo / "submissions" / "author" / "slug" / "metrics.json").unlink()
+            out2 = repo / "out2"
+            with self.assertRaises(SystemExit):
+                tool.main(["--repo", str(repo), "--out-dir", str(out2),
+                           "--date", "20260812", "--sha", sha])
+            self.assertFalse((out2 / "metrics-fullfield-20260812.summary.json").exists())
+        finally:
+            import shutil
+            shutil.rmtree(repo.parent, ignore_errors=True)
+
 
 class IdentifiersOptInTest(unittest.TestCase):
     def _ready_repo(self) -> tuple[Path, str]:

--- a/contrib/test_tools_metrics_scan.py
+++ b/contrib/test_tools_metrics_scan.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -215,6 +216,33 @@ class PrivacyBoundaryTest(unittest.TestCase):
         # total entries must still be closed against the snapshot
         self.assertEqual(summary["snapshot"]["n_metric_entries"], 3)
 
+    def test_controlled_key_illegal_status_and_schema_version_never_echoed(self):
+        """The maintainer's second repro: with a CONTROLLED key, an illegal
+        status and an illegal root schema_version must still never be echoed -
+        root_structure.schema_versions and coverage.top_key_status_cross both
+        bucket them anonymously."""
+        leak = "alice@example.invalid"
+        metrics = make_metrics({
+            "site_area_sqm": entry(100, "sqm", status=leak),
+        })
+        metrics["schema_version"] = leak
+        with tempfile.TemporaryDirectory() as td:
+            summary = run_scan(Path(td), metrics)
+        text = json.dumps(summary, ensure_ascii=False)
+        self.assertNotIn(leak, text, "injected string leaked into summary")
+        # schema_versions: only the known enum appears verbatim
+        sv = summary["root_structure"]["schema_versions"]
+        self.assertEqual(sv["declared_enum"], {})
+        self.assertEqual(sv["other_values"]["total_count"], 1)
+        self.assertEqual(sv["other_values"]["n_distinct_values"], 1)
+        # status cross of a controlled key: enum + anonymous other only
+        cross = summary["coverage"]["top_key_status_cross"]["site_area_sqm"]
+        self.assertEqual(cross["other"]["total_count"], 1)
+        self.assertEqual(cross["other"]["n_distinct_values"], 1)
+        self.assertNotIn(leak, json.dumps(cross, ensure_ascii=False))
+        # the controlled key itself still reported verbatim
+        self.assertIn("site_area_sqm", text)
+
 
 class SnapshotShaTest(unittest.TestCase):
     def test_sha_mismatch_rejected_unless_allow_flag(self):
@@ -394,6 +422,87 @@ class IdentifiersOptInTest(unittest.TestCase):
         finally:
             import shutil
             shutil.rmtree(repo.parent, ignore_errors=True)
+
+    def test_relative_repo_absolute_outdir_inside_refused(self):
+        """Path-spelling bypass repro: --repo as a relative path with
+        --out-dir as an absolute path inside the repo must still be refused
+        (a lexical is_relative_to check misses this mix; resolve() catches it)."""
+        import shutil
+        tool = load_tool()
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td) / "repo"
+            init_repo(repo)
+            write_pkg_metrics(repo, "author", "slug",
+                              make_metrics({"site_area_sqm": entry(100, "sqm")}))
+            sha = commit_all(repo)
+            cwd = Path.cwd()
+            try:
+                os.chdir(Path(td))
+                with self.assertRaises(SystemExit):
+                    tool.main(["--repo", "repo",
+                               "--out-dir", str(repo / "private-out"),
+                               "--date", "20260812", "--sha", sha,
+                               "--write-local-identifiers"])
+                self.assertFalse(
+                    list((repo / "private-out").glob("*.csv.gz")),
+                    "no identifiers table via relative/absolute path mix")
+            finally:
+                os.chdir(cwd)
+                shutil.rmtree(Path(td), ignore_errors=True)
+
+    def test_symlink_outdir_inside_refused(self):
+        """A symlink pointing into the worktree must not bypass the
+        outside-worktree boundary (resolve() follows the link)."""
+        tool = load_tool()
+        repo, sha = self._ready_repo()
+        try:
+            inside_link = repo.parent / "inside-link"
+            try:
+                inside_link.symlink_to(repo, target_is_directory=True)
+            except OSError:
+                self.skipTest("symlinks unavailable on this platform")
+            with self.assertRaises(SystemExit):
+                tool.main(["--repo", str(repo),
+                           "--out-dir", str(inside_link / "o"),
+                           "--date", "20260812", "--sha", sha,
+                           "--write-local-identifiers"])
+            self.assertFalse(list((inside_link / "o").glob("*.csv.gz")),
+                             "no identifiers table through a symlink")
+        finally:
+            import shutil
+            shutil.rmtree(repo.parent, ignore_errors=True)
+
+    def test_parse_failures_require_opt_in_outside_worktree(self):
+        """Parse-failure detail carries submission paths: off by default
+        (anonymous count only), written only with --write-local-identifiers
+        to an out-dir outside the worktree."""
+        tool = load_tool()
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td) / "repo"
+            init_repo(repo)
+            write_pkg_metrics(repo, "author", "slug",
+                              make_metrics({"site_area_sqm": entry(100, "sqm")}))
+            (repo / "submissions" / "author" / "bad").mkdir(parents=True)
+            (repo / "submissions" / "author" / "bad" / "metrics.json").write_text(
+                "{broken", encoding="utf-8")
+            sha = commit_all(repo)
+            outside = repo.parent / "outside-out"
+            try:
+                out1 = repo / "out1"
+                tool.main(["--repo", str(repo), "--out-dir", str(out1),
+                           "--date", "20260812", "--sha", sha])
+                s1 = json.loads(
+                    (out1 / "metrics-fullfield-20260812.summary.json").read_text(encoding="utf-8"))
+                self.assertEqual(s1["snapshot"]["n_parse_failures"], 1)
+                self.assertFalse(list(out1.glob("*.parse-failures.txt")),
+                                 "no parse-failure detail without opt-in")
+                tool.main(["--repo", str(repo), "--out-dir", str(outside),
+                           "--date", "20260812", "--sha", sha,
+                           "--write-local-identifiers"])
+                self.assertEqual(len(list(outside.glob("*.parse-failures.txt"))), 1)
+            finally:
+                import shutil
+                shutil.rmtree(repo.parent, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/contrib/test_tools_metrics_scan.py
+++ b/contrib/test_tools_metrics_scan.py
@@ -9,6 +9,12 @@ Locks the boundaries discussed in the PR review:
 - `*_far_area_sqm` phase-area keys are not treated as floor-area-ratio
 - `--sha` mismatch is rejected unless `--allow-sha-mismatch` is passed,
   and an unverified snapshot is recorded in the summary
+- dirty worktree (tracked modification or untracked package/file under
+  submissions/) is ALWAYS refused - no flag can bypass the guard
+- the publishable summary never echoes unverified free text (metric keys
+  outside the controlled vocabulary, non-enum status/unit/confidence)
+- the identifiers csv.gz is off by default, requires
+  `--write-local-identifiers`, and is refused inside the scanned worktree
 
 Run: python3 contrib/test_tools_metrics_scan.py
 """
@@ -16,6 +22,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -59,7 +66,7 @@ def entry(value, unit=None, status="known"):
     return e
 
 
-def run_scan(tmp_dir: Path, metrics: dict) -> dict:
+def run_scan(tmp_dir: Path, metrics: dict, write_identifiers: bool = False) -> dict:
     """Write a fake repo under tmp_dir, run the scan, return the summary."""
     pkg = tmp_dir / "submissions" / "author" / "slug"
     pkg.mkdir(parents=True)
@@ -68,9 +75,40 @@ def run_scan(tmp_dir: Path, metrics: dict) -> dict:
     )
     out = tmp_dir / "out"
     tool = load_tool()
-    tool.scan(tmp_dir, out, "20260812", "deadbeef", sha_verified=True)
+    tool.scan(tmp_dir, out, "20260812", "deadbeef", sha_verified=True,
+              write_identifiers=write_identifiers)
     summary_path = out / "metrics-fullfield-20260812.summary.json"
     return json.loads(summary_path.read_text(encoding="utf-8"))
+
+
+# ---- helpers for real-git-repo tests ----
+
+def git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True,
+                   capture_output=True, text=True)
+
+
+def init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True)
+    git(repo, "init", "-q")
+    git(repo, "config", "user.name", "test")
+    git(repo, "config", "user.email", "test@example.com")
+
+
+def commit_all(repo: Path, message: str = "test commit") -> str:
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", message)
+    out = subprocess.run(["git", "-C", str(repo), "rev-parse", "HEAD"],
+                         capture_output=True, text=True, check=True)
+    return out.stdout.strip()
+
+
+def write_pkg_metrics(repo: Path, author: str, slug: str, metrics: dict) -> Path:
+    pkg = repo / "submissions" / author / slug
+    pkg.mkdir(parents=True, exist_ok=True)
+    path = pkg / "metrics.json"
+    path.write_text(json.dumps(metrics, ensure_ascii=False), encoding="utf-8")
+    return path
 
 
 class UnitEnumSplitTest(unittest.TestCase):
@@ -94,6 +132,8 @@ class UnitEnumSplitTest(unittest.TestCase):
         others = summary["distributions"]["unit"]["other_values"]
         self.assertEqual(others["total_count"], 3, "None x2 + hectare x1")
         self.assertEqual(others["n_distinct_values"], 2)
+        # privacy boundary: the non-enum string itself must never be echoed
+        self.assertNotIn("hectare", json.dumps(summary, ensure_ascii=False))
 
     def test_valid_units_do_not_trigger_either_counter(self):
         metrics = make_metrics({
@@ -132,6 +172,50 @@ class SanityBoundaryTest(unittest.TestCase):
         self.assertEqual(summary["outlier_counts_only"]["far_above_12"], 1)
 
 
+class PrivacyBoundaryTest(unittest.TestCase):
+    def test_free_text_never_appears_in_publishable_summary(self):
+        """The maintainer's repro: email/path-style strings in metric key,
+        status, unit and confidence must not be echoed anywhere in the
+        serialized summary, while controlled keys stay visible."""
+        leak = "alice@example.invalid"
+        e = entry(1, leak, status=leak)
+        e["confidence"] = leak
+        metrics = make_metrics({
+            "contact_alice_example_invalid": e,
+            # controlled key must remain verbatim in coverage stats
+            "site_area_sqm": entry(100, "sqm"),
+        })
+        with tempfile.TemporaryDirectory() as td:
+            summary = run_scan(Path(td), metrics)
+        text = json.dumps(summary, ensure_ascii=False)
+        self.assertNotIn(leak, text, "email string leaked into summary")
+        self.assertNotIn("contact_alice_example_invalid", text,
+                         "uncontrolled metric key leaked into summary")
+        # status/unit/confidence other buckets count but never name the value
+        self.assertIn("n_distinct_values", summary["distributions"]["unit"]["other_values"])
+        self.assertNotIn("top", summary["distributions"]["unit"]["other_values"])
+        self.assertNotIn("top", summary["distributions"]["confidence"]["other_values"])
+        # controlled keys still reported verbatim
+        self.assertIn("site_area_sqm", text)
+        # uncontrolled keys collapsed into the aggregate bucket
+        self.assertEqual(
+            summary["coverage"]["other_metric_keys"]["n_distinct_keys"], 1)
+
+    def test_uncontrolled_keys_collapse_but_counts_stay_closed(self):
+        metrics = make_metrics({
+            "site_area_sqm": entry(100, "sqm"),
+            "mystery_key_xyz": entry(1, "sqm"),
+            "mystery_key_abc": entry(2, "sqm"),
+        })
+        with tempfile.TemporaryDirectory() as td:
+            summary = run_scan(Path(td), metrics)
+        other = summary["coverage"]["other_metric_keys"]
+        self.assertEqual(other["n_distinct_keys"], 2)
+        self.assertEqual(other["n_entries"], 2)
+        # total entries must still be closed against the snapshot
+        self.assertEqual(summary["snapshot"]["n_metric_entries"], 3)
+
+
 class SnapshotShaTest(unittest.TestCase):
     def test_sha_mismatch_rejected_unless_allow_flag(self):
         tool = load_tool()
@@ -140,17 +224,146 @@ class SnapshotShaTest(unittest.TestCase):
             ok, detail = tool.verify_snapshot_sha(repo, "deadbeef")
             self.assertFalse(ok)
             self.assertIn("cannot resolve HEAD", detail)
-            # no --allow-sha-mismatch: must exit with an error
+            # not a git repo -> worktree guard fails closed, even with the flag
             with self.assertRaises(SystemExit):
                 tool.main(["--repo", str(repo), "--out-dir", str(repo / "o"),
-                           "--date", "20260812", "--sha", "deadbeef"])
-            # with the flag: proceeds and records the snapshot as unverified
-            tool.main(["--repo", str(repo), "--out-dir", str(repo / "o"),
+                           "--date", "20260812", "--sha", "deadbeef",
+                           "--allow-sha-mismatch"])
+
+    def test_clean_repo_matching_sha_runs_and_records_verified(self):
+        tool = load_tool()
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td) / "repo"
+            init_repo(repo)
+            write_pkg_metrics(repo, "author", "slug",
+                              make_metrics({"site_area_sqm": entry(100, "sqm")}))
+            sha = commit_all(repo)
+            out = repo / "out"
+            tool.main(["--repo", str(repo), "--out-dir", str(out),
+                       "--date", "20260812", "--sha", sha])
+            summary = json.loads(
+                (out / "metrics-fullfield-20260812.summary.json").read_text(encoding="utf-8"))
+            self.assertIs(summary["snapshot"]["sha_verified_against_head"], True)
+            self.assertEqual(summary["snapshot"]["sha"], sha)
+
+    def test_sha_mismatch_with_allow_flag_records_unverified(self):
+        tool = load_tool()
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td) / "repo"
+            init_repo(repo)
+            write_pkg_metrics(repo, "author", "slug",
+                              make_metrics({"site_area_sqm": entry(100, "sqm")}))
+            commit_all(repo)
+            out = repo / "out"
+            tool.main(["--repo", str(repo), "--out-dir", str(out),
                        "--date", "20260812", "--sha", "deadbeef",
                        "--allow-sha-mismatch"])
-            summary_path = repo / "o" / "metrics-fullfield-20260812.summary.json"
-            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            summary = json.loads(
+                (out / "metrics-fullfield-20260812.summary.json").read_text(encoding="utf-8"))
             self.assertIs(summary["snapshot"]["sha_verified_against_head"], False)
+
+
+class DirtyWorktreeTest(unittest.TestCase):
+    def _ready_repo(self) -> tuple[Path, str]:
+        repo = Path(tempfile.mkdtemp()) / "repo"
+        init_repo(repo)
+        write_pkg_metrics(repo, "author", "slug",
+                          make_metrics({"site_area_sqm": entry(100, "sqm")}))
+        sha = commit_all(repo)
+        return repo, sha
+
+    def test_dirty_tracked_file_refused_even_with_allow_flag(self):
+        """The maintainer's repro: modify a tracked metrics.json without
+        committing, re-run with the ORIGINAL head sha - must refuse and
+        produce no publishable summary, even with --allow-sha-mismatch."""
+        tool = load_tool()
+        repo, sha = self._ready_repo()
+        try:
+            out = repo / "out"
+            # clean run first: produces a summary
+            tool.main(["--repo", str(repo), "--out-dir", str(out),
+                       "--date", "20260812", "--sha", sha])
+            # now dirty the tracked file without committing
+            write_pkg_metrics(repo, "author", "slug",
+                              make_metrics({"site_area_sqm": entry(1, "sqm")}))
+            out2 = repo / "out2"
+            with self.assertRaises(SystemExit):
+                tool.main(["--repo", str(repo), "--out-dir", str(out2),
+                           "--date", "20260812", "--sha", sha,
+                           "--allow-sha-mismatch"])
+            # fail-closed: no publishable summary was written
+            self.assertFalse((out2 / "metrics-fullfield-20260812.summary.json").exists())
+        finally:
+            import shutil
+            shutil.rmtree(repo.parent, ignore_errors=True)
+
+    def test_untracked_package_refused(self):
+        tool = load_tool()
+        repo, sha = self._ready_repo()
+        try:
+            write_pkg_metrics(repo, "author2", "slug2",
+                              make_metrics({"site_area_sqm": entry(50, "sqm")}))
+            out = repo / "out"
+            with self.assertRaises(SystemExit):
+                tool.main(["--repo", str(repo), "--out-dir", str(out),
+                           "--date", "20260812", "--sha", sha])
+            self.assertFalse((out / "metrics-fullfield-20260812.summary.json").exists())
+        finally:
+            import shutil
+            shutil.rmtree(repo.parent, ignore_errors=True)
+
+
+class IdentifiersOptInTest(unittest.TestCase):
+    def _ready_repo(self) -> tuple[Path, str]:
+        repo = Path(tempfile.mkdtemp()) / "repo"
+        init_repo(repo)
+        write_pkg_metrics(repo, "author", "slug",
+                          make_metrics({"site_area_sqm": entry(100, "sqm")}))
+        sha = commit_all(repo)
+        return repo, sha
+
+    def test_csv_gz_off_by_default(self):
+        tool = load_tool()
+        repo, sha = self._ready_repo()
+        try:
+            out = repo / "out"
+            tool.main(["--repo", str(repo), "--out-dir", str(out),
+                       "--date", "20260812", "--sha", sha])
+            self.assertTrue((out / "metrics-fullfield-20260812.summary.json").exists())
+            self.assertFalse(list(out.glob("*.csv.gz")),
+                             "identifiers table must not be written by default")
+        finally:
+            import shutil
+            shutil.rmtree(repo.parent, ignore_errors=True)
+
+    def test_csv_gz_opt_in_outside_worktree(self):
+        tool = load_tool()
+        repo, sha = self._ready_repo()
+        try:
+            outside = repo.parent / "outside-out"
+            tool.main(["--repo", str(repo), "--out-dir", str(outside),
+                       "--date", "20260812", "--sha", sha,
+                       "--write-local-identifiers"])
+            gz_files = list(outside.glob("*.csv.gz"))
+            self.assertEqual(len(gz_files), 1, "opt-in outside worktree writes csv.gz")
+        finally:
+            import shutil
+            shutil.rmtree(repo.parent, ignore_errors=True)
+
+    def test_csv_gz_refused_inside_worktree(self):
+        tool = load_tool()
+        repo, sha = self._ready_repo()
+        try:
+            out = repo / "out"
+            with self.assertRaises(SystemExit):
+                tool.main(["--repo", str(repo), "--out-dir", str(out),
+                           "--date", "20260812", "--sha", sha,
+                           "--write-local-identifiers"])
+            self.assertFalse(list(out.glob("*.csv.gz")),
+                             "no identifiers table inside the worktree")
+        finally:
+            import shutil
+            shutil.rmtree(repo.parent, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/contrib/tools-metrics-scan.py
+++ b/contrib/tools-metrics-scan.py
@@ -278,7 +278,12 @@ def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str, sha_verified
                 field_missing[f] += 1
             if row["status"] not in VALID_STATUS:
                 outliers["status_not_in_enum"] += 1
-            if row["unit"] not in VALID_UNITS:
+            if row["unit"] is None:
+                # field absent or not a string (e.g. JSON null): field absence,
+                # not a declared invalid value - counted separately so the
+                # summary can distinguish "no unit declared" from "bad unit"
+                outliers["unit_missing"] += 1
+            elif row["unit"] not in VALID_UNITS:
                 outliers["unit_not_in_enum"] += 1
             # numeric sanity (counts only)
             if row["value_is_num"]:
@@ -394,6 +399,7 @@ def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str, sha_verified
         },
         "outlier_counts_only": {
             "status_not_in_enum": outliers["status_not_in_enum"],
+            "unit_missing": outliers["unit_missing"],
             "unit_not_in_enum": outliers["unit_not_in_enum"],
             "ratio_outside_0_1": outliers["ratio_outside_0_1"],
             "far_above_12": outliers["far_above_12"],

--- a/contrib/tools-metrics-scan.py
+++ b/contrib/tools-metrics-scan.py
@@ -18,6 +18,7 @@ import argparse
 import csv
 import gzip
 import json
+import subprocess
 import sys
 from collections import Counter, defaultdict
 from pathlib import Path
@@ -134,6 +135,27 @@ def is_num(value) -> bool:
     return False
 
 
+def verify_snapshot_sha(repo_root: Path, declared_sha: str) -> tuple[bool, str]:
+    """Verify --sha against the repo HEAD so a typo cannot mislabel a snapshot.
+
+    Returns (ok, detail). ok=False when git metadata is unavailable or the
+    declared sha does not match the actual HEAD of the scanned checkout.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+            capture_output=True, text=True, timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"git unavailable for {repo_root}: {exc}"
+    if result.returncode != 0:
+        return False, f"cannot resolve HEAD in {repo_root}: {result.stderr.strip()}"
+    actual = result.stdout.strip()
+    if actual == declared_sha:
+        return True, actual
+    return False, f"declared --sha {declared_sha} does not match repo HEAD {actual}"
+
+
 def parse_metrics_file(path: Path) -> tuple[dict | None, str | None]:
     """Return (parsed_json, error). parsed_json is None on failure."""
     try:
@@ -167,7 +189,7 @@ def read_model_family(pkg_dir: Path) -> str | None:
     return None
 
 
-def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str) -> None:
+def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str, sha_verified: bool = True) -> None:
     pkg_dirs = sorted((repo_root / "submissions").glob("*/*"))
     metrics_paths = [p / "metrics.json" for p in pkg_dirs if (p / "metrics.json").is_file()]
     manifest_paths = [p / "manifest.json" for p in pkg_dirs if (p / "manifest.json").is_file()]
@@ -318,6 +340,7 @@ def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str) -> None:
         "snapshot": {
             "repository": "open-city-ai/haidian",
             "sha": sha,
+            "sha_verified_against_head": sha_verified,
             "date": date_stamp,
             "n_packages_total_dirs": n_pkgs,
             "n_packages_with_metrics": len(metrics_paths),
@@ -425,8 +448,19 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--out-dir", required=True, help="output directory")
     parser.add_argument("--date", required=True, help="snapshot date YYYYMMDD")
     parser.add_argument("--sha", required=True, help="commit sha of the snapshot")
+    parser.add_argument(
+        "--allow-sha-mismatch",
+        action="store_true",
+        help="proceed even when --sha does not match the repo HEAD; the summary "
+        "then records sha_verified_against_head=false",
+    )
     args = parser.parse_args(argv)
-    scan(Path(args.repo), Path(args.out_dir), args.date, args.sha)
+    verified, detail = verify_snapshot_sha(Path(args.repo), args.sha)
+    if not verified and not args.allow_sha_mismatch:
+        parser.error(detail)
+    if not verified:
+        print(f"WARNING: {detail}; summary marks the snapshot as unverified")
+    scan(Path(args.repo), Path(args.out_dir), args.date, args.sha, sha_verified=verified)
     return 0
 
 

--- a/contrib/tools-metrics-scan.py
+++ b/contrib/tools-metrics-scan.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""Read-only sweep of all submission metrics.json files.
+
+Produces a long-format table (one row per package per metric) and a summary
+JSON that reports coverage, units, status, confidence, and outlier COUNTS
+only - never package paths, authors, or slugs. The summary is safe to
+publish; the long table is a local reproducibility artifact and must not be
+committed with author-identifying columns.
+
+Usage:
+    python3 tools-metrics-scan.py --repo <repo-root> --out-dir <dir> \
+        --date YYYYMMDD --sha <commit-sha>
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import gzip
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+VALID_STATUS = {"known", "unknown", "not_applicable"}
+VALID_UNITS = {"sqm", "m", "ratio", "count", "index", "none"}
+RATIO_SANITY = (0.0, 1.0)
+FAR_SANITY_MAX = 12.0
+HEIGHT_SANITY_MAX_M = 300.0
+
+
+def is_ratio_metric(key: str) -> bool:
+    """True when the metric key is a ratio (suffix/segment `ratio`)."""
+    lower = key.lower()
+    return lower.endswith("_ratio") or "_ratio_" in lower or lower.endswith("ratio")
+
+
+def is_share_ratio(key: str, unit) -> bool:
+    """True when the ratio is a share/coverage (0-1 semantics).
+
+    Not every ratio belongs in [0,1]: floor_area_ratio is a FAR (sanity max
+    12), network_detour_ratio and street-wall height/width ratios are
+    routinely >1. Also skip percentage units (pct/percent) - a 10 pct
+    control is not a 0-1 ratio violation. Substring pitfalls: 'acceleration'
+    contains 'ratio'.
+    """
+    if unit and ("pct" in str(unit).lower() or "percent" in str(unit).lower()):
+        return False
+    if not is_ratio_metric(key):
+        return False
+    if is_far_metric(key, unit):
+        return False
+    lower = key.lower()
+    if any(p in lower for p in ("detour", "street_wall", "height_width", "width")):
+        return False
+    return any(p in lower for p in ("green", "public_space", "coverage", "_share", "open_space", "utilization", "renewal", "vacancy", "occupancy"))
+
+
+def is_far_metric(key: str, unit=None) -> bool:
+    """True for floor-area-ratio keys. Unit must not be an area unit:
+    keys like phasing_far_area_sqm are phase areas ('far' = far-term
+    phase), not floor-area-ratio values, and would otherwise trip the
+    FAR sanity bound as false positives."""
+    if unit and "sqm" in str(unit).lower():
+        return False
+    lower = key.lower()
+    return "floor_area_ratio" in lower or lower.endswith("_far") or "_far_" in lower
+
+
+def is_height_metric(key: str) -> bool:
+    lower = key.lower()
+    # height controls (m), excluding derived ratios like street-wall height/width
+    return "height" in lower and not is_ratio_metric(key)
+
+
+# From brief/site-package/ranges/planning_limits.json known_official_area_values
+OFFICIAL_AREA_SQM = {
+    "coordinated_research_area_sqm": 43600000,
+    "overall_design_area_sqm": 11400000,
+    "key_detailed_design_area_sqm": 3684000,
+    "zhongzhiyuan_ai_acceleration_area_sqm": 1921000,
+    "beijing_ai_origin_community_sqm": 1043000,
+    "dazhongsi_ai_industry_cluster_sqm": 720000,
+}
+
+REQUIRED_FIELDS = ("status", "value", "unit", "source_files", "formula", "confidence")
+LONG_FIELDS = (
+    "pkg", "author", "slug", "metric_key", "norm_key", "concept",
+    "status", "value", "value_is_num", "unit", "confidence", "formula",
+    "reason", "n_source_files", "n_assumptions", "has_breakdown",
+    "n_breakdown", "missing_required", "missing_fields", "n_extra_fields",
+    "formula_mentions_epsg", "formula_mentions_4548",
+    "schema_version", "units_area", "units_length", "model_family",
+    "entry_ok", "entry_problem",
+)
+
+
+def norm_key(metric_key: str) -> str:
+    """Normalize a metric key by stripping trailing units like _sqm/_m."""
+    key = metric_key
+    for suffix in ("_sqm", "_m2", "_km2", "_m", "_ha", "_ratio", "_count", "_pct"):
+        if key.endswith(suffix):
+            return key[: -len(suffix)]
+    return key
+
+
+def concept_of(key: str) -> str:
+    """Coarse concept bucket for a normalized key, for coverage stats."""
+    k = key.lower()
+    if "area" in k:
+        return "area"
+    if "length" in k or "network" in k or "road" in k or "trail" in k or "path" in k:
+        return "mobility"
+    if "ratio" in k or "density" in k or "far" in k or "height" in k:
+        return "intensity"
+    if "green" in k or "open" in k or "public" in k or "park" in k:
+        return "green_public"
+    if "count" in k or "number" in k or "node" in k or "scenario" in k or "case" in k:
+        return "counts"
+    return "other"
+
+
+def is_num(value) -> bool:
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, (int, float)):
+        return True
+    if isinstance(value, str):
+        try:
+            float(value)
+            return True
+        except ValueError:
+            return False
+    return False
+
+
+def parse_metrics_file(path: Path) -> tuple[dict | None, str | None]:
+    """Return (parsed_json, error). parsed_json is None on failure."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f), None
+    except json.JSONDecodeError as exc:
+        return None, f"json decode error: {exc}"
+    except OSError as exc:
+        return None, f"read error: {exc}"
+
+
+def read_model_family(pkg_dir: Path) -> str | None:
+    """Best-effort model family from agent.json or manifest.json, if present."""
+    for name in ("agent.json", "manifest.json"):
+        path = pkg_dir / name
+        if not path.is_file():
+            continue
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, dict):
+                continue
+            family = data.get("model_family")
+            if isinstance(family, str) and family:
+                return family
+            detail = data.get("model_detail") or data.get("model")
+            if isinstance(detail, str) and detail:
+                return detail
+        except (json.JSONDecodeError, OSError):
+            continue
+    return None
+
+
+def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str) -> None:
+    pkg_dirs = sorted((repo_root / "submissions").glob("*/*"))
+    metrics_paths = [p / "metrics.json" for p in pkg_dirs if (p / "metrics.json").is_file()]
+    manifest_paths = [p / "manifest.json" for p in pkg_dirs if (p / "manifest.json").is_file()]
+    proposal_paths = [p / "proposal.md" for p in pkg_dirs if (p / "proposal.md").is_file()]
+
+    n_pkgs = len(pkg_dirs)
+    rows: list[dict] = []
+    parse_failures: list[tuple[str, str]] = []  # (path, error) - local only
+    root_shape = Counter()
+    schema_versions = Counter()
+    per_pkg_metric_count = []
+    field_missing: Counter = Counter()
+    entry_problems = Counter()
+    outliers: Counter = Counter()
+
+    for path in metrics_paths:
+        data, err = parse_metrics_file(path)
+        if err:
+            parse_failures.append((str(path), err))
+            continue
+        # root structure check
+        if not isinstance(data, dict):
+            parse_failures.append((str(path), "root not a dict"))
+            continue
+        keys = tuple(sorted(k for k in ("schema_version", "units", "metrics") if k in data))
+        root_shape[keys] += 1
+        sv = data.get("schema_version")
+        schema_versions[str(sv)] += 1
+        units = data.get("units") if isinstance(data.get("units"), dict) else {}
+        metrics = data.get("metrics")
+        if not isinstance(metrics, dict):
+            parse_failures.append((str(path), "metrics not a dict"))
+            continue
+        author = path.parent.parent.name
+        slug = path.parent.name
+        pkg = f"{author}/{slug}"
+        model_family = read_model_family(path.parent)
+        per_pkg_metric_count.append(len(metrics))
+        for key, entry in metrics.items():
+            if not isinstance(entry, dict):
+                entry_problems["non-dict metric entry"] += 1
+                continue
+            row = {
+                "pkg": pkg, "author": author, "slug": slug,
+                "metric_key": key, "norm_key": norm_key(key),
+                "concept": concept_of(key),
+            }
+            status = entry.get("status")
+            value = entry.get("value")
+            unit = entry.get("unit")
+            confidence = entry.get("confidence")
+            source_files = entry.get("source_files")
+            formula = entry.get("formula")
+            assumptions = entry.get("assumptions")
+            breakdown = entry.get("breakdown")
+
+            missing_req = [f for f in REQUIRED_FIELDS if f not in entry]
+            missing_all = [f for f in LONG_FIELDS if f in REQUIRED_FIELDS and f not in entry]
+            row.update({
+                "status": status if isinstance(status, str) else None,
+                "value": value if value is not None else None,
+                "value_is_num": is_num(value),
+                "unit": unit if isinstance(unit, str) else None,
+                "confidence": confidence if isinstance(confidence, str) else None,
+                "formula": formula if isinstance(formula, str) else None,
+                "reason": entry.get("reason") if isinstance(entry.get("reason"), str) else None,
+                "n_source_files": len(source_files) if isinstance(source_files, list) else 0,
+                "n_assumptions": len(assumptions) if isinstance(assumptions, list) else 0,
+                "has_breakdown": breakdown is not None,
+                "n_breakdown": len(breakdown) if isinstance(breakdown, dict) else 0,
+                "missing_required": ",".join(missing_req) if missing_req else "",
+                "missing_fields": ",".join(missing_all) if missing_all else "",
+                "n_extra_fields": len(set(entry) - set(REQUIRED_FIELDS + ("reason", "assumptions", "breakdown"))),
+                "formula_mentions_epsg": bool(formula and "EPSG" in formula),
+                "formula_mentions_4548": bool(formula and "4548" in formula),
+                "schema_version": str(sv),
+                "units_area": units.get("area") if isinstance(units.get("area"), str) else None,
+                "units_length": units.get("length") if isinstance(units.get("length"), str) else None,
+                "model_family": model_family,
+                "entry_ok": not missing_req and entry.get("status") in VALID_STATUS,
+                "entry_problem": "",
+            })
+            if not row["entry_ok"]:
+                entry_problems[f"status={status!r}"] += 1
+            for f in missing_req:
+                field_missing[f] += 1
+            if row["status"] not in VALID_STATUS:
+                outliers["status_not_in_enum"] += 1
+            if row["unit"] not in VALID_UNITS:
+                outliers["unit_not_in_enum"] += 1
+            # numeric sanity (counts only)
+            if row["value_is_num"]:
+                v = float(value)
+                if is_share_ratio(key, unit) and not (RATIO_SANITY[0] <= v <= RATIO_SANITY[1]):
+                    outliers["ratio_outside_0_1"] += 1
+                if is_far_metric(key, unit) and v > FAR_SANITY_MAX:
+                    outliers["far_above_12"] += 1
+                if is_height_metric(key) and v > HEIGHT_SANITY_MAX_M:
+                    outliers["height_above_300m"] += 1
+            # area sanity vs the official known values in planning_limits.json:
+            # flag entries that deviate more than 50% from the official figure.
+            # Counts only - this catches e.g. a site area entered as the
+            # 43.6 sqkm research scope instead of the 11.4 sqkm design area.
+            if key in OFFICIAL_AREA_SQM and row["value_is_num"]:
+                official = OFFICIAL_AREA_SQM[key]
+                if v <= 0 or abs(v - official) / official > 0.5:
+                    outliers[f"area_deviation_over_50pct_{key}"] += 1
+            rows.append(row)
+
+    # ---- summary (publishable: counts and anonymized stats only) ----
+    n_entries = len(rows)
+    per_pkg = sorted(per_pkg_metric_count)
+    top_metric_keys = Counter(r["metric_key"] for r in rows).most_common(20)
+    top_norm_keys = Counter(r["norm_key"] for r in rows).most_common(20)
+    concept_cover = Counter(r["concept"] for r in rows)
+    status_dist = Counter(r["status"] for r in rows)
+    unit_dist = Counter(r["unit"] for r in rows)
+    confidence_dist = Counter(r["confidence"] for r in rows)
+    # per-key status cross tabulation for the most common metric keys:
+    # e.g. floor_area_ratio is present in many packages, but how many of
+    # those entries are known vs unknown (planning controls are unpublished)?
+    key_status = defaultdict(Counter)
+    for r in rows:
+        key_status[r["metric_key"]][r["status"]] += 1
+
+    def enum_summary(dist: Counter, valid_values: set[str], top_n: int = 8) -> dict:
+        """Split a distribution into the declared enum (with counts) and a
+        compact 'other' bucket, so the summary stays readable even when
+        entries drift from the declared schema enum."""
+        declared = {k: v for k, v in dist.most_common() if k in valid_values}
+        others = {k: v for k, v in dist.most_common() if k not in valid_values}
+        n_other_values = len(others)
+        other_total = sum(others.values())
+        top_others = {k: v for k, v in list(others.items())[:top_n]}
+        return {
+            "declared_enum": declared,
+            "other_values": {
+                "total_count": other_total,
+                "n_distinct_values": n_other_values,
+                "top": top_others,
+            },
+        }
+
+    def pct(n: int) -> float:
+        return round(100.0 * n / n_entries, 2) if n_entries else 0.0
+
+    summary = {
+        "snapshot": {
+            "repository": "open-city-ai/haidian",
+            "sha": sha,
+            "date": date_stamp,
+            "n_packages_total_dirs": n_pkgs,
+            "n_packages_with_metrics": len(metrics_paths),
+            "n_packages_with_manifest": len(manifest_paths),
+            "n_packages_with_proposal": len(proposal_paths),
+            "n_metric_entries": n_entries,
+            "n_parse_failures": len(parse_failures),
+        },
+        "root_structure": {
+            "container_shapes": {",".join(k) if k else "(empty)": v for k, v in root_shape.most_common()},
+            "schema_versions": dict(schema_versions.most_common()),
+        },
+        "field_coverage": {
+            f: {"missing_count": c, "missing_pct": pct(c)} for f, c in field_missing.most_common()
+        },
+        "entry_validity": {
+            "valid_entries": sum(1 for r in rows if r["entry_ok"]),
+            "valid_pct": pct(sum(1 for r in rows if r["entry_ok"])),
+            "problem_breakdown": {
+                k: {
+                    "count": v,
+                    "explanation": (
+                        "metric entry is not a dict" if k == "non-dict metric entry"
+                        else "entry has a declared-valid status but is missing one or more required fields (status/value/unit/source_files/formula/confidence)"
+                    ),
+                }
+                for k, v in entry_problems.most_common()
+            },
+        },
+        "distributions": {
+            "status": {k: {"count": v, "pct": pct(v)} for k, v in status_dist.most_common()},
+            "unit": enum_summary(unit_dist, VALID_UNITS),
+            "confidence": enum_summary(confidence_dist, {"high", "medium", "low", "unknown"}),
+        },
+        "packages": {
+            "metrics_per_pkg": {
+                "min": per_pkg[0] if per_pkg else None,
+                "median": per_pkg[len(per_pkg) // 2] if per_pkg else None,
+                "max": per_pkg[-1] if per_pkg else None,
+                "mean": round(sum(per_pkg) / len(per_pkg), 2) if per_pkg else None,
+            },
+        },
+        "coverage": {
+            "top_metric_keys": [{k: v} for k, v in top_metric_keys],
+            "top_normalized_keys": [{k: v} for k, v in top_norm_keys],
+            "concept_buckets": {k: {"count": v, "pct": pct(v)} for k, v in concept_cover.most_common()},
+            "top_key_status_cross": {
+                k: {s: c for s, c in sorted(key_status[k].items())}
+                for k, _ in top_metric_keys[:15]
+            },
+        },
+        "outlier_counts_only": {
+            "status_not_in_enum": outliers["status_not_in_enum"],
+            "unit_not_in_enum": outliers["unit_not_in_enum"],
+            "ratio_outside_0_1": outliers["ratio_outside_0_1"],
+            "far_above_12": outliers["far_above_12"],
+            "height_above_300m": outliers["height_above_300m"],
+            **{k: v for k, v in outliers.items() if k.startswith("area_deviation")},
+            "note": "counts only; no package is named or ranked",
+            "sanity_sources": (
+                "bounds from brief/site-package/ranges/planning_limits.json "
+                "schema_sanity_bounds_not_planning_approval; ratio check applies "
+                "to share/coverage ratios only (FAR, detour and street-wall "
+                "height/width ratios have their own legitimate ranges and are "
+                "excluded; percentage-unit entries are excluded); FAR check "
+                "excludes area-valued keys (e.g. phasing_far_area_sqm is a "
+                "phase area, not a floor-area-ratio); area deviation threshold: "
+                ">50% off the official known area value in the same file "
+                "(known_official_area_values)"
+            ),
+        },
+        "privacy_boundary": (
+            "This summary contains aggregate counts only. It does not contain "
+            "package paths, authors, slugs, or any ranking. The long-format "
+            "table with identifying columns is a local artifact and must not "
+            "be committed."
+        ),
+    }
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = out_dir / f"metrics-fullfield-{date_stamp}.summary.json"
+    # newline="" keeps LF on Windows: CRLF line endings have broken CI
+    # checksum validation before (see issue #1062), so artifacts stay LF.
+    with open(summary_path, "w", encoding="utf-8", newline="") as f:
+        json.dump(summary, f, ensure_ascii=False, indent=2)
+
+    long_path = out_dir / f"metrics-fullfield-{date_stamp}.csv.gz"
+    with gzip.open(long_path, "wt", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=LONG_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    if parse_failures:
+        with open(out_dir / f"metrics-scan-{date_stamp}.parse-failures.txt", "w", encoding="utf-8") as f:
+            for path, err in parse_failures:
+                f.write(f"{path}\t{err}\n")
+
+    print(json.dumps(summary["snapshot"], ensure_ascii=False, indent=2))
+    print(f"wrote {summary_path}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="repository root containing submissions/")
+    parser.add_argument("--out-dir", required=True, help="output directory")
+    parser.add_argument("--date", required=True, help="snapshot date YYYYMMDD")
+    parser.add_argument("--sha", required=True, help="commit sha of the snapshot")
+    args = parser.parse_args(argv)
+    scan(Path(args.repo), Path(args.out_dir), args.date, args.sha)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contrib/tools-metrics-scan.py
+++ b/contrib/tools-metrics-scan.py
@@ -84,6 +84,20 @@ OFFICIAL_AREA_SQM = {
     "dazhongsi_ai_industry_cluster_sqm": 720000,
 }
 
+# Metric keys that are safe to publish VERBATIM in the anonymous summary:
+# the official known area values plus the well-known keys observed across
+# the full-field sweep (see the last refreshed summary's top_metric_keys).
+# metric_key is an open attribute in the schema - any other key is
+# unverified free text and must only ever appear aggregated (counts only).
+CONTROLLED_METRIC_KEYS = frozenset(OFFICIAL_AREA_SQM) | frozenset({
+    "site_area_sqm", "green_ratio", "public_space_ratio", "key_area_count",
+    "building_footprint_area_sqm", "floor_area_ratio", "public_space_area_sqm",
+    "green_space_area_sqm", "persona_count", "building_density",
+    "building_height_m", "total_floor_area_sqm", "scenario_node_count",
+    "renewal_project_count", "scenario_card_count", "landmark_count",
+    "phase_count", "phase_1_area_sqm", "road_area_sqm", "phase_2_area_sqm",
+})
+
 REQUIRED_FIELDS = ("status", "value", "unit", "source_files", "formula", "confidence")
 LONG_FIELDS = (
     "pkg", "author", "slug", "metric_key", "norm_key", "concept",
@@ -156,6 +170,36 @@ def verify_snapshot_sha(repo_root: Path, declared_sha: str) -> tuple[bool, str]:
     return False, f"declared --sha {declared_sha} does not match repo HEAD {actual}"
 
 
+def check_worktree_clean(repo_root: Path, scan_subdir: str = "submissions/") -> tuple[bool, str]:
+    """Fail-closed guard: nothing under the scanned paths may differ from HEAD.
+
+    scan() reads the working tree (not the declared commit's object content),
+    so a snapshot claiming ``sha_verified_against_head=true`` is only honest
+    when every path that participates in the statistics is byte-identical to
+    the commit - no tracked modifications, no untracked additions. Returns
+    (ok, detail). There is deliberately no opt-out: dirty-tree scans must not
+    produce a publishable summary.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "status", "--porcelain", "--", scan_subdir],
+            capture_output=True, text=True, timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"git unavailable for {repo_root}: {exc}"
+    if result.returncode != 0:
+        return False, f"cannot check worktree status in {repo_root}: {result.stderr.strip()}"
+    dirty = [line for line in result.stdout.splitlines() if line.strip()]
+    if dirty:
+        sample = " | ".join(dirty[:5])
+        return False, (
+            f"worktree is not clean under {scan_subdir} ({len(dirty)} "
+            f"changed/untracked path(s), e.g. {sample}); a snapshot claiming "
+            f"the declared --sha would read dirty bytes - refusing to run"
+        )
+    return True, "worktree clean"
+
+
 def parse_metrics_file(path: Path) -> tuple[dict | None, str | None]:
     """Return (parsed_json, error). parsed_json is None on failure."""
     try:
@@ -189,7 +233,8 @@ def read_model_family(pkg_dir: Path) -> str | None:
     return None
 
 
-def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str, sha_verified: bool = True) -> None:
+def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str,
+         sha_verified: bool = True, write_identifiers: bool = False) -> None:
     pkg_dirs = sorted((repo_root / "submissions").glob("*/*"))
     metrics_paths = [p / "metrics.json" for p in pkg_dirs if (p / "metrics.json").is_file()]
     manifest_paths = [p / "manifest.json" for p in pkg_dirs if (p / "manifest.json").is_file()]
@@ -273,7 +318,12 @@ def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str, sha_verified
                 "entry_problem": "",
             })
             if not row["entry_ok"]:
-                entry_problems[f"status={status!r}"] += 1
+                if status in VALID_STATUS:
+                    # enum values are a fixed vocabulary - safe to name
+                    entry_problems[f"status={status}"] += 1
+                else:
+                    # free text: aggregate only, never echo the value
+                    entry_problems["status_not_in_enum"] += 1
             for f in missing_req:
                 field_missing[f] += 1
             if row["status"] not in VALID_STATUS:
@@ -307,34 +357,41 @@ def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str, sha_verified
     # ---- summary (publishable: counts and anonymized stats only) ----
     n_entries = len(rows)
     per_pkg = sorted(per_pkg_metric_count)
-    top_metric_keys = Counter(r["metric_key"] for r in rows).most_common(20)
-    top_norm_keys = Counter(r["norm_key"] for r in rows).most_common(20)
+    # Only controlled official keys may appear verbatim; any other metric key
+    # is unverified free text (open attribute in the schema) and is collapsed
+    # into an aggregate "other" bucket - counts only, never the key itself.
+    top_metric_keys = Counter(
+        r["metric_key"] for r in rows if r["metric_key"] in CONTROLLED_METRIC_KEYS
+    ).most_common(20)
+    top_norm_keys = Counter(
+        r["norm_key"] for r in rows if r["metric_key"] in CONTROLLED_METRIC_KEYS
+    ).most_common(20)
+    n_other_metric_keys = len({r["metric_key"] for r in rows} - CONTROLLED_METRIC_KEYS)
+    n_other_metric_entries = sum(
+        1 for r in rows if r["metric_key"] not in CONTROLLED_METRIC_KEYS
+    )
     concept_cover = Counter(r["concept"] for r in rows)
     status_dist = Counter(r["status"] for r in rows)
     unit_dist = Counter(r["unit"] for r in rows)
     confidence_dist = Counter(r["confidence"] for r in rows)
-    # per-key status cross tabulation for the most common metric keys:
-    # e.g. floor_area_ratio is present in many packages, but how many of
-    # those entries are known vs unknown (planning controls are unpublished)?
+    # per-key status cross tabulation for the controlled metric keys only
     key_status = defaultdict(Counter)
     for r in rows:
-        key_status[r["metric_key"]][r["status"]] += 1
+        if r["metric_key"] in CONTROLLED_METRIC_KEYS:
+            key_status[r["metric_key"]][r["status"]] += 1
 
-    def enum_summary(dist: Counter, valid_values: set[str], top_n: int = 8) -> dict:
-        """Split a distribution into the declared enum (with counts) and a
-        compact 'other' bucket, so the summary stays readable even when
-        entries drift from the declared schema enum."""
+    def enum_summary(dist: Counter, valid_values: set[str]) -> dict:
+        """Split a distribution into the declared enum (with counts) and an
+        anonymous 'other' bucket. Non-enum values are free text: the summary
+        reports only their total count and the number of distinct values,
+        never the values themselves (privacy boundary)."""
         declared = {k: v for k, v in dist.most_common() if k in valid_values}
         others = {k: v for k, v in dist.most_common() if k not in valid_values}
-        n_other_values = len(others)
-        other_total = sum(others.values())
-        top_others = {k: v for k, v in list(others.items())[:top_n]}
         return {
             "declared_enum": declared,
             "other_values": {
-                "total_count": other_total,
-                "n_distinct_values": n_other_values,
-                "top": top_others,
+                "total_count": sum(others.values()),
+                "n_distinct_values": len(others),
             },
         }
 
@@ -369,14 +426,20 @@ def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str, sha_verified
                     "count": v,
                     "explanation": (
                         "metric entry is not a dict" if k == "non-dict metric entry"
-                        else "entry has a declared-valid status but is missing one or more required fields (status/value/unit/source_files/formula/confidence)"
+                        else (
+                            "entry status is outside the declared enum "
+                            "(known/unknown/not_applicable); the status value "
+                            "is free text and is not echoed (privacy)"
+                            if k == "status_not_in_enum"
+                            else "entry has a declared-valid status but is missing one or more required fields (status/value/unit/source_files/formula/confidence)"
+                        )
                     ),
                 }
                 for k, v in entry_problems.most_common()
             },
         },
         "distributions": {
-            "status": {k: {"count": v, "pct": pct(v)} for k, v in status_dist.most_common()},
+            "status": enum_summary(status_dist, VALID_STATUS),
             "unit": enum_summary(unit_dist, VALID_UNITS),
             "confidence": enum_summary(confidence_dist, {"high", "medium", "low", "unknown"}),
         },
@@ -391,6 +454,10 @@ def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str, sha_verified
         "coverage": {
             "top_metric_keys": [{k: v} for k, v in top_metric_keys],
             "top_normalized_keys": [{k: v} for k, v in top_norm_keys],
+            "other_metric_keys": {
+                "n_distinct_keys": n_other_metric_keys,
+                "n_entries": n_other_metric_entries,
+            },
             "concept_buckets": {k: {"count": v, "pct": pct(v)} for k, v in concept_cover.most_common()},
             "top_key_status_cross": {
                 k: {s: c for s, c in sorted(key_status[k].items())}
@@ -420,9 +487,15 @@ def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str, sha_verified
         },
         "privacy_boundary": (
             "This summary contains aggregate counts only. It does not contain "
-            "package paths, authors, slugs, or any ranking. The long-format "
-            "table with identifying columns is a local artifact and must not "
-            "be committed."
+            "package paths, authors, slugs, or any ranking. Metric keys are "
+            "published verbatim only when they belong to the controlled "
+            "official vocabulary (CONTROLLED_METRIC_KEYS); all other keys, "
+            "and all non-enum status/unit/confidence values, appear only as "
+            "counts (total and number of distinct values) - never verbatim. "
+            "The long-format table with identifying columns is a local "
+            "artifact, written only with --write-local-identifiers to a "
+            "directory outside the scanned worktree, and must never be "
+            "committed."
         ),
     }
 
@@ -433,11 +506,21 @@ def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str, sha_verified
     with open(summary_path, "w", encoding="utf-8", newline="") as f:
         json.dump(summary, f, ensure_ascii=False, indent=2)
 
-    long_path = out_dir / f"metrics-fullfield-{date_stamp}.csv.gz"
-    with gzip.open(long_path, "wt", encoding="utf-8", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=LONG_FIELDS)
-        writer.writeheader()
-        writer.writerows(rows)
+    if write_identifiers:
+        # Identity table (pkg/author/slug/model_family) is a local artifact:
+        # refuse to write it anywhere inside the scanned worktree, so a stray
+        # `--out-dir contrib` can never be staged/committed by accident.
+        if out_dir.is_relative_to(repo_root):
+            raise SystemExit(
+                f"refusing to write the identifiers table into the scanned "
+                f"worktree ({out_dir}); choose an out-dir outside the repo, "
+                f"e.g. a temp dir"
+            )
+        long_path = out_dir / f"metrics-fullfield-{date_stamp}.csv.gz"
+        with gzip.open(long_path, "wt", encoding="utf-8", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=LONG_FIELDS)
+            writer.writeheader()
+            writer.writerows(rows)
 
     if parse_failures:
         with open(out_dir / f"metrics-scan-{date_stamp}.parse-failures.txt", "w", encoding="utf-8") as f:
@@ -458,15 +541,30 @@ def main(argv: list[str] | None = None) -> int:
         "--allow-sha-mismatch",
         action="store_true",
         help="proceed even when --sha does not match the repo HEAD; the summary "
-        "then records sha_verified_against_head=false",
+        "then records sha_verified_against_head=false. Never bypasses the "
+        "dirty-worktree guard.",
+    )
+    parser.add_argument(
+        "--write-local-identifiers",
+        action="store_true",
+        help="also write the long-format table (pkg/author/slug/model_family) "
+        "as csv.gz. Off by default; refused when out-dir is inside the scanned "
+        "worktree.",
     )
     args = parser.parse_args(argv)
-    verified, detail = verify_snapshot_sha(Path(args.repo), args.sha)
+    repo = Path(args.repo)
+    # Fail-closed: a dirty worktree would make the scan read bytes that do
+    # not belong to the declared commit - no flag can override this.
+    clean, clean_detail = check_worktree_clean(repo)
+    if not clean:
+        parser.error(clean_detail)
+    verified, detail = verify_snapshot_sha(repo, args.sha)
     if not verified and not args.allow_sha_mismatch:
         parser.error(detail)
     if not verified:
         print(f"WARNING: {detail}; summary marks the snapshot as unverified")
-    scan(Path(args.repo), Path(args.out_dir), args.date, args.sha, sha_verified=verified)
+    scan(repo, Path(args.out_dir), args.date, args.sha,
+         sha_verified=verified, write_identifiers=args.write_local_identifiers)
     return 0
 
 

--- a/contrib/tools-metrics-scan.py
+++ b/contrib/tools-metrics-scan.py
@@ -170,15 +170,26 @@ def verify_snapshot_sha(repo_root: Path, declared_sha: str) -> tuple[bool, str]:
     return False, f"declared --sha {declared_sha} does not match repo HEAD {actual}"
 
 
+# File names that participate in the scan statistics. Everything else under
+# submissions/ is irrelevant to the snapshot and is ignored by the
+# dirty-worktree guard (a sparse-checkout checkout shows every unmatched
+# tracked path as deleted, which must not block a legitimate scan).
+SCANNABLE_SUFFIXES = ("metrics.json", "manifest.json", "agent.json", "proposal.md")
+
+
 def check_worktree_clean(repo_root: Path, scan_subdir: str = "submissions/") -> tuple[bool, str]:
-    """Fail-closed guard: nothing under the scanned paths may differ from HEAD.
+    """Fail-closed guard: nothing that participates in the scan may differ
+    from HEAD.
 
     scan() reads the working tree (not the declared commit's object content),
     so a snapshot claiming ``sha_verified_against_head=true`` is only honest
-    when every path that participates in the statistics is byte-identical to
-    the commit - no tracked modifications, no untracked additions. Returns
-    (ok, detail). There is deliberately no opt-out: dirty-tree scans must not
-    produce a publishable summary.
+    when every path that feeds the statistics is byte-identical to the
+    commit - no tracked modifications to scannable files, no untracked
+    additions. Returns (ok, detail). There is deliberately no opt-out:
+    dirty-tree scans must not produce a publishable summary.
+
+    Deleted (D) entries for non-scannable files are expected under
+    sparse-checkout checkouts and are not treated as dirty.
     """
     try:
         result = subprocess.run(
@@ -189,7 +200,17 @@ def check_worktree_clean(repo_root: Path, scan_subdir: str = "submissions/") -> 
         return False, f"git unavailable for {repo_root}: {exc}"
     if result.returncode != 0:
         return False, f"cannot check worktree status in {repo_root}: {result.stderr.strip()}"
-    dirty = [line for line in result.stdout.splitlines() if line.strip()]
+    dirty = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        path = line[3:].strip()
+        # Deletion can appear in either column ("D " = index/sparse-checkout
+        # removal, " D" = worktree removal); non-scannable deletions are
+        # expected under sparse-checkout and never block a scan.
+        if "D" in line[:2] and not path.endswith(SCANNABLE_SUFFIXES):
+            continue
+        dirty.append(line)
     if dirty:
         sample = " | ".join(dirty[:5])
         return False, (
@@ -360,12 +381,15 @@ def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str,
     # Only controlled official keys may appear verbatim; any other metric key
     # is unverified free text (open attribute in the schema) and is collapsed
     # into an aggregate "other" bucket - counts only, never the key itself.
+    # The controlled vocabulary is small (26 keys) and fixed: list ALL of
+    # them so that top_metric_keys + other_metric_keys exactly reconciles
+    # against n_metric_entries (no truncation gap for reviewers to chase).
     top_metric_keys = Counter(
         r["metric_key"] for r in rows if r["metric_key"] in CONTROLLED_METRIC_KEYS
-    ).most_common(20)
+    ).most_common()
     top_norm_keys = Counter(
         r["norm_key"] for r in rows if r["metric_key"] in CONTROLLED_METRIC_KEYS
-    ).most_common(20)
+    ).most_common()
     n_other_metric_keys = len({r["metric_key"] for r in rows} - CONTROLLED_METRIC_KEYS)
     n_other_metric_entries = sum(
         1 for r in rows if r["metric_key"] not in CONTROLLED_METRIC_KEYS
@@ -461,7 +485,7 @@ def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str,
             "concept_buckets": {k: {"count": v, "pct": pct(v)} for k, v in concept_cover.most_common()},
             "top_key_status_cross": {
                 k: {s: c for s, c in sorted(key_status[k].items())}
-                for k, _ in top_metric_keys[:15]
+                for k, _ in top_metric_keys
             },
         },
         "outlier_counts_only": {

--- a/contrib/tools-metrics-scan.py
+++ b/contrib/tools-metrics-scan.py
@@ -25,6 +25,10 @@ from pathlib import Path
 
 VALID_STATUS = {"known", "unknown", "not_applicable"}
 VALID_UNITS = {"sqm", "m", "ratio", "count", "index", "none"}
+# schema_version is an open string attribute in the schema: only versions
+# observed across the field may appear verbatim, everything else collapses
+# into an anonymous other bucket (counts only, never the value itself).
+KNOWN_SCHEMA_VERSIONS = {"0.1.0", "0.2.0", "0.1.1", "1.0", "1.10.0"}
 RATIO_SANITY = (0.0, 1.0)
 FAR_SANITY_MAX = 12.0
 HEIGHT_SANITY_MAX_M = 300.0
@@ -219,6 +223,19 @@ def check_worktree_clean(repo_root: Path, scan_subdir: str = "submissions/") -> 
             f"the declared --sha would read dirty bytes - refusing to run"
         )
     return True, "worktree clean"
+
+
+def _out_dir_inside_worktree(out_dir: Path, repo_root: Path) -> bool:
+    """True when out-dir, under any path spelling, lands inside the scanned
+    worktree. Path.resolve() normalizes relative-vs-absolute mixes and
+    symlinks; strict=False resolves the existing parent prefix when the
+    out-dir itself does not exist yet. A resolve failure fails closed."""
+    try:
+        out_real = out_dir.resolve(strict=False)
+        repo_real = repo_root.resolve(strict=False)
+    except OSError:
+        return True
+    return out_real.is_relative_to(repo_real)
 
 
 def parse_metrics_file(path: Path) -> tuple[dict | None, str | None]:
@@ -419,6 +436,21 @@ def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str,
             },
         }
 
+    def status_cross_summary(dist: Counter) -> dict:
+        """Per-key status cross for controlled keys: only the declared status
+        enum appears verbatim; any other status (free text, or JSON null)
+        collapses into an anonymous other bucket - counts only, never the
+        value itself (privacy boundary)."""
+        declared = {s: c for s, c in sorted(dist.items()) if s in VALID_STATUS}
+        others = {s: c for s, c in dist.items() if s not in VALID_STATUS}
+        return {
+            **declared,
+            "other": {
+                "total_count": sum(others.values()),
+                "n_distinct_values": len(others),
+            },
+        }
+
     def pct(n: int) -> float:
         return round(100.0 * n / n_entries, 2) if n_entries else 0.0
 
@@ -437,7 +469,7 @@ def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str,
         },
         "root_structure": {
             "container_shapes": {",".join(k) if k else "(empty)": v for k, v in root_shape.most_common()},
-            "schema_versions": dict(schema_versions.most_common()),
+            "schema_versions": enum_summary(schema_versions, KNOWN_SCHEMA_VERSIONS),
         },
         "field_coverage": {
             f: {"missing_count": c, "missing_pct": pct(c)} for f, c in field_missing.most_common()
@@ -484,7 +516,7 @@ def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str,
             },
             "concept_buckets": {k: {"count": v, "pct": pct(v)} for k, v in concept_cover.most_common()},
             "top_key_status_cross": {
-                k: {s: c for s, c in sorted(key_status[k].items())}
+                k: status_cross_summary(key_status[k])
                 for k, _ in top_metric_keys
             },
         },
@@ -516,8 +548,13 @@ def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str,
             "official vocabulary (CONTROLLED_METRIC_KEYS); all other keys, "
             "and all non-enum status/unit/confidence values, appear only as "
             "counts (total and number of distinct values) - never verbatim. "
-            "The long-format table with identifying columns is a local "
-            "artifact, written only with --write-local-identifiers to a "
+            "schema_version appears verbatim only for the known versions "
+            "observed across the field (KNOWN_SCHEMA_VERSIONS); the per-key "
+            "status cross for controlled keys lists only the declared status "
+            "enum (known/unknown/not_applicable), any other status collapsing "
+            "into an anonymous other count. The long-format table and the "
+            "parse-failure detail carry identifying paths and are local "
+            "artifacts, written only with --write-local-identifiers to a "
             "directory outside the scanned worktree, and must never be "
             "committed."
         ),
@@ -531,25 +568,28 @@ def scan(repo_root: Path, out_dir: Path, date_stamp: str, sha: str,
         json.dump(summary, f, ensure_ascii=False, indent=2)
 
     if write_identifiers:
-        # Identity table (pkg/author/slug/model_family) is a local artifact:
-        # refuse to write it anywhere inside the scanned worktree, so a stray
-        # `--out-dir contrib` can never be staged/committed by accident.
-        if out_dir.is_relative_to(repo_root):
+        # Local artifacts (identifiers long table, parse-failure detail) carry
+        # package paths/authors: refuse ANY spelling of an in-worktree out-dir
+        # (relative-vs-absolute mixes and symlinks are resolved first) so a
+        # stray `--out-dir contrib` can never be staged/committed by accident.
+        if _out_dir_inside_worktree(out_dir, repo_root):
             raise SystemExit(
-                f"refusing to write the identifiers table into the scanned "
-                f"worktree ({out_dir}); choose an out-dir outside the repo, "
-                f"e.g. a temp dir"
+                f"refusing to write local artifacts into the scanned worktree "
+                f"({out_dir}); choose an out-dir outside the repo, e.g. a "
+                f"temp dir"
             )
         long_path = out_dir / f"metrics-fullfield-{date_stamp}.csv.gz"
         with gzip.open(long_path, "wt", encoding="utf-8", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=LONG_FIELDS)
             writer.writeheader()
             writer.writerows(rows)
-
-    if parse_failures:
-        with open(out_dir / f"metrics-scan-{date_stamp}.parse-failures.txt", "w", encoding="utf-8") as f:
-            for path, err in parse_failures:
-                f.write(f"{path}\t{err}\n")
+        if parse_failures:
+            # Parse-failure detail contains submission paths: same opt-in and
+            # same outside-worktree boundary as the identifiers table; the
+            # summary keeps only the anonymous failure count.
+            with open(out_dir / f"metrics-scan-{date_stamp}.parse-failures.txt", "w", encoding="utf-8") as f:
+                for path, err in parse_failures:
+                    f.write(f"{path}\t{err}\n")
 
     print(json.dumps(summary["snapshot"], ensure_ascii=False, indent=2))
     print(f"wrote {summary_path}")


### PR DESCRIPTION
## 关联

- Issue #1781「全场 metrics 底数：539 个投稿包、12,090 条指标的覆盖、口径与可比性」
- 认领于 #1781 评论区（2026-08-11），获原作者 @anselasimov-web 让位与交叉核对承诺

## 内容（新增 4 个文件）

1. `contrib/tools-metrics-scan.py` — 只读扫描脚本（纯标准库，零新依赖）
2. `contrib/metrics-fullfield-20260812.summary.json` — 固定 SHA 快照的匿名 summary
3. `contrib/test_tools_metrics_scan.py` — 标准库回归测试（19 用例）
4. `contrib/README.md` — 复现命令 + 28 列字段字典 + 统计口径 + 隐私边界

## 快照与口径

- **SHA**: `f0d74e446aae8e78bef53345155a82a678f4604f`（2026-08-20 main）
- **923 包 / 20,985 条指标 / 0 解析失败**；metrics/manifest/proposal 三口径 923/923/923 交叉核对一致
- 全部统计只给计数与匿名聚合：metric key 仅**受控官方词表**（`CONTROLLED_METRIC_KEYS`，26 个）逐字发布，其余 5,235 个 key 聚合进 `other_metric_keys`（只报计数）；status/unit/confidence 非枚举值只报 total_count / n_distinct_values，**不回显原文**（含 `problem_breakdown` 中 status 自由文本的泄漏点，已堵）；`schema_version` 仅已知版本枚举（`KNOWN_SCHEMA_VERSIONS`）逐字发布，其余匿名聚合；受控 key 的 status 交叉表只列声明枚举（known/unknown/not_applicable），其他状态匿名聚合为 other 计数
- 计数对账闭合：受控 key 9,156 条 + 其他 key 11,829 条 = 20,985 = `n_metric_entries`
- 长表（含作者标识 csv.gz）与解析失败明细（含投稿路径）默认不生成，需 `--write-local-identifiers` 且 out-dir 在仓库外——out-dir 经 `resolve()` 规范化后做包含检查，相对/绝对路径混写与 symlink 指向工作树内均拒绝
- 快照证据链 fail-closed：`--sha` 与 HEAD 不一致拒绝执行（`--allow-sha-mismatch` 仅表达有意扫描非 HEAD）；工作树不干净（参与统计的 4 类文件有 tracked 修改或 untracked 新增）一律拒绝，任何 flag 不可绕过，失败时不产出可发布 summary
- 0-1 ratio 检查仅针对占比/覆盖率语义；FAR 检查排除面积单位条目（如 `phasing_far_area_sqm` 是分期面积）；百分比单位条目不适用 0-1 检查

## 主要发现（计数，详见 summary）

- unit 字段 171 种非声明枚举值（507 条，unit_missing 另有 49 条）——与「validate_metrics_file 未执行 unit 枚举」的已知 gap 一致
- confidence 非枚举值 13 种（382 条）
- floor_area_ratio 861 条中 840 条 unknown、building_height_m 291 条全 unknown（1 条 not_applicable）——组织方控规条件未公布的直接结果
- 条目完整度 98.39%；根结构 100% 一致（schema_version/units/metrics）
- 回归测试 19/19 通过（隐私回显、受控 key 注入原文、schema_version/status cross 桶化、脏树拒绝、相对-绝对路径与 symlink 绕过、parse-failures opt-in、unit 口径拆分、FAR/面积区分等边界；symlink 用例在本环境按平台 skip）

欢迎交叉核对与口径指正。

