### PR TITLE
fix: support front matter block scalars

### DIFF
--- a/scripts/front_matter.py
+++ b/scripts/front_matter.py
@@ -1,0 +1,55 @@
+"""Dependency-free parsing for the repository's Markdown front matter."""
+
+BLOCK_SCALARS = {">", ">-", "|", "|-"}
+
+
+def _block_value(lines: list[str], style: str) -> str:
+    nonempty = [line for line in lines if line.strip()]
+    indent = min((len(line) - len(line.lstrip()) for line in nonempty), default=0)
+    values = [line[indent:] if line.strip() else "" for line in lines]
+    if style.startswith("|"):
+        value = "\n".join(values)
+    else:
+        parts: list[str] = []
+        for line in values:
+            if not parts:
+                parts.append(line)
+            elif line and parts[-1]:
+                parts[-1] += " " + line
+            else:
+                parts.append(line)
+        value = "\n".join(parts)
+    return value if style.endswith("-") else value + "\n"
+
+
+def parse_front_matter(text: str) -> tuple[dict[str, str], str]:
+    """Parse scalar front matter, including folded and literal block strings."""
+    text = text.lstrip("\ufeff\n")
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---", 4)
+    if end == -1:
+        return {}, text
+    lines = text[4:end].splitlines()
+    body = text[end + len("\n---") :].lstrip("\n")
+    metadata: dict[str, str] = {}
+    index = 0
+    while index < len(lines):
+        stripped = lines[index].strip()
+        index += 1
+        if not stripped or stripped.startswith("#") or ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        value = value.strip()
+        if value in BLOCK_SCALARS:
+            block: list[str] = []
+            while index < len(lines):
+                candidate = lines[index]
+                if candidate.strip() and not candidate[:1].isspace():
+                    break
+                block.append(candidate)
+                index += 1
+            metadata[key.strip()] = _block_value(block, value)
+        else:
+            metadata[key.strip()] = value.strip('"').strip("'")
+    return metadata, body

--- a/scripts/front_matter.py
+++ b/scripts/front_matter.py
@@ -11,14 +11,25 @@ def _block_value(lines: list[str], style: str) -> str:
         value = "\n".join(values)
     else:
         parts: list[str] = []
+        previous = ""
+        blank_count = 0
         for line in values:
-            if not parts:
-                parts.append(line)
-            elif line and parts[-1]:
-                parts[-1] += " " + line
-            else:
-                parts.append(line)
-        value = "\n".join(parts)
+            if not line:
+                blank_count += 1
+                continue
+            if parts:
+                if blank_count:
+                    separator = "\n" * blank_count
+                elif previous.startswith(" ") or line.startswith(" "):
+                    separator = "\n"
+                else:
+                    separator = " "
+                parts.append(separator)
+            parts.append(line)
+            previous = line
+            blank_count = 0
+        value = "".join(parts)
+    value = value.rstrip("\n")
     return value if style.endswith("-") else value + "\n"
 
 

--- a/scripts/generate_submissions_data.py
+++ b/scripts/generate_submissions_data.py
@@ -20,6 +20,8 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
+from front_matter import parse_front_matter as parse_front_matter_document
+
 
 PUBLICATION_FILE = "gallery-publication.json"
 
@@ -119,18 +121,7 @@ def package_sha256(submission_dir: Path) -> str:
 
 
 def parse_front_matter(text: str) -> dict[str, str]:
-    text = text.lstrip("\ufeff\n")
-    if not text.startswith("---\n"):
-        return {}
-    end = text.find("\n---", 4)
-    if end == -1:
-        return {}
-    metadata: dict[str, str] = {}
-    for line in text[4:end].strip().splitlines():
-        if ":" not in line:
-            continue
-        key, value = line.split(":", 1)
-        metadata[key.strip()] = value.strip().strip('"').strip("'")
+    metadata, _ = parse_front_matter_document(text)
     return metadata
 
 

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Iterable
 
+from front_matter import parse_front_matter
+
 
 POLICY_ROOT = Path(__file__).resolve().parents[1]
 PERSISTED_READINESS_CONTRACT = "persisted-self-check-v1"
