### PR TITLE
fix: show allowed GeoJSON enum values

### DIFF
--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -993,6 +993,10 @@ def load_string_enums(repo_root: Path, relative_path: str) -> dict[str, set[str]
     }
 
 
+def allowed_values_hint(values: set[str]) -> str:
+    return ", ".join(sorted(values))
+
+
 def load_required_standard_ids(repo_root: Path) -> set[str]:
     standards_path = policy_file(repo_root, "brief/site-package/standards/standards.json")
     if not standards_path.exists():
@@ -1195,28 +1199,49 @@ def validate_geojson_file(
                 report.add_error(f"{feature_label}: missing property `{key}`")
         layer = properties.get("layer")
         if allowed_layers and layer and layer not in allowed_layers:
-            report.add_error(f"{feature_label}: unknown layer `{layer}`")
+            report.add_error(
+                f"{feature_label}: unknown layer `{layer}`; allowed: "
+                f"{allowed_values_hint(allowed_layers)}"
+            )
         source_type = properties.get("source_type")
         allowed_source_types = source_enums.get("source_types", set())
         if allowed_source_types and source_type and source_type not in allowed_source_types:
-            report.add_error(f"{feature_label}: unknown source_type `{source_type}`")
+            report.add_error(
+                f"{feature_label}: unknown source_type `{source_type}`; allowed: "
+                f"{allowed_values_hint(allowed_source_types)}"
+            )
         confidence = properties.get("confidence")
         allowed_confidence = source_enums.get("confidence_levels", set())
         if allowed_confidence and confidence and confidence not in allowed_confidence:
-            report.add_error(f"{feature_label}: unknown confidence `{confidence}`")
+            report.add_error(
+                f"{feature_label}: unknown confidence `{confidence}`; allowed: "
+                f"{allowed_values_hint(allowed_confidence)}"
+            )
         geometry_role = properties.get("geometry_role")
         allowed_roles = source_enums.get("geometry_roles", set())
         if allowed_roles and geometry_role and geometry_role not in allowed_roles:
-            report.add_error(f"{feature_label}: unknown geometry_role `{geometry_role}`")
+            report.add_error(
+                f"{feature_label}: unknown geometry_role `{geometry_role}`; allowed: "
+                f"{allowed_values_hint(allowed_roles)}"
+            )
         land_use_code = properties.get("land_use_code")
         if land_use_codes and land_use_code and str(land_use_code) not in land_use_codes:
-            report.add_error(f"{feature_label}: unknown land_use_code `{land_use_code}`")
+            report.add_error(
+                f"{feature_label}: unknown land_use_code `{land_use_code}`; allowed: "
+                f"{allowed_values_hint(land_use_codes)}"
+            )
         road_class = properties.get("road_class")
         if road_classes and road_class and str(road_class) not in road_classes:
-            report.add_error(f"{feature_label}: unknown road_class `{road_class}`")
+            report.add_error(
+                f"{feature_label}: unknown road_class `{road_class}`; allowed: "
+                f"{allowed_values_hint(road_classes)}"
+            )
         building_type = properties.get("building_type")
         if building_types and building_type and str(building_type) not in building_types:
-            report.add_error(f"{feature_label}: unknown building_type `{building_type}`")
+            report.add_error(
+                f"{feature_label}: unknown building_type `{building_type}`; allowed: "
+                f"{allowed_values_hint(building_types)}"
+            )
         if not isinstance(geometry, dict):
             report.add_error(f"{feature_label}: geometry must be an object")
         elif not geometry_coordinates_are_valid(geometry):

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -3285,7 +3285,13 @@ class SubmissionWorkflowTests(unittest.TestCase):
                 root,
                 f"{base}/geometry/land_use.geojson",
                 lambda data: data["features"][0]["properties"].update(
-                    {"land_use_code": "BAD"}
+                    {
+                        "layer": "BAD_LAYER",
+                        "source_type": "bad-source",
+                        "confidence": "bad-confidence",
+                        "geometry_role": "bad-role",
+                        "land_use_code": "BAD",
+                    }
                 ),
             )
             self.update_json(
@@ -3305,9 +3311,24 @@ class SubmissionWorkflowTests(unittest.TestCase):
             report = validate_submission(root, "alice", changed)
             self.assertFalse(report.ok)
             errors = "\n".join(report.errors)
-            self.assertIn("unknown land_use_code", errors)
-            self.assertIn("unknown road_class", errors)
-            self.assertIn("unknown building_type", errors)
+            for field in [
+                "layer",
+                "source_type",
+                "confidence",
+                "geometry_role",
+                "land_use_code",
+                "road_class",
+                "building_type",
+            ]:
+                self.assertIn(f"unknown {field}", errors)
+            self.assertEqual(7, errors.count("; allowed: "))
+            self.assertIn("allowed: AI_SERVICE_ZONE", errors)
+            self.assertIn("allowed: agent_generated_design", errors)
+            self.assertIn("allowed: high, low, medium, unknown", errors)
+            self.assertIn("allowed: analysis_helper", errors)
+            self.assertIn("allowed: 05, 07, 0701", errors)
+            self.assertIn("allowed: arterial, branch, cycleway", errors)
+            self.assertIn("allowed: ai_r_and_d", errors)
 
     def test_formal_empty_core_geometry_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Fixes #1902

## Summary
- include sorted allowed values in all seven GeoJSON enum validation errors
- cover layer, source type, confidence, geometry role, land-use code, road class, and building type
- keep validation behavior unchanged; only make failures directly actionable

## Validation
- `python3 -m unittest tests.test_submission_workflow` (127 PASS)
- `python3 -m py_compile scripts/validate_submission.py`
- `git diff --check`