### PR TITLE
fix: isolate malformed proposal image URLs

### DIFF
--- a/proposal-view.html
+++ b/proposal-view.html
@@ -442,9 +442,11 @@ function sanitizeReport(root,reportUrl){
   });
   root.querySelectorAll('img').forEach(img=>{
     const raw=img.getAttribute('src')||'';
-    const resolved=new URL(raw,reportUrl);
-    if(resolved.origin!==location.origin||!resolved.pathname.includes(`/${state.packagePath}/`)){img.remove();return}
-    img.src=resolved.href;img.loading='lazy';
+    const resolved=safeHttpUrl(raw,reportUrl);
+    if(!resolved){img.remove();return}
+    const url=new URL(resolved);
+    if(url.origin!==location.origin||!url.pathname.includes(`/${state.packagePath}/`)){img.remove();return}
+    img.src=url.href;img.loading='lazy';
   });
   root.querySelectorAll('a[href]').forEach(link=>{
     const raw=link.getAttribute('href')||'';

--- a/tests/test_proposal_view_sanitizer.py
+++ b/tests/test_proposal_view_sanitizer.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VIEWER = ROOT / "proposal-view.html"
+
+
+class ProposalViewSanitizerTests(unittest.TestCase):
+    def test_malformed_image_url_is_removed_without_aborting_report(self) -> None:
+        script = r"""
+const fs = require('fs');
+const source = fs.readFileSync(process.argv[1], 'utf8');
+function extract(name, next) {
+  return source.slice(source.indexOf(`function ${name}`), source.indexOf(`function ${next}`));
+}
+global.location = {
+  href: 'https://example.test/proposal-view.html',
+  origin: 'https://example.test'
+};
+global.state = {packagePath: 'submissions/alice/demo'};
+eval(extract('safeHttpUrl', 'validPackagePath'));
+eval(extract('sanitizeReport', 'buildMaps'));
+
+function image(src) {
+  return {
+    src,
+    loading: '',
+    removed: false,
+    getAttribute: () => src,
+    remove() { this.removed = true; }
+  };
+}
+const malformed = image('https://[');
+const valid = image('../assets/figures/site.png');
+const root = {
+  querySelectorAll(selector) {
+    if (selector === 'img') return [malformed, valid];
+    return [];
+  }
+};
+
+sanitizeReport(root, 'https://example.test/submissions/alice/demo/report/proposal.html');
+if (!malformed.removed) throw new Error('malformed image was retained');
+if (valid.removed) throw new Error('valid package image was removed');
+if (valid.src !== 'https://example.test/submissions/alice/demo/assets/figures/site.png') {
+  throw new Error(`valid image resolved incorrectly: ${valid.src}`);
+}
+if (valid.loading !== 'lazy') throw new Error('valid image was not made lazy');
+"""
+        completed = subprocess.run(
+            ["node", "-e", script, str(VIEWER)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Keep the proposal report viewer usable when one embedded image has a malformed URL.

## Reproduction

`sanitizeReport()` resolves every report image with `new URL(raw, reportUrl)`. A malformed source such as `https://[` throws `TypeError: Invalid URL`, escapes the per-image loop, and rejects the entire `load()` operation. The viewer then replaces otherwise valid proposal content with its global “方案没有完整载入” error.

This differs from report links, which already use the fail-closed `safeHttpUrl()` helper.

## Change

- Parse image sources through `safeHttpUrl()` before package-boundary checks.
- Remove only the malformed image and continue sanitizing the report.
- Preserve the existing same-origin and proposal-directory containment checks.
- Add a Node-backed regression that executes the functions extracted from the real page and verifies both malformed-image isolation and valid package-image resolution.

## Verification

```bash
python3 -m unittest \
  tests.test_proposal_view_sanitizer \
  tests.test_submissions_gallery.TestSubmissionsGallery.test_human_readable_report_viewer_loads_structured_evidence \
  -v
python3 -m py_compile tests/test_proposal_view_sanitizer.py
git diff --check origin/main...HEAD
```

Result: 2 focused tests passed; compile and diff checks passed.

The full `tests.test_submissions_gallery` run currently has four unrelated baseline failures because checked-in `submissions-data.js` contains 309 entries while current `main` has 420 merged submission directories. This PR does not modify generated gallery data.
