### PR TITLE
fix: tolerate invalid stored frontend language

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -445,7 +445,19 @@ const T = {
   }
 };
 
-let lang = localStorage.getItem('lang') || (navigator.language.startsWith('zh') ? 'zh' : 'en');
+function normalizeLanguage(value) {
+  if (value === 'zh' || value === 'en') return value;
+  return String(navigator.language || '').startsWith('zh') ? 'zh' : 'en';
+}
+function storedLanguage() {
+  try { return normalizeLanguage(localStorage.getItem('lang')); }
+  catch { return normalizeLanguage(); }
+}
+function rememberLanguage(value) {
+  try { localStorage.setItem('lang', value); }
+  catch {}
+}
+let lang = storedLanguage();
 function esc(value) {
   return String(value == null ? '' : value).replace(/[&<>"']/g, ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
 }
@@ -498,7 +510,8 @@ function renderSourceRegistry() {
   list.innerHTML = cards ? `${cards}<p style="margin-top:12px">${esc(T[lang]['registry.limit'])}</p>` : `<p>${esc(T[lang]['registry.empty'])}</p>`;
 }
 function applyLang(l) {
-  lang = l; localStorage.setItem('lang', l);
+  l = normalizeLanguage(l);
+  lang = l; rememberLanguage(l);
   document.documentElement.lang = l === 'zh' ? 'zh-CN' : 'en';
   document.title = T[l]['page.title'];
   document.getElementById('langToggle').textContent = T[l]['lang.toggle'];

--- a/brief.html
+++ b/brief.html
@@ -387,9 +387,22 @@ const T = {
   }
 };
 
-let lang = localStorage.getItem('lang') || (navigator.language.startsWith('zh') ? 'zh' : 'en');
+function normalizeLanguage(value) {
+  if (value === 'zh' || value === 'en') return value;
+  return String(navigator.language || '').startsWith('zh') ? 'zh' : 'en';
+}
+function storedLanguage() {
+  try { return normalizeLanguage(localStorage.getItem('lang')); }
+  catch { return normalizeLanguage(); }
+}
+function rememberLanguage(value) {
+  try { localStorage.setItem('lang', value); }
+  catch {}
+}
+let lang = storedLanguage();
 function applyLang(l) {
-  lang = l; localStorage.setItem('lang', l);
+  l = normalizeLanguage(l);
+  lang = l; rememberLanguage(l);
   document.documentElement.lang = l === 'zh' ? 'zh-CN' : 'en';
   document.title = T[l]['page.title'];
   document.getElementById('langToggle').textContent = T[l]['lang.toggle'];

--- a/review.html
+++ b/review.html
@@ -362,9 +362,22 @@ const T = {
     'f1':'← Back to Home','f2':'Public Brief','f3':'Submissions','f4':'View on GitHub','f.note':'Advisory only · Not required CI',
   }
 };
-let lang = localStorage.getItem('lang') || (navigator.language.startsWith('zh') ? 'zh' : 'en');
+function normalizeLanguage(value) {
+  if (value === 'zh' || value === 'en') return value;
+  return String(navigator.language || '').startsWith('zh') ? 'zh' : 'en';
+}
+function storedLanguage() {
+  try { return normalizeLanguage(localStorage.getItem('lang')); }
+  catch { return normalizeLanguage(); }
+}
+function rememberLanguage(value) {
+  try { localStorage.setItem('lang', value); }
+  catch {}
+}
+let lang = storedLanguage();
 function applyLang(l) {
-  lang = l; localStorage.setItem('lang', l);
+  l = normalizeLanguage(l);
+  lang = l; rememberLanguage(l);
   document.documentElement.lang = l === 'zh' ? 'zh-CN' : 'en';
   document.title = T[l]['page.title'];
   document.getElementById('langToggle').textContent = T[l]['lang.toggle'];

--- a/tests/test_frontend_language_storage.py
+++ b/tests/test_frontend_language_storage.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGES = ("agent.html", "brief.html", "review.html")
+
+NODE_RUNNER = r"""
+const payload = JSON.parse(process.argv[1]);
+const elements = new Map();
+function element(id) {
+  if (!elements.has(id)) {
+    elements.set(id, {
+      id,
+      textContent: '',
+      innerHTML: '',
+      style: {},
+      dataset: {},
+      addEventListener() {},
+    });
+  }
+  return elements.get(id);
+}
+globalThis.window = globalThis;
+window.HAIDIAN_SOURCE_REGISTRY = {
+  registryPath: 'data/source_registry.json',
+  updatedDate: '2026-08-12',
+  counts: {by_usable_for_formal: {yes: 1}},
+  formal: [{title: 'Source', usable_for_formal: 'yes'}],
+  background: [],
+  provisional: [],
+};
+globalThis.navigator = {language: 'en-US'};
+globalThis.document = {
+  title: '',
+  documentElement: {lang: ''},
+  body: {style: {}},
+  getElementById: element,
+  querySelectorAll() { return []; },
+};
+globalThis.localStorage = payload.storageThrows ? {
+  getItem() { throw new Error('storage disabled'); },
+  setItem() { throw new Error('storage disabled'); },
+} : {
+  value: payload.storedLanguage,
+  getItem() { return this.value; },
+  setItem(_key, value) { this.value = value; },
+};
+eval(payload.script);
+process.stdout.write(JSON.stringify({
+  lang: document.documentElement.lang,
+  title: document.title,
+  toggle: element('langToggle').textContent,
+  registry: element('registryStats').innerHTML,
+}));
+"""
+
+
+def page_script(page: str) -> str:
+    html = (ROOT / page).read_text(encoding="utf-8")
+    matches = re.findall(r"<script>(.*?)</script>", html, re.DOTALL)
+    if len(matches) != 1:
+        raise AssertionError(f"expected one inline script in {page}, found {len(matches)}")
+    return matches[0]
+
+
+def run_page(page: str, *, stored_language: str = "fr", storage_throws: bool = False) -> dict:
+    payload = json.dumps(
+        {
+            "script": page_script(page),
+            "storedLanguage": stored_language,
+            "storageThrows": storage_throws,
+        }
+    )
+    completed = subprocess.run(
+        ["node", "-e", NODE_RUNNER, payload],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode:
+        raise AssertionError(completed.stdout + completed.stderr)
+    return json.loads(completed.stdout)
+
+
+class FrontendLanguageStorageTests(unittest.TestCase):
+    def test_pages_preserve_supported_stored_languages(self) -> None:
+        for stored_language, expected_lang, expected_toggle in (
+            ("zh", "zh-CN", "EN"),
+            ("en", "en", "中文"),
+        ):
+            for page in PAGES:
+                with self.subTest(page=page, stored_language=stored_language):
+                    result = run_page(page, stored_language=stored_language)
+                    self.assertEqual(expected_lang, result["lang"])
+                    self.assertTrue(result["title"])
+                    self.assertEqual(expected_toggle, result["toggle"])
+
+    def test_pages_ignore_unsupported_stored_language(self) -> None:
+        for page in PAGES:
+            with self.subTest(page=page):
+                result = run_page(page)
+                self.assertEqual("en", result["lang"])
+                self.assertTrue(result["title"])
+                self.assertEqual("中文", result["toggle"])
+        self.assertTrue(run_page("agent.html")["registry"])
+
+    def test_pages_initialize_when_storage_access_throws(self) -> None:
+        for page in PAGES:
+            with self.subTest(page=page):
+                result = run_page(page, storage_throws=True)
+                self.assertEqual("en", result["lang"])
+                self.assertTrue(result["title"])
+                self.assertEqual("中文", result["toggle"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- validate the shared persisted language before indexing each page's translation table
- tolerate browsers where reading or writing `localStorage` throws
- keep `applyLang()` defensive so future callers cannot reintroduce an unsupported language
- execute each page's real inline script in a Node regression harness

## Reproduction

On current `main`, persist a language outside the two supported values and reload any of `agent.html`, `brief.html`, or `review.html`:

```js
localStorage.setItem('lang', 'fr');
location.reload();
```

Each page throws while reading `T[l]['page.title']`. On `agent.html`, that also prevents the source registry panel from rendering. A browser configuration that throws on storage access stops initialization even earlier.

The stored value is shared across these pages, so one stale or externally written value propagates the failure between them.

## Root cause

The pages used any truthy `localStorage.lang` value directly as a key into a translation table that only defines `zh` and `en`. Both storage reads and writes were also outside exception handling.

## Verification

```text
python3 -m unittest tests.test_frontend_language_storage tests.test_source_registry_frontend -v
Ran 6 tests ... OK

python3 -m py_compile tests/test_frontend_language_storage.py
git diff --check
```

The new tests cover valid `zh`/`en` persistence, unsupported stored values, storage read/write exceptions, translated page initialization, and the `agent.html` registry render.

## Related work

PR #1071 also touches these three pages, but only changes campaign-boundary copy and its translation strings; it does not modify language persistence or initialization. This patch is based on `main` at `905b8be6`.