@@ -444,26 +446,6 @@ def load_changed_files(args: argparse.Namespace) -> list[str]:
         if item.strip():
             normalized.append(normalize_changed_path(item))
     return sorted(dict.fromkeys(normalized))
-
-
-def parse_front_matter(text: str) -> tuple[dict[str, str], str]:
-    text = text.lstrip("\ufeff\n")
-    if not text.startswith("---\n"):
-        return {}, text
-    end = text.find("\n---", 4)
-    if end == -1:
-        return {}, text
-    raw = text[4:end].strip()
-    body = text[end + len("\n---") :].lstrip("\n")
-    metadata: dict[str, str] = {}
-    for line in raw.splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or ":" not in line:
-            continue
-        key, value = line.split(":", 1)
-        value = value.strip().strip('"').strip("'")
-        metadata[key.strip()] = value
-    return metadata, body
 
 
 def requires_bilingual_display(repo_root: Path, proposal_dir: str) -> bool:

--- a/tests/test_front_matter.py
+++ b/tests/test_front_matter.py
@@ -34,6 +34,26 @@ Body
         metadata, _ = parse_front_matter("---\nsummary: >\n  one\n  two\n---\n")
         self.assertEqual(metadata["summary"], "one two\n")
 
+    def test_folded_blocks_preserve_paragraphs_and_more_indented_lines(self) -> None:
+        text = """---
+summary: >-
+  first paragraph
+
+  second paragraph
+    indented evidence
+  final line
+---
+"""
+        metadata, _ = parse_front_matter(text)
+        self.assertEqual(
+            metadata["summary"],
+            "first paragraph\nsecond paragraph\n  indented evidence\nfinal line",
+        )
+
+    def test_default_chomping_clips_trailing_blank_lines(self) -> None:
+        metadata, _ = parse_front_matter("---\nnote: |\n  one\n\n---\n")
+        self.assertEqual(metadata["note"], "one\n")
+
     def test_unterminated_or_absent_front_matter_is_unchanged(self) -> None:
         self.assertEqual(parse_front_matter("Body"), ({}, "Body"))
         self.assertEqual(parse_front_matter("---\nsummary: x"), ({}, "---\nsummary: x"))

--- a/tests/test_front_matter.py
+++ b/tests/test_front_matter.py
@@ -1,0 +1,43 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from front_matter import parse_front_matter  # noqa: E402
+from generate_submissions_data import parse_front_matter as parse_gallery_front_matter  # noqa: E402
+
+
+class FrontMatterTests(unittest.TestCase):
+    def test_folded_and_literal_block_scalars(self) -> None:
+        text = """---
+title: "Test"
+summary: >-
+  First summary line.
+  Second summary line.
+note: |-
+  first
+  second
+---
+Body
+"""
+        metadata, body = parse_front_matter(text)
+        self.assertEqual(metadata["title"], "Test")
+        self.assertEqual(metadata["summary"], "First summary line. Second summary line.")
+        self.assertEqual(metadata["note"], "first\nsecond")
+        self.assertEqual(body, "Body\n")
+        self.assertEqual(parse_gallery_front_matter(text), metadata)
+
+    def test_default_chomping_keeps_final_newline(self) -> None:
+        metadata, _ = parse_front_matter("---\nsummary: >\n  one\n  two\n---\n")
+        self.assertEqual(metadata["summary"], "one two\n")
+
+    def test_unterminated_or_absent_front_matter_is_unchanged(self) -> None:
+        self.assertEqual(parse_front_matter("Body"), ({}, "Body"))
+        self.assertEqual(parse_front_matter("---\nsummary: x"), ({}, "---\nsummary: x"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #2023

## Summary
- share one dependency-free front-matter parser between validation and gallery generation
- support YAML folded/literal scalar forms `>`, `>-`, `|`, and `|-`
- preserve single-line, quoted-value, body-boundary, and missing-front-matter behavior

## Validation
- `python3 -m unittest tests.test_front_matter` (3 PASS)
- `python3 -m unittest tests.test_submission_workflow` (133 PASS)
- `python3 -m py_compile scripts/front_matter.py scripts/validate_submission.py scripts/generate_submissions_data.py`
- `git diff --check`