### PR TITLE
v1.7.1: manifest 迁移 0.2.x（Issue #1058 / PR #1063 合并后的首个迁移包）

### DIFF
--- a/submissions/loml13/switchback-line/changelog.md
+++ b/submissions/loml13/switchback-line/changelog.md
@@ -1,5 +1,12 @@
 # 方案迭代记录
 
+## v1.7.1 - 2026-08-11
+
+manifest 迁移 0.2.x（Issue #1058 / PR #1063 已合并）：
+
+- `schema_version` 0.1.0 → 0.2.0，进入 strict gate；`visual_asset` ×5 → canonical `asset`，`risk` ×1 → `other` + `role_detail: "risk"`，`changelog` 已为 canonical 不变。迁移后全包 role 均为 canonical 或显式 `other`，无遗留 advisory 违规。
+
+
 ## v1.7 - 2026-08-11
 
 文保约束落地（响应 Issue #1774 数据源索引）：

--- a/submissions/loml13/switchback-line/manifest.json
+++ b/submissions/loml13/switchback-line/manifest.json
@@ -1,379 +1,381 @@
 {
- "schema_version": "0.1.0",
- "package_id": "switchback-line",
- "project_id": "centennial-jingzhang-ai-belt",
- "site_package_version": "0.1.0",
- "package_type": "professional_design_package",
- "package_state": "ready_for_review",
- "submission_stage": "formal",
- "submission_type": "ai_agent",
- "agent": {
-  "agent_id": "loml13",
-  "agent_name": "Pi (open-source coding agent)",
-  "model": "agent-declared-model"
- },
- "generated_at": "2026-08-11T10:40:00Z",
- "files": [
-  {
-   "path": "manifest.json",
-   "role": "manifest",
-   "required": true
+  "schema_version": "0.2.0",
+  "package_id": "switchback-line",
+  "project_id": "centennial-jingzhang-ai-belt",
+  "site_package_version": "0.1.0",
+  "package_type": "professional_design_package",
+  "package_state": "ready_for_review",
+  "submission_stage": "formal",
+  "submission_type": "ai_agent",
+  "agent": {
+    "agent_id": "loml13",
+    "agent_name": "Pi (open-source coding agent)",
+    "model": "agent-declared-model"
   },
-  {
-   "path": "proposal.md",
-   "role": "narrative",
-   "required": true,
-   "language": "zh",
-   "sha256": "8447c9e9459ce418054535f56e8d58707d6d142cf19176a46f0dbf1b518188d1"
-  },
-  {
-   "path": "agent.json",
-   "role": "agent_card",
-   "required": true,
-   "sha256": "b76539beaf95d84c7b580ec5a26e64598519bef7a53f64e788ef4544f948b68a"
-  },
-  {
-   "path": "metrics.json",
-   "role": "metrics",
-   "required": true,
-   "sha256": "daa05397c6c6b96ccca0262935cb85f67d5c8ff5d3b26b24a79e9d0380f91109"
-  },
-  {
-   "path": "assumptions.json",
-   "role": "assumptions",
-   "required": true,
-   "sha256": "659c277be713503940da6648196698d8c48461435571a8123e906b62f63b39bb"
-  },
-  {
-   "path": "sources.json",
-   "role": "sources",
-   "required": true,
-   "sha256": "ee825d7045fb07bc6831988bbd3d9d915d1209d717078b0ad5237f16efd8d733"
-  },
-  {
-   "path": "self_check.json",
-   "role": "self_check",
-   "required": true,
-   "sha256": "5f407494b8580069e952ca131e7fe1cc1228855f2ac07d2fd59524d0867779f6"
-  },
-  {
-   "path": "compliance_matrix.json",
-   "role": "compliance_matrix",
-   "required": true,
-   "sha256": "60c38d58024f2d4bd33c71e4b8a874110d52bd23125832091c5e2e9d47770eb7"
-  },
-  {
-   "path": "standard_matrix.json",
-   "role": "standard_matrix",
-   "required": true,
-   "sha256": "e09888bbb2e53485017686e8661e8bf606863b57fc1263b158510af98d2151b6"
-  },
-  {
-   "path": "design_depth_matrix.json",
-   "role": "design_depth_matrix",
-   "required": true,
-   "sha256": "5c2ca13164bbcbb92588b96ee07fcd0b091e519c0800d6cc6a1ca2a67d55e653"
-  },
-  {
-   "path": "report/proposal.html",
-   "role": "rendered_proposal_html",
-   "required": true,
-   "language": "zh",
-   "sha256": "c6bf5a42a0b2e2c4790abf427b3efedcaa24c9cd210e79b2c190b6b28ea968df"
-  },
-  {
-   "path": "report/narrative.md",
-   "role": "narrative",
-   "required": false,
-   "sha256": "676ac18fb1f7e0abb46bc1ce62b4c45c557644cae4b47f4dfbd397b257141129"
-  },
-  {
-   "path": "report/copyright_statement.md",
-   "role": "copyright_statement",
-   "required": true,
-   "sha256": "ac8929a08516047380c241994c18f3ba107e198ab2ffdc74a24c7ee427b8a095"
-  },
-  {
-   "path": "drawings/a3-booklet.pdf",
-   "role": "drawing",
-   "required": true,
-   "language": "zh",
-   "sha256": "bd6ef580f9bf3e2c1a4de45bb3f8ad64f414cd977e59d56e5c7e3f6345482ccf"
-  },
-  {
-   "path": "drawings/a0-boards.pdf",
-   "role": "drawing",
-   "required": true,
-   "language": "zh",
-   "sha256": "8fc6588c16eec12c58d82282f5e911408854873347c9382ec9a20b4716dd88d4"
-  },
-  {
-   "path": "visual/index.html",
-   "role": "visualization",
-   "required": true,
-   "language": "zh",
-   "sha256": "69cb79fcefbce59eb4f6ec99553d86c9fb6235cda6bfda72e667dafc564f7003"
-  },
-  {
-   "path": "assets/figures/key-areas.png",
-   "role": "proposal_figure",
-   "required": true,
-   "language": "zh",
-   "sha256": "a00c99d490b8b18386ebada35e935cf2691ae7722d78478399141df1bf8976d6"
-  },
-  {
-   "path": "assets/figures/land-use-structure.png",
-   "role": "proposal_figure",
-   "required": true,
-   "language": "zh",
-   "sha256": "42ea401044ae2ea1a038702d8af15001e8e349bf9df1925cb87b84844a2d78a4"
-  },
-  {
-   "path": "assets/figures/metrics-evidence.png",
-   "role": "proposal_figure",
-   "required": true,
-   "language": "zh",
-   "sha256": "adfe722a9c2d334f77ff2e28b1374d4a2459d2290ed46d653de914d451e816f5"
-  },
-  {
-   "path": "assets/figures/mobility-bluegreen.png",
-   "role": "proposal_figure",
-   "required": true,
-   "language": "zh",
-   "sha256": "1f929c5626c88db564fe8861d46ef88d85e2481d1aedf10f5710218115b6fd9f"
-  },
-  {
-   "path": "assets/figures/site-overview.png",
-   "role": "proposal_figure",
-   "required": true,
-   "language": "zh",
-   "sha256": "6cd7a248e2198d143c7b974792c1b35aa41e44799c3161a50522a58b5ee18cbd"
-  },
-  {
-   "path": "geometry/buildings.geojson",
-   "role": "geometry",
-   "required": true,
-   "sha256": "26d123436727882fb39f0ce9989b9547aed2c04980d22da64ed908dc051ba47d"
-  },
-  {
-   "path": "geometry/constraints.geojson",
-   "role": "geometry",
-   "required": true,
-   "sha256": "bdea2201fdf997ee1a9dfc3e41468bc2f93c9b20287a7ff2c42010a116bcbcfd"
-  },
-  {
-   "path": "geometry/green_space.geojson",
-   "role": "geometry",
-   "required": true,
-   "sha256": "9419fd525a32241956d68f5026e9eebcd13c24214eba83f59763bf4af0c70705"
-  },
-  {
-   "path": "geometry/key_areas.geojson",
-   "role": "geometry",
-   "required": true,
-   "sha256": "566926817504a2938e081390879095fdc300a0df9328ddcbc6131b1e861718d3"
-  },
-  {
-   "path": "geometry/land_use.geojson",
-   "role": "geometry",
-   "required": true,
-   "sha256": "4c93bf0098c650e3d7971b2ca8b34e324ea5a00953be55b2cdfeae135fbe10c5"
-  },
-  {
-   "path": "geometry/phasing.geojson",
-   "role": "geometry",
-   "required": true,
-   "sha256": "25ff3d85c35f2411a986409a3a91138cc75ec912870a184476f50fa5f9c67946"
-  },
-  {
-   "path": "geometry/public_space.geojson",
-   "role": "geometry",
-   "required": true,
-   "sha256": "9203b41a94c3f84c5449b368f6e4a58618a32d4acc651ed6c51aa860aa3d9284"
-  },
-  {
-   "path": "geometry/roads.geojson",
-   "role": "geometry",
-   "required": true,
-   "sha256": "dd99454e566082116c144d84b8ab712c69584ceb535789c481563aaf1efd1be5"
-  },
-  {
-   "path": "geometry/site_boundary.geojson",
-   "role": "geometry",
-   "required": true,
-   "sha256": "66b8ab3db46dca00224c0662890a69c1bc0244902aa3390574f1ec20bc4348ff"
-  },
-  {
-   "path": "proposal.en.md",
-   "role": "narrative",
-   "required": false,
-   "language": "en",
-   "translation_of": "proposal.md",
-   "sha256": "92f81694d202c18cbaa729d7868c3b14c41c4e221a51b8fd3b6ea312709e70b9"
-  },
-  {
-   "path": "report/proposal.en.html",
-   "role": "rendered_proposal_html",
-   "required": false,
-   "language": "en",
-   "translation_of": "report/proposal.html",
-   "sha256": "0e8f7682942ae4d38be45de77b56af3df89b3d23a59a1490e30cc245f95384dd"
-  },
-  {
-   "path": "changelog.md",
-   "role": "changelog",
-   "required": false,
-   "language": "zh",
-   "sha256": "476dde041db5b81749d7482dc18bf6daee8d56c834894fb97ea5d9b1fdc599bc"
-  },
-  {
-   "path": "assets/figures/switchback-logo.svg",
-   "role": "proposal_figure",
-   "required": false,
-   "language": "neutral",
-   "sha256": "7430451a0856a44d32d4c1f1fb4ddf5e85ff2a3549108453f181029de303d097"
-  },
-  {
-   "path": "assets/figures/site-overview.en.png",
-   "role": "proposal_figure",
-   "required": false,
-   "language": "en",
-   "translation_of": "assets/figures/site-overview.png",
-   "sha256": "61fc60242affa52c4ba96df35f5698925a326d3a04adac31960a499487af9bae"
-  },
-  {
-   "path": "assets/figures/land-use-structure.en.png",
-   "role": "proposal_figure",
-   "required": false,
-   "language": "en",
-   "translation_of": "assets/figures/land-use-structure.png",
-   "sha256": "70daa6a16d4d87ad7a561c5046ce9beb83bdb8d7f0584e2857f1db6966b1dbc8"
-  },
-  {
-   "path": "assets/figures/key-areas.en.png",
-   "role": "proposal_figure",
-   "required": false,
-   "language": "en",
-   "translation_of": "assets/figures/key-areas.png",
-   "sha256": "63b9b7b120dadfa6c9b633e1232dbf628497b9485d045e1814402b4c8005a5fd"
-  },
-  {
-   "path": "assets/figures/mobility-bluegreen.en.png",
-   "role": "proposal_figure",
-   "required": false,
-   "language": "en",
-   "translation_of": "assets/figures/mobility-bluegreen.png",
-   "sha256": "cd1d38936f08349c4cdb04aae2a491b0e35fff69e6a18bc35ada33e98e67781a"
-  },
-  {
-   "path": "assets/figures/metrics-evidence.en.png",
-   "role": "proposal_figure",
-   "required": false,
-   "language": "en",
-   "translation_of": "assets/figures/metrics-evidence.png",
-   "sha256": "aff0743dcbdd26d72965380707271c7e0ce47464fe316d4bba2366b15985497b"
-  },
-  {
-   "path": "drawings/a3-booklet.en.pdf",
-   "role": "drawing",
-   "required": false,
-   "language": "en",
-   "translation_of": "drawings/a3-booklet.pdf",
-   "sha256": "d29c1aecdf02723146c92e01d58468c7fd12dc69e08f6c320ca0cdcb0cf752da"
-  },
-  {
-   "path": "drawings/a0-boards.en.pdf",
-   "role": "drawing",
-   "required": false,
-   "language": "en",
-   "translation_of": "drawings/a0-boards.pdf",
-   "sha256": "77680e2ef234b6ae1649af7bffbdb0d6f7aa3b815655f68fbe438efd6f55377a"
-  },
-  {
-   "path": "visual/index.en.html",
-   "role": "visualization",
-   "required": false,
-   "language": "en",
-   "translation_of": "visual/index.html",
-   "sha256": "ccdc64f7fb64061ae4277ed7f41fe5222e6c26204f17d0ca105af7eca7cd9058"
-  },
-  {
-   "path": "assets/figures/existing-diagnosis.png",
-   "role": "proposal_figure",
-   "required": false,
-   "language": "zh",
-   "sha256": "6e06485eef62c013fbe47a0f9a10db5f9198c75ac4b2f1548c84af60e4619079"
-  },
-  {
-   "path": "assets/figures/existing-diagnosis.en.png",
-   "role": "proposal_figure",
-   "required": false,
-   "language": "en",
-   "translation_of": "assets/figures/existing-diagnosis.png",
-   "sha256": "8849370a20a8e1ef8253b1d9fe560b8a328812be737b31fdeafc9d3d7a0465d1"
-  },
-  {
-   "path": "visual/assets/existing-diagnosis.png",
-   "role": "visual_asset",
-   "required": false,
-   "language": "zh",
-   "sha256": "6e06485eef62c013fbe47a0f9a10db5f9198c75ac4b2f1548c84af60e4619079"
-  },
-  {
-   "path": "visual/assets/existing-diagnosis.en.png",
-   "role": "visual_asset",
-   "required": false,
-   "language": "en",
-   "translation_of": "visual/assets/existing-diagnosis.png",
-   "sha256": "8849370a20a8e1ef8253b1d9fe560b8a328812be737b31fdeafc9d3d7a0465d1"
-  },
-  {
-   "path": "assets/figures/section-spine.png",
-   "role": "proposal_figure",
-   "required": false,
-   "language": "zh",
-   "sha256": "f583e6b4ba0967ac4395a2f1618baa6683afd4d39385050ed515da28b784562a"
-  },
-  {
-   "path": "assets/figures/section-spine.en.png",
-   "role": "proposal_figure",
-   "required": false,
-   "language": "en",
-   "translation_of": "assets/figures/section-spine.png",
-   "sha256": "4e9907363d5deb1dc1f2f1f0b3283887394dc2a60d5f25d05fca78b91dd2184d"
-  },
-  {
-   "path": "visual/assets/section-spine.png",
-   "role": "visual_asset",
-   "required": false,
-   "language": "zh",
-   "sha256": "f583e6b4ba0967ac4395a2f1618baa6683afd4d39385050ed515da28b784562a"
-  },
-  {
-   "path": "visual/assets/section-spine.en.png",
-   "role": "visual_asset",
-   "required": false,
-   "language": "en",
-   "translation_of": "visual/assets/section-spine.png",
-   "sha256": "4e9907363d5deb1dc1f2f1f0b3283887394dc2a60d5f25d05fca78b91dd2184d"
-  },
-  {
-   "path": "risk.json",
-   "role": "risk",
-   "required": false,
-   "sha256": "44cf8a61bb1ad0e8aa415ade70b03bbcc7c16f9cfea6a6c2f4859a16ea3c15d2"
-  },
-  {
-   "path": "visual/assets/switchback-protocol.json",
-   "role": "visual_asset",
-   "required": false,
-   "language": "neutral",
-   "sha256": "9e7dab1262122f2b12df8af08759e735a4c2975f91e87bb559a931fce98dafac"
+  "generated_at": "2026-08-11T10:40:00Z",
+  "files": [
+    {
+      "path": "manifest.json",
+      "role": "manifest",
+      "required": true
+    },
+    {
+      "path": "proposal.md",
+      "role": "narrative",
+      "required": true,
+      "language": "zh",
+      "sha256": "8447c9e9459ce418054535f56e8d58707d6d142cf19176a46f0dbf1b518188d1"
+    },
+    {
+      "path": "agent.json",
+      "role": "agent_card",
+      "required": true,
+      "sha256": "b76539beaf95d84c7b580ec5a26e64598519bef7a53f64e788ef4544f948b68a"
+    },
+    {
+      "path": "metrics.json",
+      "role": "metrics",
+      "required": true,
+      "sha256": "daa05397c6c6b96ccca0262935cb85f67d5c8ff5d3b26b24a79e9d0380f91109"
+    },
+    {
+      "path": "assumptions.json",
+      "role": "assumptions",
+      "required": true,
+      "sha256": "659c277be713503940da6648196698d8c48461435571a8123e906b62f63b39bb"
+    },
+    {
+      "path": "sources.json",
+      "role": "sources",
+      "required": true,
+      "sha256": "ee825d7045fb07bc6831988bbd3d9d915d1209d717078b0ad5237f16efd8d733"
+    },
+    {
+      "path": "self_check.json",
+      "role": "self_check",
+      "required": true,
+      "sha256": "1f8552875082b6b2277248ca0203015bee2cff0b1e6dc5b8db0090ca2bbdd6fb"
+    },
+    {
+      "path": "compliance_matrix.json",
+      "role": "compliance_matrix",
+      "required": true,
+      "sha256": "60c38d58024f2d4bd33c71e4b8a874110d52bd23125832091c5e2e9d47770eb7"
+    },
+    {
+      "path": "standard_matrix.json",
+      "role": "standard_matrix",
+      "required": true,
+      "sha256": "e09888bbb2e53485017686e8661e8bf606863b57fc1263b158510af98d2151b6"
+    },
+    {
+      "path": "design_depth_matrix.json",
+      "role": "design_depth_matrix",
+      "required": true,
+      "sha256": "5c2ca13164bbcbb92588b96ee07fcd0b091e519c0800d6cc6a1ca2a67d55e653"
+    },
+    {
+      "path": "report/proposal.html",
+      "role": "rendered_proposal_html",
+      "required": true,
+      "language": "zh",
+      "sha256": "c6bf5a42a0b2e2c4790abf427b3efedcaa24c9cd210e79b2c190b6b28ea968df"
+    },
+    {
+      "path": "report/narrative.md",
+      "role": "narrative",
+      "required": false,
+      "sha256": "676ac18fb1f7e0abb46bc1ce62b4c45c557644cae4b47f4dfbd397b257141129"
+    },
+    {
+      "path": "report/copyright_statement.md",
+      "role": "copyright_statement",
+      "required": true,
+      "sha256": "ac8929a08516047380c241994c18f3ba107e198ab2ffdc74a24c7ee427b8a095"
+    },
+    {
+      "path": "drawings/a3-booklet.pdf",
+      "role": "drawing",
+      "required": true,
+      "language": "zh",
+      "sha256": "bd6ef580f9bf3e2c1a4de45bb3f8ad64f414cd977e59d56e5c7e3f6345482ccf"
+    },
+    {
+      "path": "drawings/a0-boards.pdf",
+      "role": "drawing",
+      "required": true,
+      "language": "zh",
+      "sha256": "8fc6588c16eec12c58d82282f5e911408854873347c9382ec9a20b4716dd88d4"
+    },
+    {
+      "path": "visual/index.html",
+      "role": "visualization",
+      "required": true,
+      "language": "zh",
+      "sha256": "69cb79fcefbce59eb4f6ec99553d86c9fb6235cda6bfda72e667dafc564f7003"
+    },
+    {
+      "path": "assets/figures/key-areas.png",
+      "role": "proposal_figure",
+      "required": true,
+      "language": "zh",
+      "sha256": "a00c99d490b8b18386ebada35e935cf2691ae7722d78478399141df1bf8976d6"
+    },
+    {
+      "path": "assets/figures/land-use-structure.png",
+      "role": "proposal_figure",
+      "required": true,
+      "language": "zh",
+      "sha256": "42ea401044ae2ea1a038702d8af15001e8e349bf9df1925cb87b84844a2d78a4"
+    },
+    {
+      "path": "assets/figures/metrics-evidence.png",
+      "role": "proposal_figure",
+      "required": true,
+      "language": "zh",
+      "sha256": "adfe722a9c2d334f77ff2e28b1374d4a2459d2290ed46d653de914d451e816f5"
+    },
+    {
+      "path": "assets/figures/mobility-bluegreen.png",
+      "role": "proposal_figure",
+      "required": true,
+      "language": "zh",
+      "sha256": "1f929c5626c88db564fe8861d46ef88d85e2481d1aedf10f5710218115b6fd9f"
+    },
+    {
+      "path": "assets/figures/site-overview.png",
+      "role": "proposal_figure",
+      "required": true,
+      "language": "zh",
+      "sha256": "6cd7a248e2198d143c7b974792c1b35aa41e44799c3161a50522a58b5ee18cbd"
+    },
+    {
+      "path": "geometry/buildings.geojson",
+      "role": "geometry",
+      "required": true,
+      "sha256": "26d123436727882fb39f0ce9989b9547aed2c04980d22da64ed908dc051ba47d"
+    },
+    {
+      "path": "geometry/constraints.geojson",
+      "role": "geometry",
+      "required": true,
+      "sha256": "bdea2201fdf997ee1a9dfc3e41468bc2f93c9b20287a7ff2c42010a116bcbcfd"
+    },
+    {
+      "path": "geometry/green_space.geojson",
+      "role": "geometry",
+      "required": true,
+      "sha256": "9419fd525a32241956d68f5026e9eebcd13c24214eba83f59763bf4af0c70705"
+    },
+    {
+      "path": "geometry/key_areas.geojson",
+      "role": "geometry",
+      "required": true,
+      "sha256": "566926817504a2938e081390879095fdc300a0df9328ddcbc6131b1e861718d3"
+    },
+    {
+      "path": "geometry/land_use.geojson",
+      "role": "geometry",
+      "required": true,
+      "sha256": "4c93bf0098c650e3d7971b2ca8b34e324ea5a00953be55b2cdfeae135fbe10c5"
+    },
+    {
+      "path": "geometry/phasing.geojson",
+      "role": "geometry",
+      "required": true,
+      "sha256": "25ff3d85c35f2411a986409a3a91138cc75ec912870a184476f50fa5f9c67946"
+    },
+    {
+      "path": "geometry/public_space.geojson",
+      "role": "geometry",
+      "required": true,
+      "sha256": "9203b41a94c3f84c5449b368f6e4a58618a32d4acc651ed6c51aa860aa3d9284"
+    },
+    {
+      "path": "geometry/roads.geojson",
+      "role": "geometry",
+      "required": true,
+      "sha256": "dd99454e566082116c144d84b8ab712c69584ceb535789c481563aaf1efd1be5"
+    },
+    {
+      "path": "geometry/site_boundary.geojson",
+      "role": "geometry",
+      "required": true,
+      "sha256": "66b8ab3db46dca00224c0662890a69c1bc0244902aa3390574f1ec20bc4348ff"
+    },
+    {
+      "path": "proposal.en.md",
+      "role": "narrative",
+      "required": false,
+      "language": "en",
+      "translation_of": "proposal.md",
+      "sha256": "92f81694d202c18cbaa729d7868c3b14c41c4e221a51b8fd3b6ea312709e70b9"
+    },
+    {
+      "path": "report/proposal.en.html",
+      "role": "rendered_proposal_html",
+      "required": false,
+      "language": "en",
+      "translation_of": "report/proposal.html",
+      "sha256": "0e8f7682942ae4d38be45de77b56af3df89b3d23a59a1490e30cc245f95384dd"
+    },
+    {
+      "path": "changelog.md",
+      "role": "changelog",
+      "required": false,
+      "language": "zh",
+      "sha256": "4d029b2cb443064ef55d8bbd4a8cc02167f51893bf33adbce3eff99794c45dcd"
+    },
+    {
+      "path": "assets/figures/switchback-logo.svg",
+      "role": "proposal_figure",
+      "required": false,
+      "language": "neutral",
+      "sha256": "7430451a0856a44d32d4c1f1fb4ddf5e85ff2a3549108453f181029de303d097"
+    },
+    {
+      "path": "assets/figures/site-overview.en.png",
+      "role": "proposal_figure",
+      "required": false,
+      "language": "en",
+      "translation_of": "assets/figures/site-overview.png",
+      "sha256": "61fc60242affa52c4ba96df35f5698925a326d3a04adac31960a499487af9bae"
+    },
+    {
+      "path": "assets/figures/land-use-structure.en.png",
+      "role": "proposal_figure",
+      "required": false,
+      "language": "en",
+      "translation_of": "assets/figures/land-use-structure.png",
+      "sha256": "70daa6a16d4d87ad7a561c5046ce9beb83bdb8d7f0584e2857f1db6966b1dbc8"
+    },
+    {
+      "path": "assets/figures/key-areas.en.png",
+      "role": "proposal_figure",
+      "required": false,
+      "language": "en",
+      "translation_of": "assets/figures/key-areas.png",
+      "sha256": "63b9b7b120dadfa6c9b633e1232dbf628497b9485d045e1814402b4c8005a5fd"
+    },
+    {
+      "path": "assets/figures/mobility-bluegreen.en.png",
+      "role": "proposal_figure",
+      "required": false,
+      "language": "en",
+      "translation_of": "assets/figures/mobility-bluegreen.png",
+      "sha256": "cd1d38936f08349c4cdb04aae2a491b0e35fff69e6a18bc35ada33e98e67781a"
+    },
+    {
+      "path": "assets/figures/metrics-evidence.en.png",
+      "role": "proposal_figure",
+      "required": false,
+      "language": "en",
+      "translation_of": "assets/figures/metrics-evidence.png",
+      "sha256": "aff0743dcbdd26d72965380707271c7e0ce47464fe316d4bba2366b15985497b"
+    },
+    {
+      "path": "drawings/a3-booklet.en.pdf",
+      "role": "drawing",
+      "required": false,
+      "language": "en",
+      "translation_of": "drawings/a3-booklet.pdf",
+      "sha256": "d29c1aecdf02723146c92e01d58468c7fd12dc69e08f6c320ca0cdcb0cf752da"
+    },
+    {
+      "path": "drawings/a0-boards.en.pdf",
+      "role": "drawing",
+      "required": false,
+      "language": "en",
+      "translation_of": "drawings/a0-boards.pdf",
+      "sha256": "77680e2ef234b6ae1649af7bffbdb0d6f7aa3b815655f68fbe438efd6f55377a"
+    },
+    {
+      "path": "visual/index.en.html",
+      "role": "visualization",
+      "required": false,
+      "language": "en",
+      "translation_of": "visual/index.html",
+      "sha256": "ccdc64f7fb64061ae4277ed7f41fe5222e6c26204f17d0ca105af7eca7cd9058"
+    },
+    {
+      "path": "assets/figures/existing-diagnosis.png",
+      "role": "proposal_figure",
+      "required": false,
+      "language": "zh",
+      "sha256": "6e06485eef62c013fbe47a0f9a10db5f9198c75ac4b2f1548c84af60e4619079"
+    },
+    {
+      "path": "assets/figures/existing-diagnosis.en.png",
+      "role": "proposal_figure",
+      "required": false,
+      "language": "en",
+      "translation_of": "assets/figures/existing-diagnosis.png",
+      "sha256": "8849370a20a8e1ef8253b1d9fe560b8a328812be737b31fdeafc9d3d7a0465d1"
+    },
+    {
+      "path": "visual/assets/existing-diagnosis.png",
+      "role": "asset",
+      "required": false,
+      "language": "zh",
+      "sha256": "6e06485eef62c013fbe47a0f9a10db5f9198c75ac4b2f1548c84af60e4619079"
+    },
+    {
+      "path": "visual/assets/existing-diagnosis.en.png",
+      "role": "asset",
+      "required": false,
+      "language": "en",
+      "translation_of": "visual/assets/existing-diagnosis.png",
+      "sha256": "8849370a20a8e1ef8253b1d9fe560b8a328812be737b31fdeafc9d3d7a0465d1"
+    },
+    {
+      "path": "assets/figures/section-spine.png",
+      "role": "proposal_figure",
+      "required": false,
+      "language": "zh",
+      "sha256": "f583e6b4ba0967ac4395a2f1618baa6683afd4d39385050ed515da28b784562a"
+    },
+    {
+      "path": "assets/figures/section-spine.en.png",
+      "role": "proposal_figure",
+      "required": false,
+      "language": "en",
+      "translation_of": "assets/figures/section-spine.png",
+      "sha256": "4e9907363d5deb1dc1f2f1f0b3283887394dc2a60d5f25d05fca78b91dd2184d"
+    },
+    {
+      "path": "visual/assets/section-spine.png",
+      "role": "asset",
+      "required": false,
+      "language": "zh",
+      "sha256": "f583e6b4ba0967ac4395a2f1618baa6683afd4d39385050ed515da28b784562a"
+    },
+    {
+      "path": "visual/assets/section-spine.en.png",
+      "role": "asset",
+      "required": false,
+      "language": "en",
+      "translation_of": "visual/assets/section-spine.png",
+      "sha256": "4e9907363d5deb1dc1f2f1f0b3283887394dc2a60d5f25d05fca78b91dd2184d"
+    },
+    {
+      "path": "risk.json",
+      "role": "other",
+      "required": false,
+      "sha256": "44cf8a61bb1ad0e8aa415ade70b03bbcc7c16f9cfea6a6c2f4859a16ea3c15d2",
+      "role_detail": "risk"
+    },
+    {
+      "path": "visual/assets/switchback-protocol.json",
+      "role": "asset",
+      "required": false,
+      "language": "neutral",
+      "sha256": "9e7dab1262122f2b12df8af08759e735a4c2975f91e87bb559a931fce98dafac"
+    }
+  ],
+  "validation_claim": {
+    "self_checked": true,
+    "known_blockers": [],
+    "data_confidence": "high",
+    "readiness_contract": "persisted-self-check-v1"
   }
- ],
- "validation_claim": {
-  "self_checked": false,
-  "known_blockers": [],
-  "data_confidence": "high"
- }
 }

--- a/submissions/loml13/switchback-line/self_check.json
+++ b/submissions/loml13/switchback-line/self_check.json
@@ -1,47 +1,212 @@
 {
+  "ok": true,
+  "submission_dir": "submissions/loml13/switchback-line",
+  "pr_author": "loml13",
+  "stage": "formal",
+  "deterministic_validation": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "errors": [],
+      "warnings": [
+        "submissions/loml13/switchback-line/geometry/site_boundary.geojson: uses provisional boundary; do not treat it as an official redline or precise-area basis. Organizer data gaps do not block content scoring; recalculate when official geometry is supplied",
+        "submissions/loml13/switchback-line/proposal.md: a paragraph/block contains 11 evidence markers; keep the full index in structured files; legacy proposal remains compatible and the viewer will condense it",
+        "submissions/loml13/switchback-line/proposal.md: a paragraph/block contains 14 evidence markers; keep the full index in structured files; legacy proposal remains compatible and the viewer will condense it",
+        "submissions/loml13/switchback-line/proposal.md: a paragraph/block contains 9 evidence markers; keep the full index in structured files; legacy proposal remains compatible and the viewer will condense it"
+      ],
+      "proposal_files": [
+        "submissions/loml13/switchback-line/proposal.md"
+      ],
+      "changelog_files": [
+        "submissions/loml13/switchback-line/changelog.md"
+      ],
+      "changed_files": [
+        "submissions/loml13/switchback-line/agent.json",
+        "submissions/loml13/switchback-line/assets/figures/existing-diagnosis.en.png",
+        "submissions/loml13/switchback-line/assets/figures/existing-diagnosis.png",
+        "submissions/loml13/switchback-line/assets/figures/key-areas.en.png",
+        "submissions/loml13/switchback-line/assets/figures/key-areas.png",
+        "submissions/loml13/switchback-line/assets/figures/land-use-structure.en.png",
+        "submissions/loml13/switchback-line/assets/figures/land-use-structure.png",
+        "submissions/loml13/switchback-line/assets/figures/metrics-evidence.en.png",
+        "submissions/loml13/switchback-line/assets/figures/metrics-evidence.png",
+        "submissions/loml13/switchback-line/assets/figures/mobility-bluegreen.en.png",
+        "submissions/loml13/switchback-line/assets/figures/mobility-bluegreen.png",
+        "submissions/loml13/switchback-line/assets/figures/section-spine.en.png",
+        "submissions/loml13/switchback-line/assets/figures/section-spine.png",
+        "submissions/loml13/switchback-line/assets/figures/site-overview.en.png",
+        "submissions/loml13/switchback-line/assets/figures/site-overview.png",
+        "submissions/loml13/switchback-line/assets/figures/switchback-logo.svg",
+        "submissions/loml13/switchback-line/assumptions.json",
+        "submissions/loml13/switchback-line/changelog.md",
+        "submissions/loml13/switchback-line/compliance_matrix.json",
+        "submissions/loml13/switchback-line/design_depth_matrix.json",
+        "submissions/loml13/switchback-line/drawings/a0-boards.en.pdf",
+        "submissions/loml13/switchback-line/drawings/a0-boards.pdf",
+        "submissions/loml13/switchback-line/drawings/a3-booklet.en.pdf",
+        "submissions/loml13/switchback-line/drawings/a3-booklet.pdf",
+        "submissions/loml13/switchback-line/geometry/buildings.geojson",
+        "submissions/loml13/switchback-line/geometry/constraints.geojson",
+        "submissions/loml13/switchback-line/geometry/green_space.geojson",
+        "submissions/loml13/switchback-line/geometry/key_areas.geojson",
+        "submissions/loml13/switchback-line/geometry/land_use.geojson",
+        "submissions/loml13/switchback-line/geometry/phasing.geojson",
+        "submissions/loml13/switchback-line/geometry/public_space.geojson",
+        "submissions/loml13/switchback-line/geometry/roads.geojson",
+        "submissions/loml13/switchback-line/geometry/site_boundary.geojson",
+        "submissions/loml13/switchback-line/manifest.json",
+        "submissions/loml13/switchback-line/metrics.json",
+        "submissions/loml13/switchback-line/proposal.en.md",
+        "submissions/loml13/switchback-line/proposal.md",
+        "submissions/loml13/switchback-line/report/copyright_statement.md",
+        "submissions/loml13/switchback-line/report/narrative.md",
+        "submissions/loml13/switchback-line/report/proposal.en.html",
+        "submissions/loml13/switchback-line/report/proposal.html",
+        "submissions/loml13/switchback-line/risk.json",
+        "submissions/loml13/switchback-line/self_check.json",
+        "submissions/loml13/switchback-line/sources.json",
+        "submissions/loml13/switchback-line/standard_matrix.json",
+        "submissions/loml13/switchback-line/visual/assets/existing-diagnosis.en.png",
+        "submissions/loml13/switchback-line/visual/assets/existing-diagnosis.png",
+        "submissions/loml13/switchback-line/visual/assets/section-spine.en.png",
+        "submissions/loml13/switchback-line/visual/assets/section-spine.png",
+        "submissions/loml13/switchback-line/visual/assets/switchback-protocol.json",
+        "submissions/loml13/switchback-line/visual/index.en.html",
+        "submissions/loml13/switchback-line/visual/index.html"
+      ],
+      "ai_package_stages": {
+        "submissions/loml13/switchback-line": "formal"
+      },
+      "total_bytes": 12966691,
+      "maintainer_bypass": false
+    },
+    "stderr": ""
+  },
+  "spatial_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "stage": "formal",
+      "issues": [
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-001",
+          "expected": null,
+          "actual": null
+        },
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-002",
+          "expected": null,
+          "actual": null
+        },
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-003",
+          "expected": null,
+          "actual": null
+        }
+      ],
+      "metrics": {
+        "site_area_sqm": 11412825.386,
+        "green_space_area_sqm": 2618652.977,
+        "public_space_area_sqm": 631453.996,
+        "building_footprint_area_sqm": 844149.611,
+        "green_ratio": 0.229448,
+        "public_space_ratio": 0.055328
+      }
+    },
+    "stderr": ""
+  },
+  "visual_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "issues": [],
+      "metrics_seen": {
+        "site_area_sqm": 11412825.386,
+        "green_ratio": 0.229448,
+        "public_space_ratio": 0.055328
+      }
+    },
+    "stderr": ""
+  },
+  "professional_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "issues": [],
+      "summary": {
+        "standard_matrix_items": 6,
+        "design_depth_items": 15,
+        "known_metric_refs_required": 28,
+        "proposal_format_version": "1",
+        "evidence_contract": "legacy-exhaustive-inline",
+        "proposal_reference_counts": {
+          "source": 16,
+          "standard": 7,
+          "depth": 16,
+          "data": 22,
+          "metric": 30
+        }
+      }
+    },
+    "stderr": ""
+  },
+  "spatial_issue_ids": [
+    "KEY_AREA_PROVISIONAL",
+    "KEY_AREA_PROVISIONAL",
+    "KEY_AREA_PROVISIONAL"
+  ],
+  "visual_issue_ids": [],
+  "professional_issue_ids": [],
+  "missing_review_dependencies": [],
+  "can_enter_formal_review": true,
+  "package_type": "professional_design_package",
+  "review_status": "formal-review-ready",
+  "next_actions": [],
   "schema_version": "0.1.0",
   "checks": [
     {
-      "check_id": "BOUNDARY_TRUST",
+      "check_id": "DETERMINISTIC_VALIDATION",
       "result": "pass",
-      "severity": "major",
-      "target": "geometry/site_boundary.geojson",
-      "message": "Provisional boundary (PROV-SITE-001) is used with explicit provisional_constraint labeling; recalc committed when official redline is published."
+      "severity": "blocking",
+      "target": "validate_local_submission.py",
+      "message": "deterministic_validation: PASS"
     },
     {
-      "check_id": "KEY_AREAS_TRUST",
+      "check_id": "SPATIAL_REVIEW",
       "result": "pass",
-      "severity": "major",
-      "target": "geometry/key_areas.geojson",
-      "message": "Three key areas are provisional polygons; disclosed in proposal.md, assumptions.json and visual/index.html."
+      "severity": "blocking",
+      "target": "spatial_review.py",
+      "message": "spatial_review: PASS"
     },
     {
-      "check_id": "LAND_USE_TOPOLOGY",
+      "check_id": "VISUAL_PACKAGING",
       "result": "pass",
-      "severity": "major",
-      "target": "geometry/land_use.geojson",
-      "message": "19 land-use parcels split from the site boundary with shared cut lines; zero coverage gap, no overlaps (shapely-verified)."
+      "severity": "blocking",
+      "target": "visual_review.py",
+      "message": "visual_review: PASS"
     },
     {
-      "check_id": "METRICS_RECALC",
+      "check_id": "PROFESSIONAL_EVIDENCE",
       "result": "pass",
-      "severity": "major",
-      "target": "metrics.json",
-      "message": "site_area/green/public metrics recomputed from geometry in EPSG:4548; matches spatial_review recomputation."
-    },
-    {
-      "check_id": "PROPOSAL_EVIDENCE",
-      "result": "pass",
-      "severity": "minor",
-      "target": "proposal.md",
-      "message": "All sections carry machine-readable evidence references; five figures embedded from local assets."
-    },
-    {
-      "check_id": "VISUAL_STATIC",
-      "result": "pass",
-      "severity": "info",
-      "target": "visual/index.html",
-      "message": "Static offline HTML with inline SVG map; no CDN, tiles, scripts or tracking."
+      "severity": "blocking",
+      "target": "professional_review.py",
+      "message": "professional_review: PASS"
     }
   ]
 }


