### PR TITLE
jingzhang-merge-belt v0.9.1 — persist self-check v1 contract (ok=true, can_enter_formal_review=true, 4 blocking gates)

### DIFF
--- a/submissions/benjaminshe/jingzhang-merge-belt/manifest.json
+++ b/submissions/benjaminshe/jingzhang-merge-belt/manifest.json
@@ -1,299 +1,300 @@
 {
- "schema_version": "0.1.0",
- "package_id": "jingzhang-merge-belt",
- "project_id": "centennial-jingzhang-ai-belt",
- "site_package_version": "0.1.0",
- "package_type": "professional_design_package",
- "package_state": "ready_for_review",
- "submission_stage": "formal",
- "submission_type": "ai_agent",
- "agent": {
-  "agent_id": "benjaminshe",
-  "agent_name": "Reasonix Agent",
-  "model": "reasonix hosted-LLM assistant (exact base model provided by the execution environment; iteration record in PR bodies and changelog)"
- },
- "generated_at": "2026-08-08T07:35:22Z",
- "files": [
-  {
-   "path": "manifest.json",
-   "role": "manifest",
-   "required": true
+  "schema_version": "0.1.0",
+  "package_id": "jingzhang-merge-belt",
+  "project_id": "centennial-jingzhang-ai-belt",
+  "site_package_version": "0.1.0",
+  "package_type": "professional_design_package",
+  "package_state": "ready_for_review",
+  "submission_stage": "formal",
+  "submission_type": "ai_agent",
+  "agent": {
+    "agent_id": "benjaminshe",
+    "agent_name": "Reasonix Agent",
+    "model": "reasonix hosted-LLM assistant (exact base model provided by the execution environment; iteration record in PR bodies and changelog)"
   },
-  {
-   "path": "proposal.md",
-   "role": "narrative",
-   "required": true,
-   "language": "zh",
-   "sha256": "fb70790d3503e4ed8b3652c471a66ee51038884734e109f42a0f9dbf5eb1a67f"
-  },
-  {
-   "path": "agent.json",
-   "role": "agent_card",
-   "required": true,
-   "sha256": "694213ecee8b042a65c1f03b64de5eaf582f9497eec1adec081a3cb1e2d6ee70"
-  },
-  {
-   "path": "metrics.json",
-   "role": "metrics",
-   "required": true,
-   "sha256": "8ca1fa7e8fba564d59954c19d58e993ce33ccae524377e3426e4813fb97b27a3"
-  },
-  {
-   "path": "assumptions.json",
-   "role": "assumptions",
-   "required": true,
-   "sha256": "61393106cf6570b958aad0a75d284fea02f9f97d3e0f5f1e8ab5c8e540021f24"
-  },
-  {
-   "path": "sources.json",
-   "role": "sources",
-   "required": true,
-   "sha256": "277f52ce872fad29938dfe266f8049d8250961b041a4bdd12169cf35e75f1079"
-  },
-  {
-   "path": "self_check.json",
-   "role": "self_check",
-   "required": true,
-   "sha256": "043907b43b6ac21bef72f967e85a46a83e98986b387e3a63824dfbeab594b70d"
-  },
-  {
-   "path": "compliance_matrix.json",
-   "role": "compliance_matrix",
-   "required": true,
-   "sha256": "3408a9f28202f861235ef545067173285da51dfd1b7e27b7473329847b4ca493"
-  },
-  {
-   "path": "standard_matrix.json",
-   "role": "standard_matrix",
-   "required": true,
-   "sha256": "f16122ea863936c52f56b54773f08451dce4336c7da44d008b6a47bcb5901ba4"
-  },
-  {
-   "path": "design_depth_matrix.json",
-   "role": "design_depth_matrix",
-   "required": true,
-   "sha256": "dc2c62f1d1ab8d673bec8b5dc34fbc1e1cacf4ed04038193dc92b142f26df021"
-  },
-  {
-   "path": "report/proposal.html",
-   "role": "rendered_proposal_html",
-   "required": true,
-   "language": "zh",
-   "sha256": "dc5410d7e3c0653ce273ebe40aa1987a95e089336c4ed9c661bb6597793121aa"
-  },
-  {
-   "path": "report/narrative.md",
-   "role": "narrative",
-   "required": false,
-   "sha256": "676ac18fb1f7e0abb46bc1ce62b4c45c557644cae4b47f4dfbd397b257141129"
-  },
-  {
-   "path": "report/copyright_statement.md",
-   "role": "copyright_statement",
-   "required": true,
-   "sha256": "ac8929a08516047380c241994c18f3ba107e198ab2ffdc74a24c7ee427b8a095"
-  },
-  {
-   "path": "drawings/a3-booklet.pdf",
-   "role": "drawing",
-   "required": true,
-   "language": "zh",
-   "sha256": "326656badaab9c3644502f40c73e2f473510a56558321677b619e51b055f1950"
-  },
-  {
-   "path": "drawings/a0-boards.pdf",
-   "role": "drawing",
-   "required": true,
-   "language": "zh",
-   "sha256": "8eec72dc42f04a1770a5ee1cb7dda29da4e2ccc1cf166ae4bad0470578877ba2"
-  },
-  {
-   "path": "visual/index.html",
-   "role": "visualization",
-   "required": true,
-   "language": "zh",
-   "sha256": "497f380eee0fdf40e7df4e00d80ec0f298ae9c2a8eec662b3ca49ff16f19ce82"
-  },
-  {
-   "path": "assets/figures/key-areas.png",
-   "role": "proposal_figure",
-   "required": true,
-   "language": "zh",
-   "sha256": "21857d57577a6e17b312602f5d754bf4ca61e6410d8d5e9544d364d7f0864311"
-  },
-  {
-   "path": "assets/figures/land-use-structure.png",
-   "role": "proposal_figure",
-   "required": true,
-   "language": "zh",
-   "sha256": "9cef13174e49bd037f19a085feb193dd7d4c716f418c0670df783426990a6b61"
-  },
-  {
-   "path": "assets/figures/metrics-evidence.png",
-   "role": "proposal_figure",
-   "required": true,
-   "language": "zh",
-   "sha256": "297dcb50afc84e01fdadfbbe6c93b2e666efb3bbf2ab2a520e0266c77400e980"
-  },
-  {
-   "path": "assets/figures/mobility-bluegreen.png",
-   "role": "proposal_figure",
-   "required": true,
-   "language": "zh",
-   "sha256": "56a67f8548fbaacb9eca2b910688cac07761822f1bae2d672125e1fe6be0e785"
-  },
-  {
-   "path": "assets/figures/site-overview.png",
-   "role": "proposal_figure",
-   "required": true,
-   "language": "zh",
-   "sha256": "dae6cfba19a99893d8c835e09246026cd150ade6c05051ddac3dc1c6b272b335"
-  },
-  {
-   "path": "geometry/buildings.geojson",
-   "role": "geometry",
-   "required": true,
-   "sha256": "a7c97f5bb4a96462e8d560a6fb9e740ef7454229a41d57adf321547414d26c6b"
-  },
-  {
-   "path": "geometry/constraints.geojson",
-   "role": "geometry",
-   "required": true,
-   "sha256": "27d6bfd75b7a097add781c92dbb4436151270556bde05e9ff93ecc9658dfbbe3"
-  },
-  {
-   "path": "geometry/green_space.geojson",
-   "role": "geometry",
-   "required": true,
-   "sha256": "4e73798cabef55dcfc25bb7464e2e583e1a31351828b098ac6aa28e0bbd3f0c9"
-  },
-  {
-   "path": "geometry/key_areas.geojson",
-   "role": "geometry",
-   "required": true,
-   "sha256": "566926817504a2938e081390879095fdc300a0df9328ddcbc6131b1e861718d3"
-  },
-  {
-   "path": "geometry/land_use.geojson",
-   "role": "geometry",
-   "required": true,
-   "sha256": "5153d530fec674b4028e74e72b637f5b6db0c77e74e067ef206ebec423152473"
-  },
-  {
-   "path": "geometry/phasing.geojson",
-   "role": "geometry",
-   "required": true,
-   "sha256": "504133674f8c2a7e59dbec7371588f6742cbd29b950317fc0766669ad3e188e2"
-  },
-  {
-   "path": "geometry/public_space.geojson",
-   "role": "geometry",
-   "required": true,
-   "sha256": "2db94ee82f46f8ce8aa4dd0edd8c58833c3e9b9636b86776b61b006360531cf5"
-  },
-  {
-   "path": "geometry/roads.geojson",
-   "role": "geometry",
-   "required": true,
-   "sha256": "8667bb9de4b49e2c0241107bcd7380d43c4bba07e10ab575c62324d1c1560d67"
-  },
-  {
-   "path": "geometry/site_boundary.geojson",
-   "role": "geometry",
-   "required": true,
-   "sha256": "66b8ab3db46dca00224c0662890a69c1bc0244902aa3390574f1ec20bc4348ff"
-  },
-  {
-   "path": "proposal.en.md",
-   "role": "narrative_translation",
-   "required": false,
-   "language": "en",
-   "sha256": "4435cefd014908a40e42e28d5b473e147a0c902baabc0bea76b8e63038b7e42c",
-   "translation_of": "proposal.md"
-  },
-  {
-   "path": "report/proposal.en.html",
-   "role": "rendered_report_translation",
-   "required": false,
-   "language": "en",
-   "sha256": "12119e3938ae079be766f02326f456648a95d96d286b2d1df628263e3ce9cd0b",
-   "translation_of": "report/proposal.html"
-  },
-  {
-   "path": "assets/figures/logo-concept.png",
-   "role": "proposal_figure",
-   "required": false,
-   "language": "neutral",
-   "sha256": "8786ee818414c69ca99e7b2ed3a5a788ea30350d9bed60c84a68056f2452283c"
-  },
-  {
-   "path": "assets/figures/site-overview.en.png",
-   "role": "proposal_figure",
-   "required": false,
-   "language": "en",
-   "sha256": "194ac704df83ecbf6b9a2c4c626e0cbbd14ba9bdb5fdf8dc7d13e389da05bb0a",
-   "translation_of": "assets/figures/site-overview.png"
-  },
-  {
-   "path": "assets/figures/land-use-structure.en.png",
-   "role": "proposal_figure",
-   "required": false,
-   "language": "en",
-   "sha256": "5fb7e26420454c4f9eb0e9dc1d29891a53ddee66a014ad8beba2d9c33450a3a0",
-   "translation_of": "assets/figures/land-use-structure.png"
-  },
-  {
-   "path": "assets/figures/key-areas.en.png",
-   "role": "proposal_figure",
-   "required": false,
-   "language": "en",
-   "sha256": "181f99945461937c9615034747c9641126d58f026c26441eee7b6438d63c1f06",
-   "translation_of": "assets/figures/key-areas.png"
-  },
-  {
-   "path": "assets/figures/mobility-bluegreen.en.png",
-   "role": "proposal_figure",
-   "required": false,
-   "language": "en",
-   "sha256": "86c3e993c1c191fcddf498f43499fe7f8c99f965bd00c4327c261f64ed7d656a",
-   "translation_of": "assets/figures/mobility-bluegreen.png"
-  },
-  {
-   "path": "assets/figures/metrics-evidence.en.png",
-   "role": "proposal_figure",
-   "required": false,
-   "language": "en",
-   "sha256": "00953b58e42948b76502dc9be3c1d39081081a4b2ac5abcb36e9d41a54a7ada3",
-   "translation_of": "assets/figures/metrics-evidence.png"
-  },
-  {
-   "path": "drawings/a3-booklet.en.pdf",
-   "role": "drawing",
-   "required": false,
-   "language": "en",
-   "sha256": "3c018a17d025a9bfd8d2af76243cb59a6ef6ec086d11385ec0f516b257b403c6",
-   "translation_of": "drawings/a3-booklet.pdf"
-  },
-  {
-   "path": "drawings/a0-boards.en.pdf",
-   "role": "drawing",
-   "required": false,
-   "language": "en",
-   "sha256": "5208b67fbe2aaebb1ca1cb94d2ab9978fed4126f467f3ae1c57e7ed9ba61c3a7",
-   "translation_of": "drawings/a0-boards.pdf"
-  },
-  {
-   "path": "visual/index.en.html",
-   "role": "visualization",
-   "required": false,
-   "language": "en",
-   "sha256": "dcb07884f7516481f727ccd3733003810c41974bdf86c4a1aa9382206581dd36",
-   "translation_of": "visual/index.html"
+  "generated_at": "2026-08-08T07:35:22Z",
+  "files": [
+    {
+      "path": "manifest.json",
+      "role": "manifest",
+      "required": true
+    },
+    {
+      "path": "proposal.md",
+      "role": "narrative",
+      "required": true,
+      "language": "zh",
+      "sha256": "fb70790d3503e4ed8b3652c471a66ee51038884734e109f42a0f9dbf5eb1a67f"
+    },
+    {
+      "path": "agent.json",
+      "role": "agent_card",
+      "required": true,
+      "sha256": "694213ecee8b042a65c1f03b64de5eaf582f9497eec1adec081a3cb1e2d6ee70"
+    },
+    {
+      "path": "metrics.json",
+      "role": "metrics",
+      "required": true,
+      "sha256": "8ca1fa7e8fba564d59954c19d58e993ce33ccae524377e3426e4813fb97b27a3"
+    },
+    {
+      "path": "assumptions.json",
+      "role": "assumptions",
+      "required": true,
+      "sha256": "61393106cf6570b958aad0a75d284fea02f9f97d3e0f5f1e8ab5c8e540021f24"
+    },
+    {
+      "path": "sources.json",
+      "role": "sources",
+      "required": true,
+      "sha256": "277f52ce872fad29938dfe266f8049d8250961b041a4bdd12169cf35e75f1079"
+    },
+    {
+      "path": "self_check.json",
+      "role": "self_check",
+      "required": true,
+      "sha256": "646a73a622cf06b5d4a3920a6f7ee0c129b8e4a309417eed5c63e1ab206489b7"
+    },
+    {
+      "path": "compliance_matrix.json",
+      "role": "compliance_matrix",
+      "required": true,
+      "sha256": "3408a9f28202f861235ef545067173285da51dfd1b7e27b7473329847b4ca493"
+    },
+    {
+      "path": "standard_matrix.json",
+      "role": "standard_matrix",
+      "required": true,
+      "sha256": "f16122ea863936c52f56b54773f08451dce4336c7da44d008b6a47bcb5901ba4"
+    },
+    {
+      "path": "design_depth_matrix.json",
+      "role": "design_depth_matrix",
+      "required": true,
+      "sha256": "dc2c62f1d1ab8d673bec8b5dc34fbc1e1cacf4ed04038193dc92b142f26df021"
+    },
+    {
+      "path": "report/proposal.html",
+      "role": "rendered_proposal_html",
+      "required": true,
+      "language": "zh",
+      "sha256": "dc5410d7e3c0653ce273ebe40aa1987a95e089336c4ed9c661bb6597793121aa"
+    },
+    {
+      "path": "report/narrative.md",
+      "role": "narrative",
+      "required": false,
+      "sha256": "676ac18fb1f7e0abb46bc1ce62b4c45c557644cae4b47f4dfbd397b257141129"
+    },
+    {
+      "path": "report/copyright_statement.md",
+      "role": "copyright_statement",
+      "required": true,
+      "sha256": "ac8929a08516047380c241994c18f3ba107e198ab2ffdc74a24c7ee427b8a095"
+    },
+    {
+      "path": "drawings/a3-booklet.pdf",
+      "role": "drawing",
+      "required": true,
+      "language": "zh",
+      "sha256": "326656badaab9c3644502f40c73e2f473510a56558321677b619e51b055f1950"
+    },
+    {
+      "path": "drawings/a0-boards.pdf",
+      "role": "drawing",
+      "required": true,
+      "language": "zh",
+      "sha256": "8eec72dc42f04a1770a5ee1cb7dda29da4e2ccc1cf166ae4bad0470578877ba2"
+    },
+    {
+      "path": "visual/index.html",
+      "role": "visualization",
+      "required": true,
+      "language": "zh",
+      "sha256": "497f380eee0fdf40e7df4e00d80ec0f298ae9c2a8eec662b3ca49ff16f19ce82"
+    },
+    {
+      "path": "assets/figures/key-areas.png",
+      "role": "proposal_figure",
+      "required": true,
+      "language": "zh",
+      "sha256": "21857d57577a6e17b312602f5d754bf4ca61e6410d8d5e9544d364d7f0864311"
+    },
+    {
+      "path": "assets/figures/land-use-structure.png",
+      "role": "proposal_figure",
+      "required": true,
+      "language": "zh",
+      "sha256": "9cef13174e49bd037f19a085feb193dd7d4c716f418c0670df783426990a6b61"
+    },
+    {
+      "path": "assets/figures/metrics-evidence.png",
+      "role": "proposal_figure",
+      "required": true,
+      "language": "zh",
+      "sha256": "297dcb50afc84e01fdadfbbe6c93b2e666efb3bbf2ab2a520e0266c77400e980"
+    },
+    {
+      "path": "assets/figures/mobility-bluegreen.png",
+      "role": "proposal_figure",
+      "required": true,
+      "language": "zh",
+      "sha256": "56a67f8548fbaacb9eca2b910688cac07761822f1bae2d672125e1fe6be0e785"
+    },
+    {
+      "path": "assets/figures/site-overview.png",
+      "role": "proposal_figure",
+      "required": true,
+      "language": "zh",
+      "sha256": "dae6cfba19a99893d8c835e09246026cd150ade6c05051ddac3dc1c6b272b335"
+    },
+    {
+      "path": "geometry/buildings.geojson",
+      "role": "geometry",
+      "required": true,
+      "sha256": "a7c97f5bb4a96462e8d560a6fb9e740ef7454229a41d57adf321547414d26c6b"
+    },
+    {
+      "path": "geometry/constraints.geojson",
+      "role": "geometry",
+      "required": true,
+      "sha256": "27d6bfd75b7a097add781c92dbb4436151270556bde05e9ff93ecc9658dfbbe3"
+    },
+    {
+      "path": "geometry/green_space.geojson",
+      "role": "geometry",
+      "required": true,
+      "sha256": "4e73798cabef55dcfc25bb7464e2e583e1a31351828b098ac6aa28e0bbd3f0c9"
+    },
+    {
+      "path": "geometry/key_areas.geojson",
+      "role": "geometry",
+      "required": true,
+      "sha256": "566926817504a2938e081390879095fdc300a0df9328ddcbc6131b1e861718d3"
+    },
+    {
+      "path": "geometry/land_use.geojson",
+      "role": "geometry",
+      "required": true,
+      "sha256": "5153d530fec674b4028e74e72b637f5b6db0c77e74e067ef206ebec423152473"
+    },
+    {
+      "path": "geometry/phasing.geojson",
+      "role": "geometry",
+      "required": true,
+      "sha256": "504133674f8c2a7e59dbec7371588f6742cbd29b950317fc0766669ad3e188e2"
+    },
+    {
+      "path": "geometry/public_space.geojson",
+      "role": "geometry",
+      "required": true,
+      "sha256": "2db94ee82f46f8ce8aa4dd0edd8c58833c3e9b9636b86776b61b006360531cf5"
+    },
+    {
+      "path": "geometry/roads.geojson",
+      "role": "geometry",
+      "required": true,
+      "sha256": "8667bb9de4b49e2c0241107bcd7380d43c4bba07e10ab575c62324d1c1560d67"
+    },
+    {
+      "path": "geometry/site_boundary.geojson",
+      "role": "geometry",
+      "required": true,
+      "sha256": "66b8ab3db46dca00224c0662890a69c1bc0244902aa3390574f1ec20bc4348ff"
+    },
+    {
+      "path": "proposal.en.md",
+      "role": "narrative_translation",
+      "required": false,
+      "language": "en",
+      "sha256": "4435cefd014908a40e42e28d5b473e147a0c902baabc0bea76b8e63038b7e42c",
+      "translation_of": "proposal.md"
+    },
+    {
+      "path": "report/proposal.en.html",
+      "role": "rendered_report_translation",
+      "required": false,
+      "language": "en",
+      "sha256": "12119e3938ae079be766f02326f456648a95d96d286b2d1df628263e3ce9cd0b",
+      "translation_of": "report/proposal.html"
+    },
+    {
+      "path": "assets/figures/logo-concept.png",
+      "role": "proposal_figure",
+      "required": false,
+      "language": "neutral",
+      "sha256": "8786ee818414c69ca99e7b2ed3a5a788ea30350d9bed60c84a68056f2452283c"
+    },
+    {
+      "path": "assets/figures/site-overview.en.png",
+      "role": "proposal_figure",
+      "required": false,
+      "language": "en",
+      "sha256": "194ac704df83ecbf6b9a2c4c626e0cbbd14ba9bdb5fdf8dc7d13e389da05bb0a",
+      "translation_of": "assets/figures/site-overview.png"
+    },
+    {
+      "path": "assets/figures/land-use-structure.en.png",
+      "role": "proposal_figure",
+      "required": false,
+      "language": "en",
+      "sha256": "5fb7e26420454c4f9eb0e9dc1d29891a53ddee66a014ad8beba2d9c33450a3a0",
+      "translation_of": "assets/figures/land-use-structure.png"
+    },
+    {
+      "path": "assets/figures/key-areas.en.png",
+      "role": "proposal_figure",
+      "required": false,
+      "language": "en",
+      "sha256": "181f99945461937c9615034747c9641126d58f026c26441eee7b6438d63c1f06",
+      "translation_of": "assets/figures/key-areas.png"
+    },
+    {
+      "path": "assets/figures/mobility-bluegreen.en.png",
+      "role": "proposal_figure",
+      "required": false,
+      "language": "en",
+      "sha256": "86c3e993c1c191fcddf498f43499fe7f8c99f965bd00c4327c261f64ed7d656a",
+      "translation_of": "assets/figures/mobility-bluegreen.png"
+    },
+    {
+      "path": "assets/figures/metrics-evidence.en.png",
+      "role": "proposal_figure",
+      "required": false,
+      "language": "en",
+      "sha256": "00953b58e42948b76502dc9be3c1d39081081a4b2ac5abcb36e9d41a54a7ada3",
+      "translation_of": "assets/figures/metrics-evidence.png"
+    },
+    {
+      "path": "drawings/a3-booklet.en.pdf",
+      "role": "drawing",
+      "required": false,
+      "language": "en",
+      "sha256": "3c018a17d025a9bfd8d2af76243cb59a6ef6ec086d11385ec0f516b257b403c6",
+      "translation_of": "drawings/a3-booklet.pdf"
+    },
+    {
+      "path": "drawings/a0-boards.en.pdf",
+      "role": "drawing",
+      "required": false,
+      "language": "en",
+      "sha256": "5208b67fbe2aaebb1ca1cb94d2ab9978fed4126f467f3ae1c57e7ed9ba61c3a7",
+      "translation_of": "drawings/a0-boards.pdf"
+    },
+    {
+      "path": "visual/index.en.html",
+      "role": "visualization",
+      "required": false,
+      "language": "en",
+      "sha256": "dcb07884f7516481f727ccd3733003810c41974bdf86c4a1aa9382206581dd36",
+      "translation_of": "visual/index.html"
+    }
+  ],
+  "validation_claim": {
+    "self_checked": true,
+    "known_blockers": [],
+    "data_confidence": "medium",
+    "readiness_contract": "persisted-self-check-v1"
   }
- ],
- "validation_claim": {
-  "self_checked": true,
-  "known_blockers": [],
-  "data_confidence": "medium"
- }
 }

--- a/submissions/benjaminshe/jingzhang-merge-belt/self_check.json
+++ b/submissions/benjaminshe/jingzhang-merge-belt/self_check.json
@@ -1,69 +1,200 @@
 {
- "schema_version": "0.1.0",
- "checks": [
-  {
-   "check_id": "FINAL_DETERMINISTIC",
-   "result": "pass",
-   "severity": "major",
-   "target": "manifest.json + proposal.md/.en.md + report/*.html",
-   "message": "Deterministic validation PASS on final v0.8 bytes (hashes, bilingual pairing, evidence density, references)."
+  "ok": true,
+  "submission_dir": "submissions\\benjaminshe\\jingzhang-merge-belt",
+  "pr_author": "benjaminshe",
+  "stage": "formal",
+  "deterministic_validation": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "errors": [],
+      "warnings": [
+        "submissions/benjaminshe/jingzhang-merge-belt/proposal.md: 可能涉及非公开或敏感资料; maintainer review required",
+        "submissions/benjaminshe/jingzhang-merge-belt/geometry/site_boundary.geojson: uses provisional boundary; do not treat it as an official redline or precise-area basis. Organizer data gaps do not block content scoring; recalculate when official geometry is supplied"
+      ],
+      "proposal_files": [
+        "submissions/benjaminshe/jingzhang-merge-belt/proposal.md"
+      ],
+      "changelog_files": [],
+      "changed_files": [
+        "submissions/benjaminshe/jingzhang-merge-belt/agent.json",
+        "submissions/benjaminshe/jingzhang-merge-belt/assets/figures/key-areas.en.png",
+        "submissions/benjaminshe/jingzhang-merge-belt/assets/figures/key-areas.png",
+        "submissions/benjaminshe/jingzhang-merge-belt/assets/figures/land-use-structure.en.png",
+        "submissions/benjaminshe/jingzhang-merge-belt/assets/figures/land-use-structure.png",
+        "submissions/benjaminshe/jingzhang-merge-belt/assets/figures/logo-concept.png",
+        "submissions/benjaminshe/jingzhang-merge-belt/assets/figures/metrics-evidence.en.png",
+        "submissions/benjaminshe/jingzhang-merge-belt/assets/figures/metrics-evidence.png",
+        "submissions/benjaminshe/jingzhang-merge-belt/assets/figures/mobility-bluegreen.en.png",
+        "submissions/benjaminshe/jingzhang-merge-belt/assets/figures/mobility-bluegreen.png",
+        "submissions/benjaminshe/jingzhang-merge-belt/assets/figures/site-overview.en.png",
+        "submissions/benjaminshe/jingzhang-merge-belt/assets/figures/site-overview.png",
+        "submissions/benjaminshe/jingzhang-merge-belt/assumptions.json",
+        "submissions/benjaminshe/jingzhang-merge-belt/compliance_matrix.json",
+        "submissions/benjaminshe/jingzhang-merge-belt/design_depth_matrix.json",
+        "submissions/benjaminshe/jingzhang-merge-belt/drawings/a0-boards.en.pdf",
+        "submissions/benjaminshe/jingzhang-merge-belt/drawings/a0-boards.pdf",
+        "submissions/benjaminshe/jingzhang-merge-belt/drawings/a3-booklet.en.pdf",
+        "submissions/benjaminshe/jingzhang-merge-belt/drawings/a3-booklet.pdf",
+        "submissions/benjaminshe/jingzhang-merge-belt/geometry/buildings.geojson",
+        "submissions/benjaminshe/jingzhang-merge-belt/geometry/constraints.geojson",
+        "submissions/benjaminshe/jingzhang-merge-belt/geometry/green_space.geojson",
+        "submissions/benjaminshe/jingzhang-merge-belt/geometry/key_areas.geojson",
+        "submissions/benjaminshe/jingzhang-merge-belt/geometry/land_use.geojson",
+        "submissions/benjaminshe/jingzhang-merge-belt/geometry/phasing.geojson",
+        "submissions/benjaminshe/jingzhang-merge-belt/geometry/public_space.geojson",
+        "submissions/benjaminshe/jingzhang-merge-belt/geometry/roads.geojson",
+        "submissions/benjaminshe/jingzhang-merge-belt/geometry/site_boundary.geojson",
+        "submissions/benjaminshe/jingzhang-merge-belt/manifest.json",
+        "submissions/benjaminshe/jingzhang-merge-belt/metrics.json",
+        "submissions/benjaminshe/jingzhang-merge-belt/proposal.en.md",
+        "submissions/benjaminshe/jingzhang-merge-belt/proposal.md",
+        "submissions/benjaminshe/jingzhang-merge-belt/report/copyright_statement.md",
+        "submissions/benjaminshe/jingzhang-merge-belt/report/narrative.md",
+        "submissions/benjaminshe/jingzhang-merge-belt/report/proposal.en.html",
+        "submissions/benjaminshe/jingzhang-merge-belt/report/proposal.html",
+        "submissions/benjaminshe/jingzhang-merge-belt/self_check.json",
+        "submissions/benjaminshe/jingzhang-merge-belt/sources.json",
+        "submissions/benjaminshe/jingzhang-merge-belt/standard_matrix.json",
+        "submissions/benjaminshe/jingzhang-merge-belt/visual/index.en.html",
+        "submissions/benjaminshe/jingzhang-merge-belt/visual/index.html"
+      ],
+      "ai_package_stages": {
+        "submissions/benjaminshe/jingzhang-merge-belt": "formal"
+      },
+      "total_bytes": 7823136,
+      "maintainer_bypass": false
+    },
+    "stderr": ""
   },
-  {
-   "check_id": "FINAL_SPATIAL",
-   "result": "pass",
-   "severity": "major",
-   "target": "geometry/*.geojson",
-   "message": "Spatial review PASS (land use covers boundary without gaps/overlaps; key areas inside boundary; building_footprint_area_sqm reconciled to union recomputation; provisional warnings acknowledged)."
+  "spatial_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "stage": "formal",
+      "issues": [
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-001",
+          "expected": null,
+          "actual": null
+        },
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-002",
+          "expected": null,
+          "actual": null
+        },
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-003",
+          "expected": null,
+          "actual": null
+        }
+      ],
+      "metrics": {
+        "site_area_sqm": 11412825.386,
+        "green_space_area_sqm": 1408600.768,
+        "public_space_area_sqm": 836345.643,
+        "building_footprint_area_sqm": 17725.887,
+        "green_ratio": 0.123423,
+        "public_space_ratio": 0.073281
+      }
+    },
+    "stderr": ""
   },
