### PR TITLE
fix: preserve generated data on invalid registry

### DIFF
--- a/scripts/generate_source_registry_data.py
+++ b/scripts/generate_source_registry_data.py
@@ -17,6 +17,12 @@ DEFAULT_OUTPUT = "source-registry-data.js"
 
 def build_frontend_data(repo_root: Path) -> dict[str, Any]:
     registry = load_source_registry(repo_root)
+    registry_error = registry.get("_error")
+    if registry_error:
+        raise ValueError(f"invalid source registry: {registry_error}")
+    sources = registry.get("sources")
+    if not isinstance(sources, list) or not sources:
+        raise ValueError("source registry must contain a non-empty sources array")
     summary = summarize_source_registry(registry, limit=20)
     return {
         "updatedDate": summary.get("updated_date"),
@@ -50,7 +56,11 @@ def main() -> int:
     out_path = Path(args.out)
     if not out_path.is_absolute():
         out_path = repo_root / out_path
-    content = render_js(build_frontend_data(repo_root))
+    try:
+        content = render_js(build_frontend_data(repo_root))
+    except ValueError as exc:
+        print(f"{repo_root / 'data' / 'source_registry.json'}: {exc}", file=sys.stderr)
+        return 1
     if args.check:
         if not out_path.exists():
             print(f"{out_path}: missing generated source registry data", file=sys.stderr)

--- a/tests/test_source_registry_frontend.py
+++ b/tests/test_source_registry_frontend.py
@@ -4,6 +4,7 @@ import json
 import re
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -29,6 +30,42 @@ class SourceRegistryFrontendTests(unittest.TestCase):
             check=False,
         )
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+
+    def test_invalid_registry_does_not_replace_generated_data(self) -> None:
+        invalid_registries = {
+            "missing": None,
+            "malformed": "{broken\n",
+            "empty_sources": '{"sources": []}\n',
+        }
+        for label, registry_text in invalid_registries.items():
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                output = root / "source-registry-data.js"
+                original = b"existing generated data\n"
+                output.write_bytes(original)
+                if registry_text is not None:
+                    registry_path = root / "data" / "source_registry.json"
+                    registry_path.parent.mkdir(parents=True)
+                    registry_path.write_text(registry_text, encoding="utf-8")
+
+                completed = subprocess.run(
+                    [
+                        sys.executable,
+                        str(ROOT / "scripts" / "generate_source_registry_data.py"),
+                        "--repo-root",
+                        str(root),
+                        "--out",
+                        str(output),
+                    ],
+                    cwd=ROOT,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+
+                self.assertNotEqual(completed.returncode, 0)
+                self.assertEqual(output.read_bytes(), original)
+                self.assertIn("source registry", completed.stderr)
 
     def test_source_registry_frontend_data_shape(self) -> None:
         data = self.load_data()


### PR DESCRIPTION
## Summary

Prevent source-registry frontend generation from silently replacing valid generated data with an empty registry when the source JSON is missing, malformed, or structurally empty.

## Reproduction

On current `main`, create a malformed `data/source_registry.json` and an existing `source-registry-data.js`, then run:

```bash
python3 scripts/generate_source_registry_data.py \
  --repo-root "$TMP" \
  --out source-registry-data.js
```

The command exits 0 and replaces the existing output with `total: 0` and empty source arrays. This turns an invalid source of truth into apparently valid generated output.

## Root cause

`load_source_registry()` represents missing or malformed input as an empty/error object, while the generator passed that value directly to `summarize_source_registry()`. The summary helper intentionally tolerates absent data, so the write path could not distinguish invalid input from an empty registry.

## Change

- Require a non-error registry with a non-empty `sources` array before rendering.
- Report invalid input and return nonzero before reading or writing the output path.
- Add subprocess regressions for missing JSON, malformed JSON, and an empty sources array; each case verifies the existing generated file remains byte-for-byte unchanged.

The validation is scoped to the generator, so tolerant summary consumers keep their current behavior.

## Verification

```bash
python3 -m unittest tests.test_source_registry_frontend tests.test_data_registry -v
python3 -m py_compile scripts/generate_source_registry_data.py
git diff --check origin/main...HEAD
```

Result: 9 tests passed; compile and diff checks passed.
