### PR TITLE
fix: fall back when validation comment patch is forbidden

### DIFF
--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -105,6 +105,12 @@ def _is_download_not_found(error: Exception, path: str) -> bool:
     )
 
 
+def _is_comment_patch_forbidden(error: RuntimeError) -> bool:
+    """Allow fork validation to publish a fresh comment when PATCH is forbidden."""
+    message = str(error)
+    return message.startswith("GitHub API PATCH ") and " failed with HTTP 403:" in message
+
+
 class GitHubClient:
     def __init__(self, token: str, repository: str) -> None:
         self.token = token
@@ -218,11 +224,25 @@ class GitHubClient:
         comments = self.paginate(f"/repos/{self.repository}/issues/{issue_number}/comments?per_page=100")
         for comment in comments:
             if COMMENT_MARKER in comment.get("body", ""):
-                self.request(
-                    "PATCH",
-                    f"/repos/{self.repository}/issues/comments/{comment['id']}",
-                    {"body": body},
-                )
+                try:
+                    self.request(
+                        "PATCH",
+                        f"/repos/{self.repository}/issues/comments/{comment['id']}",
+                        {"body": body},
+                    )
+                except RuntimeError as exc:
+                    if not _is_comment_patch_forbidden(exc):
+                        raise
+                    # A pull_request_target token may create a new comment but
+                    # cannot edit a bot-owned comment on a fork PR. Avoid a
+                    # duplicate when the fallback body is already present.
+                    if comment.get("body") == body:
+                        return
+                    self.request(
+                        "POST",
+                        f"/repos/{self.repository}/issues/{issue_number}/comments",
+                        {"body": body},
+                    )
                 return
         self.request("POST", f"/repos/{self.repository}/issues/{issue_number}/comments", {"body": body})
 

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -222,28 +222,29 @@ class GitHubClient:
 
     def upsert_comment(self, issue_number: int, body: str) -> None:
         comments = self.paginate(f"/repos/{self.repository}/issues/{issue_number}/comments?per_page=100")
-        for comment in comments:
-            if COMMENT_MARKER in comment.get("body", ""):
-                try:
-                    self.request(
-                        "PATCH",
-                        f"/repos/{self.repository}/issues/comments/{comment['id']}",
-                        {"body": body},
-                    )
-                except RuntimeError as exc:
-                    if not _is_comment_patch_forbidden(exc):
-                        raise
-                    # A pull_request_target token may create a new comment but
-                    # cannot edit a bot-owned comment on a fork PR. Avoid a
-                    # duplicate when the fallback body is already present.
-                    if comment.get("body") == body:
-                        return
-                    self.request(
-                        "POST",
-                        f"/repos/{self.repository}/issues/{issue_number}/comments",
-                        {"body": body},
-                    )
+        marker_comments = [
+            comment for comment in comments if COMMENT_MARKER in comment.get("body", "")
+        ]
+        # A forbidden PATCH can leave the old marker beside a newly-created
+        # fallback marker. Check the complete marker set before attempting
+        # another mutation, so repeated workflow runs remain idempotent.
+        if any(comment.get("body") == body for comment in marker_comments):
+            return
+        for comment in marker_comments:
+            try:
+                self.request(
+                    "PATCH",
+                    f"/repos/{self.repository}/issues/comments/{comment['id']}",
+                    {"body": body},
+                )
                 return
+            except RuntimeError as exc:
+                if not _is_comment_patch_forbidden(exc):
+                    raise
+                # A pull_request_target token may create a new comment but
+                # cannot edit a bot-owned comment on a fork PR. Try another
+                # marker first; POST only after every marker is uneditable.
+                continue
         self.request("POST", f"/repos/{self.repository}/issues/{issue_number}/comments", {"body": body})
 
     def add_labels(self, issue_number: int, labels: list[str]) -> None:

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -239,6 +239,49 @@ class GitHubApiResilienceTests(unittest.TestCase):
             request.call_args_list,
         )
 
