### PR TITLE
fix: fall back when custom covers fail

### DIFF
--- a/proposal-cover.js
+++ b/proposal-cover.js
@@ -25,17 +25,19 @@
       return ((number^number>>>14)>>>0)/4294967296;
     };
   }
-  window.renderCover=function(item,index,titleHTML){
-    if(item.coverUrl){
-      const coverUrl=escapeHTML(item.coverUrl);
-      const author=escapeHTML(item.author||'open-city');
-      return `<div class="cover-art cover-art-custom" style="--cover-bg:#07111d">
-        <img src="${coverUrl}" alt="" loading="lazy" decoding="async" style="position:absolute;inset:0;width:100%;height:100%;object-fit:cover">
-        <span aria-hidden="true" style="position:absolute;inset:0;background:linear-gradient(180deg,transparent 25%,#03070de8 100%)"></span>
-        <span class="cover-mark" aria-hidden="true">${String(index+1).padStart(2,'0')}</span>
-        <div class="cover-copy"><div class="cover-kicker">@${author} · AGENT COVER</div><div class="cover-title">${titleHTML}</div></div>
-      </div>`;
+  window.handleCoverImageError=function(image){
+    const cover=image.closest('.cover-art');
+    const layer=image.closest('.cover-custom-layer');
+    if(layer) layer.remove();
+    if(cover){
+      cover.classList.remove('cover-art-custom');
+      const signal=cover.querySelector('.cover-signal');
+      const copy=cover.querySelector('.cover-default-copy');
+      if(signal) signal.style.visibility='';
+      if(copy) copy.style.visibility='';
     }
+  };
+  window.renderCover=function(item,index,titleHTML){
     const seed=hash(`${item.title}|${item.author}|${(item.tags||[]).join('|')}`);
     const random=seededRandom(seed);
     const palette=palettes[seed%palettes.length];
@@ -53,11 +55,17 @@
       return `<span class="cover-tile" style="--tile-color:${color};--tile-opacity:${opacity};--tile-rotate:${rotate};--tile-scale:${scale};--tile-flip:${flip};--tile-duration:${duration};--tile-delay:${delay}"></span>`;
     }).join('');
     const author=escapeHTML(item.author||'open-city');
-    return `<div class="cover-art" style="--cover-bg:${palette[0]};--cover-accent:${palette[palette.length-1]};--cover-angle:${angle};--signal-angle:${signalAngle};--signal-top:${signalTop}">
+    const customCover=item.coverUrl?`<div class="cover-custom-layer" style="position:absolute;inset:0">
+        <img src="${escapeHTML(item.coverUrl)}" alt="" loading="lazy" decoding="async" onerror="handleCoverImageError(this)" style="position:absolute;inset:0;width:100%;height:100%;object-fit:cover">
+        <span aria-hidden="true" style="position:absolute;inset:0;background:linear-gradient(180deg,transparent 25%,#03070de8 100%)"></span>
+        <div class="cover-copy"><div class="cover-kicker">@${author} · AGENT COVER</div><div class="cover-title">${titleHTML}</div></div>
+      </div>`:'';
+    return `<div class="cover-art${customCover?' cover-art-custom':''}" style="--cover-bg:${palette[0]};--cover-accent:${palette[palette.length-1]};--cover-angle:${angle};--signal-angle:${signalAngle};--signal-top:${signalTop}">
       <div class="cover-grid" aria-hidden="true">${tiles}</div>
-      <span class="cover-signal" aria-hidden="true"></span>
+      <span class="cover-signal" aria-hidden="true"${customCover?' style="visibility:hidden"':''}></span>
+      ${customCover}
       <span class="cover-mark" aria-hidden="true">${String(index+1).padStart(2,'0')}</span>
-      <div class="cover-copy"><div class="cover-kicker">@${author} · OPEN CITY PROPOSAL</div><div class="cover-title">${titleHTML}</div></div>
+      <div class="cover-copy cover-default-copy"${customCover?' style="visibility:hidden"':''}><div class="cover-kicker">@${author} · OPEN CITY PROPOSAL</div><div class="cover-title">${titleHTML}</div></div>
     </div>`;
   };
 })();

--- a/tests/test_proposal_cover.py
+++ b/tests/test_proposal_cover.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COVER_SCRIPT = ROOT / "proposal-cover.js"
+
+NODE_RUNNER = r"""
+globalThis.window = globalThis;
+eval(process.argv[1]);
+const item = JSON.parse(process.argv[2]);
+const first = renderCover(item, 4, 'Rendered title');
+const second = renderCover(item, 4, 'Rendered title');
+let removed = 0;
+let classRemoved = '';
+const restored = [];
+handleCoverImageError({
+  closest(selector) {
+    if (selector === '.cover-custom-layer') return {remove() { removed += 1; }};
+    if (selector === '.cover-art') return {
+      classList: {remove(name) { classRemoved = name; }},
+      querySelector(selector) {
+        return {style: {set visibility(value) { restored.push([selector, value]); }}};
+      },
+    };
+    return null;
+  },
+});
+process.stdout.write(JSON.stringify({first, second, removed, classRemoved, restored}));
+"""
+
+
+def render(item: dict) -> dict:
+    completed = subprocess.run(
+        ["node", "-e", NODE_RUNNER, COVER_SCRIPT.read_text(encoding="utf-8"), json.dumps(item)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode:
+        raise AssertionError(completed.stdout + completed.stderr)
+    return json.loads(completed.stdout)
+
+
+class ProposalCoverTests(unittest.TestCase):
+    def test_generated_cover_remains_deterministic(self) -> None:
+        result = render({"title": "Plan", "author": "alice", "tags": ["rail"]})
+        self.assertEqual(result["first"], result["second"])
+        self.assertEqual(60, result["first"].count('class="cover-tile"'))
+        self.assertNotIn("cover-custom-layer", result["first"])
+
+    def test_custom_cover_keeps_generated_fallback_and_escapes_metadata(self) -> None:
+        result = render(
+            {
+                "title": "Plan",
+                "author": '<alice & bob>',
+                "tags": [],
+                "coverUrl": 'assets/media/cover.webp?x="quoted"&y=1',
+            }
+        )
+        markup = result["first"]
+        self.assertEqual(60, markup.count('class="cover-tile"'))
+        self.assertIn('class="cover-art cover-art-custom"', markup)
+        self.assertIn('class="cover-custom-layer"', markup)
+        self.assertNotIn('cover-custom-layer" style="position:absolute;z-index:', markup)
+        self.assertIn("onerror=\"handleCoverImageError(this)\"", markup)
+        self.assertIn("cover.webp?x=&quot;quoted&quot;&amp;y=1", markup)
+        self.assertIn("@&lt;alice &amp; bob&gt; · AGENT COVER", markup)
+        self.assertIn("@&lt;alice &amp; bob&gt; · OPEN CITY PROPOSAL", markup)
+
+    def test_image_error_removes_only_custom_layer_and_class(self) -> None:
+        result = render({"title": "Plan", "author": "alice", "coverUrl": "cover.png"})
+        self.assertEqual(1, result["removed"])
+        self.assertEqual("cover-art-custom", result["classRemoved"])
+        self.assertEqual(
+            [[".cover-signal", ""], [".cover-default-copy", ""]],
+            result["restored"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- keep the deterministic 60-tile cover underneath an optional custom image
- remove only the custom image layer when decoding or loading fails
- restore the default signal and copy without rerendering or resizing the card
- preserve the existing custom-cover appearance when the image loads successfully

## Reproduction

`generate_submissions_data.py` currently accepts a custom cover when its path exists and has a supported suffix. It does not decode the image, so a truncated or incorrectly encoded `.png`, `.jpg`, or `.webp` can still produce `coverUrl`.

On current `main`, rendering such a URL selects an early-return custom branch:

```js
renderCover({
  title: 'Plan',
  author: 'alice',
  tags: [],
  coverUrl: 'data:image/png;base64,not-a-png'
}, 0, 'Plan')
```

Chromium reports the image as complete with `naturalWidth === 0`. The markup contains no `.cover-tile` elements and has no image error handler, so the card cannot recover to the existing generated cover.

## Root cause

`renderCover()` returned immediately whenever `item.coverUrl` was truthy. That removed the deterministic cover from the DOM before the browser knew whether the custom image could decode.

## Verification

```text
python3 -m unittest tests.test_proposal_cover -v
Ran 3 tests ... OK

node --check proposal-cover.js
python3 -m py_compile tests/test_proposal_cover.py
git diff --check
```

A focused Chromium check also verified both paths:

```text
broken: naturalWidth=0, tiles=60, custom layer removed, default copy restored
valid:  naturalWidth=1, tiles=60, custom layer retained
```

The tests execute the real `proposal-cover.js`, assert deterministic output, preserve HTML escaping, verify the 60-tile fallback under custom covers, and exercise the error cleanup behavior.

## Scope

No open pull request currently modifies `proposal-cover.js`. This patch is based on `main` at `195d03f9` and does not change gallery data generation or submission validation.
