### PR TITLE
fix: allow structured data schema declarations

### DIFF
--- a/schema/collection.schema.json
+++ b/schema/collection.schema.json
@@ -5,6 +5,10 @@
   "type": "object",
   "required": ["version", "title", "summary", "items"],
   "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri-reference"
+    },
     "version": {
       "type": "integer",
       "const": 1

--- a/schema/risk.schema.json
+++ b/schema/risk.schema.json
@@ -5,6 +5,10 @@
   "type": "object",
   "required": ["version", "dimensions"],
   "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri-reference"
+    },
     "version": {
       "type": "integer",
       "const": 1

--- a/schema/scenario.schema.json
+++ b/schema/scenario.schema.json
@@ -16,6 +16,10 @@
     "human_review"
   ],
   "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri-reference"
+    },
     "version": {
       "type": "integer",
       "const": 1

--- a/schema/spatial.schema.json
+++ b/schema/spatial.schema.json
@@ -5,6 +5,10 @@
   "type": "object",
   "required": ["version", "disclaimer", "items"],
   "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri-reference"
+    },
     "version": {
       "type": "integer",
       "const": 1

--- a/schema/track.schema.json
+++ b/schema/track.schema.json
@@ -5,6 +5,10 @@
   "type": "object",
   "required": ["version", "tracks"],
   "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri-reference"
+    },
     "version": {
       "type": "integer",
       "const": 1

--- a/tests/test_registry_schema_contracts.py
+++ b/tests/test_registry_schema_contracts.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from pathlib import Path
+
+import jsonschema
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validator(schema_name: str) -> jsonschema.Draft202012Validator:
+    schema = load_json(ROOT / "schema" / schema_name)
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return jsonschema.Draft202012Validator(
+        schema,
+        format_checker=jsonschema.FormatChecker(),
+    )
+
+
+class RegistrySchemaContractTests(unittest.TestCase):
+    def test_track_registry_matches_its_declared_schema(self) -> None:
+        data = load_json(ROOT / "tracks.json")
+        validator("track.schema.json").validate(data)
+
+    def test_collections_and_template_match_their_declared_schema(self) -> None:
+        collection_validator = validator("collection.schema.json")
+        for path in sorted((ROOT / "collections").glob("*.json")):
+            with self.subTest(path=path.relative_to(ROOT)):
+                collection_validator.validate(load_json(path))
+
+        template = load_json(ROOT / "templates" / "collection.json")
+        template["items"][0]["proposal"] = "submissions/alice/example-proposal"
+        collection_validator.validate(template)
+
+    def test_structured_templates_match_their_declared_schemas(self) -> None:
+        for stem in ("risk", "scenario", "spatial"):
+            with self.subTest(schema=stem):
+                validator(f"{stem}.schema.json").validate(
+                    load_json(ROOT / "templates" / f"{stem}.json")
+                )
+
+    def test_structured_examples_match_their_declared_schemas(self) -> None:
+        example = ROOT / "examples" / "agent-civic-loop"
+        for stem in ("risk", "spatial"):
+            with self.subTest(schema=stem):
+                validator(f"{stem}.schema.json").validate(load_json(example / f"{stem}.json"))
+
+    def test_unknown_top_level_fields_remain_rejected(self) -> None:
+        cases = (
+            ("track.schema.json", ROOT / "tracks.json"),
+            ("collection.schema.json", ROOT / "collections" / "featured-civic-governance.json"),
+            ("risk.schema.json", ROOT / "templates" / "risk.json"),
+            ("scenario.schema.json", ROOT / "templates" / "scenario.json"),
+            ("spatial.schema.json", ROOT / "templates" / "spatial.json"),
+        )
+        for schema_name, path in cases:
+            with self.subTest(schema=schema_name):
+                data = copy.deepcopy(load_json(path))
+                data["unexpected"] = True
+                with self.assertRaises(jsonschema.ValidationError):
+                    validator(schema_name).validate(data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- allow the standard `$schema` annotation in collection, track, risk, scenario, and spatial documents
- retain strict rejection of every other unknown top-level field
- validate checked-in registries, collections, structured examples, and filled templates against their declared Draft 2020-12 schemas

## Reproduction

Several official data files and every corresponding maintainer template declare the schema intended to validate them:

```text
tracks.json                                  "$schema": "schema/track.schema.json"
collections/featured-civic-governance.json  "$schema": "../schema/collection.schema.json"
templates/{risk,scenario,spatial}.json       "$schema": "../schema/<name>.schema.json"
examples/agent-civic-loop/{risk,spatial}.json
```

However, all five schemas set `additionalProperties: false` without defining `$schema`. Draft 2020-12 validation rejects every one of those official instances for the same reason:

```text
Additional properties are not allowed ('$schema' was unexpected)
```

## Root cause

`$schema` is a JSON Schema keyword when it appears in a schema, but in these data instances it is an ordinary annotation property. Strict instance schemas must explicitly allow it.

## Verification

```text
python3 -m unittest \
  tests.test_registry_schema_contracts \
  tests.test_tracks \
  tests.test_collections -v
Ran 9 tests ... OK

python3 -m py_compile tests/test_registry_schema_contracts.py
git diff --check
```

The regression tests also inject an unrelated top-level property into every schema and confirm it remains rejected. The collection template's author placeholder is replaced with a valid example path in the test; this patch does not loosen the proposal-path contract.

## Scope

No open pull request changes these schemas. PR #1944 touches the existing track test for an unrelated documentation rewrite, so this patch uses a new focused test file. It is based on `main` at `b869802c`.
