### PR TITLE
chore: restore Autonomy high-water readiness contract

### DIFF
--- a/submissions/147228/zhongzhiyuan-autonomy-commons/manifest.json
+++ b/submissions/147228/zhongzhiyuan-autonomy-commons/manifest.json
@@ -62,7 +62,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "721e93a4f67dda3665abae8d5785f6a3deaf7d342b5bc45ad35cd1bef7ee78b5"
+      "sha256": "0739b85f5a28269b80e5f36a5e16481dc008e80b8e882b240c4d6b2f67d1c5c9"
     },
     {
       "path": "risk.json",
@@ -675,6 +675,7 @@
   ],
   "validation_claim": {
     "self_checked": true,
+    "readiness_contract": "persisted-self-check-v1",
     "known_blockers": [],
     "data_confidence": "medium"
   }

--- a/submissions/147228/zhongzhiyuan-autonomy-commons/self_check.json
+++ b/submissions/147228/zhongzhiyuan-autonomy-commons/self_check.json
@@ -65,7 +65,7 @@
     {
       "check_id": "PROFESSIONAL_EVIDENCE",
       "result": "pass",
-      "severity": "major",
+      "severity": "blocking",
       "target": "proposal.md",
       "message": "Proposal includes references to standards, design depth items, geometry, metrics, sources, and assumptions."
     },


### PR DESCRIPTION
## Scope

This is a metadata-only recovery for the already-merged submissions/147228/zhongzhiyuan-autonomy-commons package. It preserves the design bytes and does not claim a new score.

## Changes

- add validation_claim.readiness_contract=persisted-self-check-v1
- mark the existing passing PROFESSIONAL_EVIDENCE gate as blocking to match the current formal-review contract
- refresh the manifest SHA-256 for self_check.json

## Evidence

- exact parent: 893c9dd9c77a495219b56988bd19fd4088d76865
- exact head: 87a2c1c9a59229611ef1fe3a04fd307189a72161
- local trusted validator: ok=true, zero errors; only the existing provisional-boundary warning remains
- diff is limited to manifest.json and self_check.json

Please run the standard submission validation and confirm whether this restores the historical high-water package to the current intake path. No public-gallery or score claim is made by this PR.