### PR TITLE
fix(validation): reject boolean metric values

### DIFF
--- a/scripts/metric_types.py
+++ b/scripts/metric_types.py
@@ -1,0 +1,10 @@
+"""Shared JSON metric type predicates used by the review gates."""
+
+from __future__ import annotations
+
+
+def is_json_number(value: object) -> bool:
+    """Return true only for JSON numbers, never for Python booleans."""
+
+    # Python makes bool a subclass of int, but JSON booleans are not numbers.
+    return isinstance(value, (int, float)) and not isinstance(value, bool)

--- a/scripts/spatial_review.py
+++ b/scripts/spatial_review.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from metric_types import is_json_number
+
 
 try:
     from pyproj import Transformer
@@ -172,7 +174,18 @@ def load_feature_geometries(
                 )
             )
         declared = props.get("area_sqm_declared")
-        if isinstance(declared, (int, float)) and geom.geom_type in {"Polygon", "MultiPolygon"}:
+        if isinstance(declared, bool):
+            report.add(
+                SpatialIssue(
+                    "DECLARED_AREA_TYPE",
+                    "major",
+                    str(path),
+                    "Declared area must be a JSON number, not a boolean.",
+                    feature_id,
+                    actual=declared,
+                )
+            )
+        elif is_json_number(declared) and geom.geom_type in {"Polygon", "MultiPolygon"}:
             delta = abs(float(declared) - float(geom.area))
             allowed_delta = max(AREA_TOLERANCE_SQM, abs(float(geom.area)) * RELATIVE_AREA_TOLERANCE)
             if delta > allowed_delta:
@@ -345,9 +358,20 @@ def check_key_areas(report: SpatialReport, site: Any, key_items: list[tuple[str,
                 )
             )
         expected_area = props.get("official_area_sqm")
-        if not isinstance(expected_area, (int, float)) and is_official:
+        if isinstance(expected_area, bool):
+            report.add(
+                SpatialIssue(
+                    "KEY_AREA_AREA_TYPE",
+                    "major",
+                    "geometry/key_areas.geojson",
+                    "Official key-area area must be a JSON number, not a boolean.",
+                    feature_id,
+                    actual=expected_area,
+                )
+            )
+        elif not is_json_number(expected_area) and is_official:
             expected_area = OFFICIAL_KEY_AREA_AREAS.get(area_id)
-        if isinstance(expected_area, (int, float)) and is_official:
+        if is_json_number(expected_area) and is_official:
             delta = abs(float(expected_area) - float(geom.area))
             allowed = max(AREA_TOLERANCE_SQM, float(expected_area) * KEY_AREA_RELATIVE_TOLERANCE)
             if delta > allowed:
@@ -394,7 +418,7 @@ def metric_value(metrics: dict, name: str) -> float | None:
     if not isinstance(metric, dict):
         return None
     value = metric.get("value")
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
+    if is_json_number(value):
         return float(value)
     return None
 
@@ -521,6 +545,17 @@ def review_submission(submission_dir: Path, repo_root: Path, stage: str) -> Spat
     }
 
     metrics = load_metrics(submission_dir)
+    for name, metric in metrics.items():
+        if isinstance(metric, dict) and isinstance(metric.get("value"), bool):
+            report.add(
+                SpatialIssue(
+                    "METRIC_VALUE_TYPE",
+                    "major",
+                    "metrics.json",
+                    f"{name} must use a JSON number, not a boolean.",
+                    actual=metric["value"],
+                )
+            )
     check_metric_close(report, metrics, "site_area_sqm", site_area, "sqm")
     check_metric_close(report, metrics, "green_space_area_sqm", green_area, "sqm")
     check_metric_close(report, metrics, "public_space_area_sqm", public_area, "sqm")
@@ -532,7 +567,7 @@ def review_submission(submission_dir: Path, repo_root: Path, stage: str) -> Spat
     for name, metric in metrics.items():
         if isinstance(metric, dict) and metric.get("unit") == "ratio":
             value = metric.get("value")
