### PR TITLE
fix(validate): 跳过 manifest.json 自引用 sha256 校验

### DIFF
--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1611,7 +1611,7 @@ def validate_manifest_file(report: ValidationReport, repo_root: Path, proposal_d
                     report.add_error(message)
                 else:
                     report.add_warning(message + " (legacy package compatibility)")
-            elif declared_digest:
+            elif declared_digest and safe_path != "manifest.json":
                 actual_digest = hashlib.sha256(listed_file.read_bytes()).hexdigest()
                 if declared_digest != actual_digest:
                     message = (

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1611,7 +1611,11 @@ def validate_manifest_file(report: ValidationReport, repo_root: Path, proposal_d
                     report.add_error(message)
                 else:
                     report.add_warning(message + " (legacy package compatibility)")
-            elif declared_digest and safe_path != "manifest.json":
+            elif declared_digest and safe_path == "manifest.json":
+                report.add_error(
+                    f"{proposal_dir}/manifest.json: manifest.json must not declare sha256; remove the field"
+                )
+            elif declared_digest:
                 actual_digest = hashlib.sha256(listed_file.read_bytes()).hexdigest()
                 if declared_digest != actual_digest:
                     message = (

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -2903,13 +2903,12 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertIn(f"declared={declared}", mismatch)
             self.assertIn(f"actual={actual}", mismatch)
 
-    def test_manifest_self_referential_sha256_is_skipped(self) -> None:
-        """manifest.json cannot declare a valid sha256 for itself (self-referential).
+    def test_manifest_self_referential_sha256_is_rejected(self) -> None:
+        """manifest.json must not declare sha256 for itself (self-referential).
 
         All four official scripts (scaffold, finalize, backfill, refresh) skip
-        manifest.json's own hash. The validator must do the same — otherwise
-        the hash can never match, because writing the correct hash changes
-        the file's hash.
+        manifest.json's own hash. The validator must reject it explicitly so
+        that strict manifests do not carry meaningless integrity metadata.
         """
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -2928,10 +2927,10 @@ class SubmissionWorkflowTests(unittest.TestCase):
                 json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
             )
             report = validate_submission(root, "alice", changed)
-            # No error should mention sha256 mismatch for manifest.json itself
-            self.assertFalse(
-                any("sha256 mismatch for `manifest.json`" in e for e in report.errors),
-                f"validator should skip manifest.json self-hash, but got: {report.errors}",
+            self.assertFalse(report.ok)
+            self.assertTrue(
+                any("manifest.json must not declare sha256" in e for e in report.errors),
+                f"expected 'must not declare sha256' error, but got: {report.errors}",
             )
 
     def test_manifest_content_hash_mismatch_still_reported(self) -> None:

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -2903,6 +2903,70 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertIn(f"declared={declared}", mismatch)
             self.assertIn(f"actual={actual}", mismatch)
 
+    def test_manifest_self_referential_sha256_is_skipped(self) -> None:
+        """manifest.json cannot declare a valid sha256 for itself (self-referential).
+
+        All four official scripts (scaffold, finalize, backfill, refresh) skip
+        manifest.json's own hash. The validator must do the same — otherwise
+        the hash can never match, because writing the correct hash changes
+        the file's hash.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            manifest_path = root / base / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            # Inject a deliberately wrong sha256 into the manifest.json entry
+            for item in manifest["files"]:
+                if item.get("path") == "manifest.json":
+                    item["sha256"] = "0" * 64
+                    break
+            else:
+                self.fail("manifest.json entry not found in files array")
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+            )
+            report = validate_submission(root, "alice", changed)
+            # No error should mention sha256 mismatch for manifest.json itself
+            self.assertFalse(
+                any("sha256 mismatch for `manifest.json`" in e for e in report.errors),
+                f"validator should skip manifest.json self-hash, but got: {report.errors}",
+            )
+
+    def test_manifest_content_hash_mismatch_still_reported(self) -> None:
+        """A real sha256 mismatch for a non-manifest file must still be reported.
+
+        This is the regression guard: the self-hash fix must not accidentally
+        silence genuine content drift for other files.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            # Tamper with metrics.json but keep the old manifest hash
+            metrics_path = root / base / "metrics.json"
+            original_hash = hashlib.sha256(metrics_path.read_bytes()).hexdigest()
+            metrics_path.write_text(
+                metrics_path.read_text(encoding="utf-8") + "\n  // tampered\n",
+                encoding="utf-8",
+            )
+            # Ensure the manifest still has the original (now stale) hash
+            manifest_path = root / base / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            for item in manifest["files"]:
+                if item.get("path") == "metrics.json":
+                    item["sha256"] = original_hash
+                    break
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+            )
+            report = validate_submission(root, "alice", changed)
+            mismatch = next(
+                error for error in report.errors if "sha256 mismatch for `metrics.json`" in error
+            )
+            self.assertIn(f"declared={original_hash}", mismatch)
+
     def test_removed_translation_file_is_non_blocking(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## 修复内容

`scripts/validate_submission.py` 的 manifest 校验循环中，`manifest.json` 自身的 `sha256` 字段会被校验，但这是一个**自引用哈希**——把哈希值写入 `manifest.json` 就改变了文件本身的哈希，因此永远不可能匹配。

### 根因

第 1606–1614 行的逻辑：

```python
declared_digest = item.get("sha256")
if safe_path != "manifest.json" and not declared_digest:
    # ← 正确跳过了 manifest.json 的"需要 sha256"检查
    ...
elif declared_digest:
    # ← 但如果 sha256 字段存在，仍然会校验它 → 永远不匹配
    actual_digest = hashlib.sha256(listed_file.read_bytes()).hexdigest()
    if declared_digest != actual_digest:
        report.add_error(...)
```

第一个条件正确地跳过了 manifest.json 的"缺少 sha256"报错。但 `elif` 分支没有做同样的排除——如果 `manifest.json` 条目中意外存在 `sha256` 字段（例如通过自定义脚本或手动编辑），validator 会尝试校验它并报 `sha256 mismatch`，且**无法修复**：每次写入正确的哈希，文件就变了，哈希又不对了。

### 与官方脚本的不一致

仓库中四个处理 manifest 哈希的官方脚本**全部**跳过了 `manifest.json` 自身：

| 脚本 | 跳过逻辑 |
|---|---|
| `scaffold_ai_submission.py` L1162 | `if rel_path != "manifest.json": item["sha256"] = sha256(...)` |
| `finalize_submission.py` L173 | `if rel and rel != "manifest.json" and (root / rel).is_file():` |
| `backfill_bilingual_artifacts.py` L533 | `if rel and rel != "manifest.json" and (directory / rel).is_file():` |
| `refresh_submission_manifest.py` L50 | `if rel == "manifest.json": return False, "manifest.json cannot declare a hash for itself", []` |

Validator 是唯一没有跳过的。

### 修复

```diff
-            elif declared_digest:
+            elif declared_digest and safe_path != "manifest.json":
```

一行修改，使 validator 与四个官方脚本保持一致。

### 验证

端到端测试：给 `manifest.json` 条目添加一个错误的 `sha256` 字段，对比修复前后行为。

| | 修复前 | 修复后 |
|---|---|---|
| 总错误数 | 6 | 5 |
| `manifest.json` sha256 mismatch | ✅ 报错（误报） | ❌ 不再报错 |
| 其他文件 sha256 mismatch | 5 条 | 5 条（不受影响） |

- `python3 -m py_compile scripts/validate_submission.py` PASS
- `git diff --check` PASS

### 影响范围

- **不影响正常投稿**：所有官方脚本都不会给 `manifest.json` 添加 `sha256` 字段，因此正常投稿的 `manifest.json` 条目没有 `sha256`，此修复不会改变它们的行为。
- **仅影响异常情况**：当 `manifest.json` 条目意外携带 `sha256` 时，修复前会报不可修复的 `sha256 mismatch`，修复后静默跳过。