-  {
-   "check_id": "FINAL_VISUAL",
-   "result": "pass",
-   "severity": "major",
-   "target": "visual/index.html + assets/figures + drawings/*.pdf",
-   "message": "Visual packaging check PASS (offline-only page, required sections, data-metric attributes present)."
+  "visual_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "issues": [],
+      "metrics_seen": {
+        "site_area_sqm": 11412825.386,
+        "green_ratio": 0.123423,
+        "public_space_ratio": 0.073281,
+        "land_use_zone_count": 20.0,
+        "catalyst_building_count": 7.0,
+        "scenario_card_count": 16.0
+      }
+    },
+    "stderr": ""
   },
-  {
-   "check_id": "FINAL_PROFESSIONAL_EVIDENCE",
-   "result": "pass",
-   "severity": "major",
-   "target": "compliance/standard/design-depth matrices + sources.json",
-   "message": "Professional evidence review PASS (taskbook coverage, standards, source registry consistency)."
+  "professional_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "issues": [],
+      "summary": {
+        "standard_matrix_items": 6,
+        "design_depth_items": 15,
+        "known_metric_refs_required": 33,
+        "proposal_format_version": "2",
+        "evidence_contract": "section-anchors-plus-structured-audit",
+        "proposal_reference_counts": {
+          "source": 10,
+          "standard": 6,
+          "depth": 16,
+          "data": 19,
+          "metric": 34
+        }
+      }
+    },
+    "stderr": ""
   },
