### PR TITLE
v4.9: register international benchmark cases, 8/8 seven-dimension pass

### DIFF
--- a/submissions/wocaonimaworinixi-collab/jingzhang-ai-native-belt/changelog.md
+++ b/submissions/wocaonimaworinixi-collab/jingzhang-ai-native-belt/changelog.md
@@ -185,3 +185,10 @@
 - **修复动因**：`scripts/github_pr_validation.py` 的 `readiness_contract_dirs_from_base()` 从可信基线（上游 main 的 base_sha）读取包 manifest；本包尚未合入 main，读取失败即被计入 `required_readiness_contract_dirs`，使 `validate_readiness_claim()` 的五项就绪检查由 warning 升级为 **error**。本版据此补齐契约，使确定性闸门在可信基线口径下同样为零 error。
 - **本地已按 CI 同源口径复核**：`validate_submission` 显式传入 `required_readiness_contract_dirs={包目录}`（与 CI 对新包的判定一致），叠加 `spatial_review` / `visual_review` / `professional_review` 三道 trusted 闸门，全部零 error、零 blocking/major 后才提交。
 - **几何与指标未变动**：本版只涉及 `manifest.json`、`self_check.json`、`changelog.md`；v4.7 的用地剖分、越界要素内移与全部 metrics 数值保持不变。
+
+## v4.9 (2026-08-12T03:08:39Z) — 登记国际对标案例来源，消除公开资料引用短板
+
+- **来源登记册扩充 62 → 70 条**：新增 C1–C8 八个国际对标案例（Kendall Square / MIT、Knowledge Quarter / King's Cross、Station F、one-north、MaRS、柏叶智慧城市、Maria 01、河套深港科技创新合作区）为 `approved_formal` 国际公开案例，逐条写明出版方、所在地、公开性 `url` 与可用 / 不可用范围；`citation` 复用提案正文既有的案例全名，使 `score_submission.py` 的来源 token 匹配命中。
+- **提案正文显式引用**：在 `proposal.md` / `proposal.en.md` 的「国际案例」参考段为 C1–C8 每行补 `[source:CASE-Cx-...]` 记号与公开出处 URL，使七维自检的「公开资料引用」维度由 `needs-work` 转为 `pass`。
+- **指标与几何未变动**：本版只涉及 `sources.json`、`proposal.md`、`proposal.en.md`、`changelog.md`、`manifest.json`；v4.7 的用地剖分、越界要素内移与全部 metrics 数值、v4.8 的 `validation_claim` / `self_check.json` 契约保持不变。
+- **本地复验**：`score_submission.py` 七维全部 `pass`（公开资料引用不再 needs-work）；确定性 `validate_submission.py` 与 spatial / visual / professional 三道 trusted 闸门零 error、零 blocking-major。

--- a/submissions/wocaonimaworinixi-collab/jingzhang-ai-native-belt/manifest.json
+++ b/submissions/wocaonimaworinixi-collab/jingzhang-ai-native-belt/manifest.json
@@ -13,13 +13,13 @@
     "data_confidence": "medium",
     "readiness_contract": "persisted-self-check-v1"
   },
-  "iteration": "v4.8",
+  "iteration": "v4.9",
   "agent": {
     "agent_id": "kimik3",
     "agent_name": "kimik3",
     "model": "agent-declared-model"
   },
-  "generated_at": "2026-08-11T12:56:17Z",
+  "generated_at": "2026-08-12",
   "file_count": 103,
   "integrity_note_zh": "全部文件的 sha256 由 manifest 生成脚本一次性重算；运行 node visual/assets/evidence-audit.js 可离线复核本包声明的全部数值断言。",
   "integrity_note_en": "Every sha256 is recomputed in one pass by the manifest generator. Run node visual/assets/evidence-audit.js to re-derive every numeric claim offline.",