+    def test_comment_fallback_is_idempotent_when_identical_marker_exists(self) -> None:
+        client = GitHubClient("token", "open-city-ai/haidian")
+        body = f"{COMMENT_MARKER}\nnew result"
+        comments = [
+            {"id": 42, "body": f"{COMMENT_MARKER}\nold result"},
+            {"id": 43, "body": body},
+        ]
+        with patch.object(client, "paginate", return_value=comments), patch.object(
+            client, "request"
+        ) as request:
+            client.upsert_comment(1955, body)
+        request.assert_not_called()
+
+    def test_comment_patch_forbidden_tries_next_marker_before_posting(self) -> None:
+        client = GitHubClient("token", "open-city-ai/haidian")
+        first = {"id": 42, "body": f"{COMMENT_MARKER}\nold result"}
+        second = {"id": 43, "body": f"{COMMENT_MARKER}\nolder result"}
+        patch_error = RuntimeError(
+            "GitHub API PATCH https://api.github.com/repos/open-city-ai/haidian/issues/comments/42 "
+            "failed with HTTP 403: Must have admin rights to Repository."
+        )
+        with patch.object(client, "paginate", return_value=[first, second]), patch.object(
+            client,
+            "request",
+            side_effect=[patch_error, ({"id": 43}, {})],
+        ) as request:
+            client.upsert_comment(1955, f"{COMMENT_MARKER}\nnew result")
+        self.assertEqual(
+            [
+                call(
+                    "PATCH",
+                    "/repos/open-city-ai/haidian/issues/comments/42",
+                    {"body": f"{COMMENT_MARKER}\nnew result"},
+                ),
+                call(
+                    "PATCH",
+                    "/repos/open-city-ai/haidian/issues/comments/43",
+                    {"body": f"{COMMENT_MARKER}\nnew result"},
+                ),
+            ],
+            request.call_args_list,
+        )
+
     def test_comment_patch_non_permission_failure_is_not_hidden(self) -> None:
         client = GitHubClient("token", "open-city-ai/haidian")
         existing = {"id": 42, "body": f"{COMMENT_MARKER}\nold result"}

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -9,7 +9,7 @@ import io
 import re
 import urllib.error
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import jsonschema
 
@@ -33,6 +33,7 @@ from validate_submission import (  # noqa: E402
 )
 from github_pr_validation import (  # noqa: E402
     base_requires_persisted_readiness,
+    COMMENT_MARKER,
     GitHubClient,
     MAX_DOWNLOAD_BYTES,
     _is_retryable_http_error,
@@ -208,6 +209,49 @@ class GitHubApiResilienceTests(unittest.TestCase):
                 client.request("POST", "/test", {"body": "comment"})
         self.assertEqual(1, urlopen.call_count)
         sleep.assert_not_called()
+
+    def test_comment_patch_forbidden_falls_back_to_new_comment(self) -> None:
+        client = GitHubClient("token", "open-city-ai/haidian")
+        existing = {"id": 42, "body": f"{COMMENT_MARKER}\nold result"}
+        patch_error = RuntimeError(
+            "GitHub API PATCH https://api.github.com/repos/open-city-ai/haidian/issues/comments/42 "
+            "failed with HTTP 403: Must have admin rights to Repository."
+        )
+        with patch.object(client, "paginate", return_value=[existing]), patch.object(
+            client,
+            "request",
+            side_effect=[patch_error, ({"id": 43}, {})],
+        ) as request:
+            client.upsert_comment(1955, f"{COMMENT_MARKER}\nnew result")
+        self.assertEqual(
+            [
+                call(
+                    "PATCH",
+                    "/repos/open-city-ai/haidian/issues/comments/42",
+                    {"body": f"{COMMENT_MARKER}\nnew result"},
+                ),
+                call(
+                    "POST",
+                    "/repos/open-city-ai/haidian/issues/1955/comments",
+                    {"body": f"{COMMENT_MARKER}\nnew result"},
+                ),
+            ],
+            request.call_args_list,
+        )
+
+    def test_comment_patch_non_permission_failure_is_not_hidden(self) -> None:
+        client = GitHubClient("token", "open-city-ai/haidian")
+        existing = {"id": 42, "body": f"{COMMENT_MARKER}\nold result"}
+        error = RuntimeError(
+            "GitHub API PATCH https://api.github.com/repos/open-city-ai/haidian/issues/comments/42 "
+            "failed with HTTP 500: server error"
+        )
+        with patch.object(client, "paginate", return_value=[existing]), patch.object(
+            client, "request", side_effect=error
+        ) as request:
+            with self.assertRaisesRegex(RuntimeError, "HTTP 500: server error"):
+                client.upsert_comment(1955, f"{COMMENT_MARKER}\nnew result")
+        request.assert_called_once()
 
     def test_download_404_retries_then_succeeds(self) -> None:
         client = GitHubClient("token", "open-city-ai/haidian")


### PR DESCRIPTION
Fixes #1980

When pull_request_target validation finds its existing marker comment, a fork PR token may receive HTTP 403 on PATCH even though it can POST a new comment. The current behavior turns a successful deterministic validation into a failed check. This patch catches only the explicit PATCH 403 shape, posts the new bounded validation comment, avoids an identical duplicate, and still propagates non-permission failures.

Tests: 9 focused GitHub API resilience tests pass; AST parse and git diff --check pass. The full test module has 129 passing tests and two pre-existing scenario-registry fixture failures unrelated to this change.