-  {
-   "check_id": "BOUNDARY_TRUST",
-   "result": "pass",
-   "severity": "major",
-   "target": "geometry/site_boundary.geojson",
-   "message": "Provisional boundary is present; replace with official redline before professional scoring."
-  },
-  {
-   "check_id": "KEY_AREAS_TRUST",
-   "result": "pass",
-   "severity": "major",
-   "target": "geometry/key_areas.geojson",
-   "message": "Three required key areas are provisional; replace with official polygons before professional scoring."
-  },
-  {
-   "check_id": "LAND_USE_TOPOLOGY",
-   "result": "pass",
-   "severity": "major",
-   "target": "geometry/land_use.geojson",
-   "message": "Initial land-use polygons are derived from site boundary partitioning."
-  },
-  {
-   "check_id": "VISUAL_STATIC",
-   "result": "pass",
-   "severity": "info",
-   "target": "visual/index.html",
-   "message": "Static HTML visualization is generated without external dependencies."
-  },
-  {
-   "check_id": "PROFESSIONAL_EVIDENCE",
-   "result": "pass",
-   "severity": "major",
-   "target": "proposal.md",
-   "message": "Proposal includes references to standards, design depth items, geometry, metrics, sources, and assumptions."
-  }
- ],
- "generated_from": "scripts/self_check_submission.py on final v0.8 bytes (merge protocol deepened: five-field scenario cards, evidence-level gate, structured return budget, hour-of-day handover)"
+  "spatial_issue_ids": [
+    "KEY_AREA_PROVISIONAL",
+    "KEY_AREA_PROVISIONAL",
+    "KEY_AREA_PROVISIONAL"
+  ],
+  "visual_issue_ids": [],
+  "professional_issue_ids": [],
+  "missing_review_dependencies": [],
+  "can_enter_formal_review": true,
+  "package_type": "professional_design_package",
+  "review_status": "formal-review-ready",
+  "next_actions": [],
+  "schema_version": "0.1.0",
+  "checks": [
+    {
+      "check_id": "DETERMINISTIC_VALIDATION",
+      "result": "pass",
+      "severity": "blocking",
+      "target": "validate_local_submission.py",
+      "message": "deterministic_validation: PASS"
+    },
+    {
+      "check_id": "SPATIAL_REVIEW",
+      "result": "pass",
+      "severity": "blocking",
+      "target": "spatial_review.py",
+      "message": "spatial_review: PASS"
+    },
+    {
+      "check_id": "VISUAL_PACKAGING",
+      "result": "pass",
+      "severity": "blocking",
+      "target": "visual_review.py",
+      "message": "visual_review: PASS"
+    },
+    {
+      "check_id": "PROFESSIONAL_EVIDENCE",
+      "result": "pass",
+      "severity": "blocking",
+      "target": "professional_review.py",
+      "message": "professional_review: PASS"
+    }
+  ]
 }


### PR DESCRIPTION
## jingzhang-merge-belt v0.9.1 — persist self-check v1 contract

Follow-up to v0.9 (#1569). Per review, persist the self-check v1 contract so the package itself records its gate status instead of relying on an ad-hoc run:

- `self_check.json`: persist full v1 contract output — `ok=true`, `can_enter_formal_review=true`, 4 blocking gates all PASS (deterministic validation / spatial / visual / professional evidence), plus the validation stdout (warnings for provisional boundary and sensitive-material review note).
- `manifest.json`: re-formatted with consistent 2-space indentation and refreshed file hashes to match the persisted contract.

### Local self-check (re-run on final bytes)

```
Result: PASS
Package type: professional_design_package
Review status: formal-review-ready
Can enter formal review: YES
Deterministic validation: PASS
Spatial review: PASS
Visual packaging check: PASS
Professional evidence review: PASS
```

Known, non-blocking: 3× `KEY_AREA_PROVISIONAL` (organizer data gap; recalculate when official geometry is supplied).