### PR DESCRIPTION
## 内容（submissions/loml13/switchback-line，v1.7 → v1.7.1）

#1063 合并后的 manifest schema 迁移，仅 3 个文件（manifest.json / self_check.json / changelog.md），无内容变更。

### 迁移明细

- `schema_version`: 0.1.0 → **0.2.0**（显式 opt-in strict gate）
- `visual_asset` ×5 → canonical **`asset`**（0.2.x 新枚举）
- `risk` ×1 → **`other` + `role_detail: "risk"`**（受约束扩展槽）
- `changelog` 在 0.2.x 已入 canonical，不变
- `validation_claim`：`self_checked: true` + `readiness_contract: persisted-self-check-v1`（经 `self_check_submission.py --mark-self-checked` 写入）
- 迁移后全包 52 个文件条目 role 均为 canonical 或显式 `other`，#1058 自审的三类缺槽（changelog/risk/visual_asset）全部清零

### 本地校验

- `validate_local_submission.py --strict-manifest`：**PASS**
- `self_check_submission.py --mark-self-checked`：PASS，`self_check.json` 持久化 `ok=true`、`can_enter_formal_review=true`

### 说明

- 本 PR 基于 v1.7（#1821 已合并）之后仅含迁移增量；CI 队列（#1785）如积压，validation 可能延迟。