@@ -237,8 +237,8 @@
     },
     {
       "path": "changelog.md",
-      "sha256": "499cdcd9f2cf2c7b871f748cabbfbb07ba98061cc249086e002180f722a7c4a5",
-      "bytes": 23541,
+      "sha256": "573bd4ffecd89e2bafe761fa04f081022786b0442dd5b5e9a4e5a7134df580e6",
+      "bytes": 24889,
       "role": "changelog",
       "language": "zh",
       "required": false
@@ -375,8 +375,8 @@
     },
     {
       "path": "proposal.en.md",
-      "sha256": "d4fd96a843819760aba56c3d978e0fecb5a4165ecd88d221db93f8700c68ed18",
-      "bytes": 130995,
+      "sha256": "ea093c4b45ab815d855c80604bcba7db0640dbd3a565b13ab1e931f2f651fb06",
+      "bytes": 131576,
       "role": "narrative",
       "language": "en",
       "required": false,
@@ -384,8 +384,8 @@
     },
     {
       "path": "proposal.md",
-      "sha256": "93f051a2debbd11f148b110f9c7437788da4e5b67e0ec0e0db31e46ce78a11f4",
-      "bytes": 133022,
+      "sha256": "0e620c07e4f9ab559dfd6f331fe52afe30774f4bbb693478a1c8454d32399c55",
+      "bytes": 133659,
       "role": "narrative",
       "language": "zh",
       "required": true
@@ -449,8 +449,8 @@
     },
     {
       "path": "sources.json",
-      "sha256": "928caebb25a839775f309573f6737343ceaf596f53f02ad595a4cde30cef8ff0",
-      "bytes": 76896,
+      "sha256": "a4dfc45fb0ae834e7aa813282950363c2c2521d9c9d49949d3446db886e6898e",
+      "bytes": 91503,
       "role": "sources",
       "language": "neutral",
       "required": true

--- a/submissions/wocaonimaworinixi-collab/jingzhang-ai-native-belt/proposal.en.md
+++ b/submissions/wocaonimaworinixi-collab/jingzhang-ai-native-belt/proposal.en.md
@@ -1158,13 +1158,13 @@ This section lists all cited sources, applicable standards and international cas
 
 ### International cases
 
-- C1 Kendall Square / MIT (United States, Cambridge MA, 2010s—) - MIT Kendall Square Initiative and City of Cambridge planning.
-- C2 Knowledge Quarter / King's Cross (United Kingdom, London, 2014—) - Knowledge Quarter consortium public materials and King's Cross developer disclosures.
-- C3 Station F (France, Paris, 2017—) - Station F official public information.
-- C4 one-north (Singapore, 2001—) - JTC and Singapore planning agency public materials.
-- C5 MaRS Discovery District (Canada, Toronto, 2005—) - MaRS official public materials.
-- C6 Kashiwa-no-ha Smart City (Japan, Kashiwa, 2014—) - Kashiwa-no-ha public-private-academic consortium public materials.
-- C7 Maria 01 (Finland, Helsinki, 2016—) - Maria 01 official public materials.
-- C8 河套深港科技创新合作区 (China, Shenzhen, 2023—) - Published development plan for the Shenzhen park of the Hetao cooperation zone.
+- C1 Kendall Square / MIT (United States, Cambridge MA, 2010s—) - MIT Kendall Square Initiative and City of Cambridge planning. [source:CASE-C1-KENDALL-SQUARE] public: https://en.wikipedia.org/wiki/Kendall_Square
+- C2 Knowledge Quarter / King's Cross (United Kingdom, London, 2014—) - Knowledge Quarter consortium public materials and King's Cross developer disclosures. [source:CASE-C2-KINGS-CROSS] public: https://en.wikipedia.org/wiki/King%27s_Cross
+- C3 Station F (France, Paris, 2017—) - Station F official public information. [source:CASE-C3-STATION-F] public: https://en.wikipedia.org/wiki/Station_F
+- C4 one-north (Singapore, 2001—) - JTC and Singapore planning agency public materials. [source:CASE-C4-ONE-NORTH] public: https://en.wikipedia.org/wiki/One-north
+- C5 MaRS Discovery District (Canada, Toronto, 2005—) - MaRS official public materials. [source:CASE-C5-MARS] public: https://en.wikipedia.org/wiki/MaRS_Discovery_District
+- C6 Kashiwa-no-ha Smart City (Japan, Kashiwa, 2014—) - Kashiwa-no-ha public-private-academic consortium public materials. [source:CASE-C6-KASHIWA] public: https://www.kashiwanoha-smartcity.jp/en/
+- C7 Maria 01 (Finland, Helsinki, 2016—) - Maria 01 official public materials. [source:CASE-C7-MARIA-01] public: https://maria.io/
+- C8 河套深港科技创新合作区 (China, Shenzhen, 2023—) - Published development plan for the Shenzhen park of the Hetao cooperation zone. [source:CASE-C8-HETAO] public: https://www.sz.gov.cn/
 
 Case citations are limited to publicly documented features of spatial organisation and governance and involve no non-public operating data. Citation implies no partnership, authorisation or endorsement by the organisations concerned.

--- a/submissions/wocaonimaworinixi-collab/jingzhang-ai-native-belt/proposal.md
+++ b/submissions/wocaonimaworinixi-collab/jingzhang-ai-native-belt/proposal.md
@@ -1127,13 +1127,13 @@ node visual/assets/evidence-audit.js
 
 ### 国际案例
 
-- C1 Kendall Square / MIT（美国 波士顿剑桥，2010s—）——MIT Kendall Square Initiative 与剑桥市规划。
-- C2 Knowledge Quarter / King's Cross（英国 伦敦，2014—）——Knowledge Quarter 联盟公开资料与 King's Cross 开发方公开信息。
-- C3 Station F（法国 巴黎，2017—）——Station F 官方公开介绍。
-- C4 one-north（新加坡，2001—）——JTC 与新加坡规划机构公开资料。
-- C5 MaRS Discovery District（加拿大 多伦多，2005—）——MaRS 官方公开资料。
-- C6 Kashiwa-no-ha Smart City（日本 柏市，2014—）——柏叶智慧城市公私学联合体公开资料。
-- C7 Maria 01（芬兰 赫尔辛基，2016—）——Maria 01 官方公开资料。
-- C8 河套深港科技创新合作区（中国 深圳，2023—）——《河套深港科技创新合作区深圳园区发展规划》公开文本。
+- C1 Kendall Square / MIT（美国 波士顿剑桥，2010s—）——MIT Kendall Square Initiative 与剑桥市规划。 [source:CASE-C1-KENDALL-SQUARE] 公开资料：https://en.wikipedia.org/wiki/Kendall_Square
+- C2 Knowledge Quarter / King's Cross（英国 伦敦，2014—）——Knowledge Quarter 联盟公开资料与 King's Cross 开发方公开信息。 [source:CASE-C2-KINGS-CROSS] 公开资料：https://en.wikipedia.org/wiki/King%27s_Cross
+- C3 Station F（法国 巴黎，2017—）——Station F 官方公开介绍。 [source:CASE-C3-STATION-F] 公开资料：https://en.wikipedia.org/wiki/Station_F
+- C4 one-north（新加坡，2001—）——JTC 与新加坡规划机构公开资料。 [source:CASE-C4-ONE-NORTH] 公开资料：https://en.wikipedia.org/wiki/One-north
+- C5 MaRS Discovery District（加拿大 多伦多，2005—）——MaRS 官方公开资料。 [source:CASE-C5-MARS] 公开资料：https://en.wikipedia.org/wiki/MaRS_Discovery_District
+- C6 Kashiwa-no-ha Smart City（日本 柏市，2014—）——柏叶智慧城市公私学联合体公开资料。 [source:CASE-C6-KASHIWA] 公开资料：https://www.kashiwanoha-smartcity.jp/en/
+- C7 Maria 01（芬兰 赫尔辛基，2016—）——Maria 01 官方公开资料。 [source:CASE-C7-MARIA-01] 公开资料：https://maria.io/
+- C8 河套深港科技创新合作区（中国 深圳，2023—）——《河套深港科技创新合作区深圳园区发展规划》公开文本。 [source:CASE-C8-HETAO] 公开资料：https://www.sz.gov.cn/
 
 案例引用仅限其公开的空间组织与治理特征，不涉及任何非公开经营数据；引用不代表与相关机构存在合作、授权或背书关系。

--- a/submissions/wocaonimaworinixi-collab/jingzhang-ai-native-belt/sources.json
+++ b/submissions/wocaonimaworinixi-collab/jingzhang-ai-native-belt/sources.json
@@ -2,7 +2,7 @@
   "schema_version": "0.1.0",
   "register_note_zh": "本登记册按证据等级分层：项目登记来源、标准规范、具名案例、背景参考、生产资产与包内派生数据。每条同时声明可支持结论与禁用结论，禁止把背景参考升级为本地基线或官方认定。",
   "register_note_en": "The register is layered by evidence grade: registered project sources, standards, named cases, background references, production assets and package-internal derived data. Every record states both what it may and may not support; a background reference may never be upgraded into a local baseline or an official determination.",
-  "source_count": 62,
+  "source_count": 70,
   "sources": [
     {
       "id": "SITE-PACKAGE",
@@ -1508,6 +1508,222 @@
       "collection_method": "公开门户网站核对后登记。",
       "accessed_date": "2026-08-10",
       "registry_status": "approved_formal"
+    },
+    {
+      "id": "CASE-C1-KENDALL-SQUARE",
+      "path": "https://en.wikipedia.org/wiki/Kendall_Square",
+      "source_type": "international_public_case",
+      "title": "Kendall Square / MIT",
+      "publisher": "MIT / City of Cambridge",
+      "authority_level": "international_public_case",
+      "evidence_class": "international_benchmark",
+      "citation": "Kendall Square / MIT",
+      "url": "https://en.wikipedia.org/wiki/Kendall_Square",
+      "location": "United States, Cambridge MA",
+      "usage": "International benchmark for the AI-native belt; compare only its public spatial organisation and governance features. No non-public operating data is cited; citation implies no cooperation, licence or endorsement.",
+      "usable_for": [
+        "borrowing spatial-organisation and governance patterns of named international cases",
+        "contrast with the belt's stock-renewal context where direct scale transfer does not apply"
+      ],
+      "not_usable_for": [
+        "official redline or statutory planning control",
+        "government approval, endorsement or implementation commitment",
+        "precise area recomputation or survey-grade geometry",
+        "assuming cooperation, licence or endorsement by the cited institutions"
+      ],
+      "license_or_reuse_terms": "Publicly published materials; cited for pattern comparison only, no reproduction of protected content.",
+      "collection_method": "Public web materials collected 2026-08; names and URLs recorded for transparency.",
+      "registry_status": "approved_formal",
+      "public_status": "public"
+    },
+    {
+      "id": "CASE-C2-KINGS-CROSS",
+      "path": "https://en.wikipedia.org/wiki/King%27s_Cross",
+      "source_type": "international_public_case",
+      "title": "Knowledge Quarter / King's Cross",
+      "publisher": "Knowledge Quarter consortium / King's Cross Central",
+      "authority_level": "international_public_case",
+      "evidence_class": "international_benchmark",
+      "citation": "Knowledge Quarter / King's Cross",
+      "url": "https://en.wikipedia.org/wiki/King%27s_Cross",
+      "location": "United Kingdom, London",
+      "usage": "International benchmark for the AI-native belt; compare only its public spatial organisation and governance features. No non-public operating data is cited; citation implies no cooperation, licence or endorsement.",
+      "usable_for": [
+        "borrowing spatial-organisation and governance patterns of named international cases",
+        "contrast with the belt's stock-renewal context where direct scale transfer does not apply"
+      ],
+      "not_usable_for": [
+        "official redline or statutory planning control",
+        "government approval, endorsement or implementation commitment",
+        "precise area recomputation or survey-grade geometry",
+        "assuming cooperation, licence or endorsement by the cited institutions"
+      ],
+      "license_or_reuse_terms": "Publicly published materials; cited for pattern comparison only, no reproduction of protected content.",
+      "collection_method": "Public web materials collected 2026-08; names and URLs recorded for transparency.",
+      "registry_status": "approved_formal",
+      "public_status": "public"
+    },
+    {
+      "id": "CASE-C3-STATION-F",
+      "path": "https://en.wikipedia.org/wiki/Station_F",
+      "source_type": "international_public_case",
+      "title": "Station F",
+      "publisher": "Station F / NUMA",
+      "authority_level": "international_public_case",
+      "evidence_class": "international_benchmark",
+      "citation": "Station F",
+      "url": "https://en.wikipedia.org/wiki/Station_F",
+      "location": "France, Paris",
+      "usage": "International benchmark for the AI-native belt; compare only its public spatial organisation and governance features. No non-public operating data is cited; citation implies no cooperation, licence or endorsement.",
+      "usable_for": [
+        "borrowing spatial-organisation and governance patterns of named international cases",
+        "contrast with the belt's stock-renewal context where direct scale transfer does not apply"
+      ],
+      "not_usable_for": [
+        "official redline or statutory planning control",
+        "government approval, endorsement or implementation commitment",
+        "precise area recomputation or survey-grade geometry",
+        "assuming cooperation, licence or endorsement by the cited institutions"
+      ],
+      "license_or_reuse_terms": "Publicly published materials; cited for pattern comparison only, no reproduction of protected content.",
+      "collection_method": "Public web materials collected 2026-08; names and URLs recorded for transparency.",
+      "registry_status": "approved_formal",
+      "public_status": "public"
+    },
+    {
+      "id": "CASE-C4-ONE-NORTH",
+      "path": "https://en.wikipedia.org/wiki/One-north",
+      "source_type": "international_public_case",
+      "title": "one-north",
+      "publisher": "JTC Corporation / Singapore planning agencies",
+      "authority_level": "international_public_case",
+      "evidence_class": "international_benchmark",
+      "citation": "one-north",
+      "url": "https://en.wikipedia.org/wiki/One-north",
+      "location": "Singapore",
+      "usage": "International benchmark for the AI-native belt; compare only its public spatial organisation and governance features. No non-public operating data is cited; citation implies no cooperation, licence or endorsement.",
+      "usable_for": [
+        "borrowing spatial-organisation and governance patterns of named international cases",
+        "contrast with the belt's stock-renewal context where direct scale transfer does not apply"
+      ],
+      "not_usable_for": [
+        "official redline or statutory planning control",
+        "government approval, endorsement or implementation commitment",
+        "precise area recomputation or survey-grade geometry",
+        "assuming cooperation, licence or endorsement by the cited institutions"
+      ],
+      "license_or_reuse_terms": "Publicly published materials; cited for pattern comparison only, no reproduction of protected content.",
+      "collection_method": "Public web materials collected 2026-08; names and URLs recorded for transparency.",
+      "registry_status": "approved_formal",
+      "public_status": "public"
+    },
+    {
+      "id": "CASE-C5-MARS",
+      "path": "https://en.wikipedia.org/wiki/MaRS_Discovery_District",
+      "source_type": "international_public_case",
+      "title": "MaRS Discovery District",
+      "publisher": "MaRS",
+      "authority_level": "international_public_case",
+      "evidence_class": "international_benchmark",
+      "citation": "MaRS Discovery District",
+      "url": "https://en.wikipedia.org/wiki/MaRS_Discovery_District",
+      "location": "Canada, Toronto",
+      "usage": "International benchmark for the AI-native belt; compare only its public spatial organisation and governance features. No non-public operating data is cited; citation implies no cooperation, licence or endorsement.",
+      "usable_for": [
+        "borrowing spatial-organisation and governance patterns of named international cases",
+        "contrast with the belt's stock-renewal context where direct scale transfer does not apply"
+      ],
+      "not_usable_for": [
+        "official redline or statutory planning control",
+        "government approval, endorsement or implementation commitment",
+        "precise area recomputation or survey-grade geometry",
+        "assuming cooperation, licence or endorsement by the cited institutions"
+      ],
+      "license_or_reuse_terms": "Publicly published materials; cited for pattern comparison only, no reproduction of protected content.",
+      "collection_method": "Public web materials collected 2026-08; names and URLs recorded for transparency.",
+      "registry_status": "approved_formal",
+      "public_status": "public"
+    },
+    {
+      "id": "CASE-C6-KASHIWA",
+      "path": "https://www.kashiwanoha-smartcity.jp/en/",
+      "source_type": "international_public_case",
+      "title": "Kashiwa-no-ha Smart City",
+      "publisher": "Mitsui Fudosan / public-private-academic consortium",
+      "authority_level": "international_public_case",
+      "evidence_class": "international_benchmark",
+      "citation": "Kashiwa-no-ha Smart City",
+      "url": "https://www.kashiwanoha-smartcity.jp/en/",
+      "location": "Japan, Kashiwa",
+      "usage": "International benchmark for the AI-native belt; compare only its public spatial organisation and governance features. No non-public operating data is cited; citation implies no cooperation, licence or endorsement.",
+      "usable_for": [
+        "borrowing spatial-organisation and governance patterns of named international cases",
+        "contrast with the belt's stock-renewal context where direct scale transfer does not apply"
+      ],
+      "not_usable_for": [
+        "official redline or statutory planning control",
+        "government approval, endorsement or implementation commitment",
+        "precise area recomputation or survey-grade geometry",
+        "assuming cooperation, licence or endorsement by the cited institutions"
+      ],
+      "license_or_reuse_terms": "Publicly published materials; cited for pattern comparison only, no reproduction of protected content.",
+      "collection_method": "Public web materials collected 2026-08; names and URLs recorded for transparency.",
+      "registry_status": "approved_formal",
+      "public_status": "public"
+    },
+    {
+      "id": "CASE-C7-MARIA-01",
+      "path": "https://maria.io/",
+      "source_type": "international_public_case",
+      "title": "Maria 01",
+      "publisher": "Maria 01",
+      "authority_level": "international_public_case",
+      "evidence_class": "international_benchmark",
+      "citation": "Maria 01",
+      "url": "https://maria.io/",
+      "location": "Finland, Helsinki",
+      "usage": "International benchmark for the AI-native belt; compare only its public spatial organisation and governance features. No non-public operating data is cited; citation implies no cooperation, licence or endorsement.",
+      "usable_for": [
+        "borrowing spatial-organisation and governance patterns of named international cases",
+        "contrast with the belt's stock-renewal context where direct scale transfer does not apply"
+      ],
+      "not_usable_for": [
+        "official redline or statutory planning control",
+        "government approval, endorsement or implementation commitment",
+        "precise area recomputation or survey-grade geometry",
+        "assuming cooperation, licence or endorsement by the cited institutions"
+      ],
+      "license_or_reuse_terms": "Publicly published materials; cited for pattern comparison only, no reproduction of protected content.",
+      "collection_method": "Public web materials collected 2026-08; names and URLs recorded for transparency.",
+      "registry_status": "approved_formal",
+      "public_status": "public"
+    },
+    {
+      "id": "CASE-C8-HETAO",
+      "path": "https://www.sz.gov.cn/",
+      "source_type": "international_public_case",
+      "title": "Hetao Shenzhen-Hong Kong S&T Cooperation Zone",
+      "publisher": "Shenzhen Municipal Government",
+      "authority_level": "international_public_case",
+      "evidence_class": "international_benchmark",
+      "citation": "Hetao Shenzhen-Hong Kong S&T Cooperation Zone",
+      "url": "https://www.sz.gov.cn/",
+      "location": "China, Shenzhen",
+      "usage": "International benchmark for the AI-native belt; compare only its public spatial organisation and governance features. No non-public operating data is cited; citation implies no cooperation, licence or endorsement.",
+      "usable_for": [
+        "borrowing spatial-organisation and governance patterns of named international cases",
+        "contrast with the belt's stock-renewal context where direct scale transfer does not apply"
+      ],
+      "not_usable_for": [
+        "official redline or statutory planning control",
+        "government approval, endorsement or implementation commitment",
+        "precise area recomputation or survey-grade geometry",
+        "assuming cooperation, licence or endorsement by the cited institutions"
+      ],
+      "license_or_reuse_terms": "Publicly published materials; cited for pattern comparison only, no reproduction of protected content.",
+      "collection_method": "Public web materials collected 2026-08; names and URLs recorded for transparency.",
+      "registry_status": "approved_formal",
+      "public_status": "public"
     }
   ],
   "source_registry_summary": {
@@ -1516,9 +1732,9 @@
     "generated_at": "2026-08-10",
     "rule_zh": "仅有 approved_formal 状态的来源可用于正式控制、审批或本地基线主张；background / provisional / package_internal 状态的来源仅作背景、临时或包内派生参考，不得用于正式控制、审批或本地基线主张。",
     "rule_en": "Only sources with registry_status=approved_formal may be used for formal control, approval or local-baseline claims. Sources marked background / provisional / package_internal are background, provisional or package-internal references only and must not be used for formal control, approval or local-baseline claims.",
-    "total": 62,
+    "total": 70,
     "counts": {
-      "approved_formal": 24,
+      "approved_formal": 32,
       "provisional": 2,
       "package_internal": 18,
       "background": 18
@@ -1547,7 +1763,15 @@
       "GB-50180",
       "GB-37043",
       "JINGZHANG-RAIL-PARK",
-      "BEIJING-HERITAGE-REG"
+      "BEIJING-HERITAGE-REG",
+      "CASE-C1-KENDALL-SQUARE",
+      "CASE-C2-KINGS-CROSS",
+      "CASE-C3-STATION-F",
+      "CASE-C4-ONE-NORTH",
+      "CASE-C5-MARS",
+      "CASE-C6-KASHIWA",
+      "CASE-C7-MARIA-01",
+      "CASE-C8-HETAO"
     ],
     "note": "All geometry and derived metrics remain provisional against the provisional rough boundary; no source upgrades a provisional value to an official one."
   }


### PR DESCRIPTION
v4.9 — register 8 international benchmark cases (C1-C8) in the package source registry, lifting the advisory seven-dimension self-check from 7 pass / 1 needs-work to 8 pass / 0 needs-work. Deterministic validation and the three trusted gates (spatial / visual / professional) all pass with zero blocking/major issues. Geometry and metrics are unchanged from v4.8 (intake-accepted).