-            if isinstance(value, (int, float)) and not 0 <= float(value) <= 1:
+            if is_json_number(value) and not 0 <= float(value) <= 1:
                 report.add(
                     SpatialIssue(
                         "METRIC_RATIO_RANGE",

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Iterable
 
+from metric_types import is_json_number
+
 
 POLICY_ROOT = Path(__file__).resolve().parents[1]
 PERSISTED_READINESS_CONTRACT = "persisted-self-check-v1"
@@ -1307,9 +1309,9 @@ def validate_metrics_file(report: ValidationReport, path: Path, display_path: st
                 report.add_error(f"{label}: unknown metric value must be null")
             if not metric.get("reason"):
                 report.add_error(f"{label}: unknown metric needs reason")
-        if status == "known" and not isinstance(metric.get("value"), (int, float)):
+        if status == "known" and not is_json_number(metric.get("value")):
             report.add_error(f"{label}: known metric needs numeric value")
-        if metric.get("unit") == "ratio" and isinstance(metric.get("value"), (int, float)):
+        if metric.get("unit") == "ratio" and is_json_number(metric.get("value")):
             value = metric["value"]
             if value < 0 or value > 1:
                 report.add_error(f"{label}: ratio value must be between 0 and 1")

--- a/scripts/visual_review.py
+++ b/scripts/visual_review.py
@@ -18,6 +18,8 @@ from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any
 
+from metric_types import is_json_number
+
 
 REQUIRED_TEXT_MARKERS = [
     "总览地图",
@@ -190,7 +192,7 @@ def review_visual(submission_dir: Path) -> VisualReport:
             )
             continue
         expected = metric.get("value")
-        if not isinstance(expected, (int, float)):
+        if not is_json_number(expected):
             report.add(
                 "VISUAL_METRIC_SOURCE_MISSING",
                 "major",

--- a/tests/test_metric_types.py
+++ b/tests/test_metric_types.py
@@ -1,0 +1,74 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from validate_submission import ValidationReport, validate_metrics_file  # noqa: E402
+from metric_types import is_json_number  # noqa: E402
+
+
+class MetricTypeTests(unittest.TestCase):
+    def test_booleans_are_not_json_numbers(self) -> None:
+        self.assertTrue(is_json_number(0))
+        self.assertTrue(is_json_number(1.0))
+        self.assertFalse(is_json_number(True))
+        self.assertFalse(is_json_number(False))
+
+    def test_boolean_known_metric_fails_deterministic_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "metrics.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "0.1.0",
+                        "units": {"length": "m", "area": "sqm"},
+                        "metrics": {
+                            "green_ratio": {
+                                "status": "known",
+                                "value": True,
+                                "unit": "ratio",
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            report = ValidationReport()
+            validate_metrics_file(report, path, "metrics.json")
+
+        self.assertFalse(report.ok)
+        self.assertTrue(any("known metric needs numeric value" in error for error in report.errors))
+
+    def test_numeric_zero_and_one_remain_valid_ratio_values(self) -> None:
+        for value in (0, 1):
+            with self.subTest(value=value), tempfile.TemporaryDirectory() as tmp:
+                path = Path(tmp) / "metrics.json"
+                path.write_text(
+                    json.dumps(
+                        {
+                            "schema_version": "0.1.0",
+                            "units": {"length": "m", "area": "sqm"},
+                            "metrics": {
+                                "green_ratio": {
+                                    "status": "known",
+                                    "value": value,
+                                    "unit": "ratio",
+                                }
+                            },
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                report = ValidationReport()
+                validate_metrics_file(report, path, "metrics.json")
+
+            self.assertTrue(report.ok, report.errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spatial_review.py
+++ b/tests/test_spatial_review.py
@@ -119,6 +119,28 @@ class SpatialReviewTests(unittest.TestCase):
             report = review_submission(root / base, REPO_ROOT, "formal")
             self.assertTrue(report.ok, [issue.__dict__ for issue in report.issues])
 
+    def test_boolean_metric_value_is_rejected_before_spatial_recalculation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/spatial-boolean-metric"
+            write_valid_spatial_package(root, base)
+            write_json(
+                root,
+                f"{base}/metrics.json",
+                {
+                    "schema_version": "0.1.0",
+                    "units": {"length": "m", "area": "sqm"},
+                    "metrics": {
+                        "green_ratio": {"status": "known", "value": True, "unit": "ratio"},
+                    },
+                },
+            )
+
+            report = review_submission(root / base, REPO_ROOT, "formal")
+
+        self.assertFalse(report.ok)
+        self.assertIn("METRIC_VALUE_TYPE", {issue.check_id for issue in report.issues})
+
     def test_land_use_gap_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_visual_review.py
+++ b/tests/test_visual_review.py
@@ -95,6 +95,19 @@ class VisualReviewTests(unittest.TestCase):
             self.assertFalse(report.ok)
             self.assertIn("VISUAL_METRIC_MISMATCH", {issue.check_id for issue in report.issues})
 
+    def test_boolean_metric_value_is_not_coerced_to_one(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_valid_visual_package(Path(tmp))
+            metrics_path = submission / "metrics.json"
+            metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+            metrics["metrics"]["green_ratio"]["value"] = True
+            metrics_path.write_text(json.dumps(metrics), encoding="utf-8")
+
+            report = review_visual(submission)
+
+        self.assertFalse(report.ok)
+        self.assertIn("VISUAL_METRIC_SOURCE_MISSING", {issue.check_id for issue in report.issues})
+
     def test_metric_attribute_order_does_not_change_validation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             submission = write_valid_visual_package(Path(tmp))


### PR DESCRIPTION
## Summary

Closes #2071.

Python treats `bool` as a subclass of `int`, so the metrics deterministic gate, visual gate, and spatial recalculation could interpret JSON `true`/`false` as `1`/`0`. This PR introduces one shared `is_json_number()` predicate and uses it across those three gates.

- known metric booleans now fail deterministic validation;
- visual review no longer compares a boolean to an HTML numeric value;
- spatial review reports a blocking metric type issue instead of silently skipping recalculation;
- geometry area declarations and official key-area values receive the same type guard;
- legal numeric ratios `0` and `1` remain valid.

## Verification

- `python3 -m unittest tests.test_metric_types tests.test_visual_review tests.test_spatial_review -q` — 26 passed
- `python3 -m unittest tests.test_submission_workflow.SubmissionWorkflowTests.test_minimal_ai_package_passes_hard_validation tests.test_submission_workflow.SubmissionWorkflowTests.test_v2_simulation_metrics_must_match_task_records -v` — 2 passed
- Python compile checks passed with a workspace-local bytecode cache
- `git diff --check` passed

This is a validation-integrity fix only. It does not alter scoring weights, historical submissions, gallery data, or the protected first-place package.
