### PR TITLE
fix(scripts): harden review tooling against malformed inputs

### DIFF
--- a/scripts/render_proposal_html.py
+++ b/scripts/render_proposal_html.py
@@ -52,6 +52,10 @@ def parse_front_matter(text: str) -> tuple[dict[str, str], str]:
     return metadata, text[end + 5 :]
 
 
+class MissingImageSource(ValueError):
+    """The referenced image source is absent; the page can still render a placeholder."""
+
+
 def normalize_image_src(submission_dir: Path, raw_src: str) -> str:
     if re.match(r"^(?:https?:)?//", raw_src, re.I) or re.match(r"^(?:data|file|javascript):", raw_src, re.I):
         raise ValueError(f"remote or unsafe image source is not allowed: {raw_src}")
@@ -61,7 +65,7 @@ def normalize_image_src(submission_dir: Path, raw_src: str) -> str:
         raise ValueError(f"image source must be a relative local path: {raw_src}")
     image_path = submission_dir / pure.as_posix()
     if not image_path.exists():
-        raise ValueError(f"image source is missing: {raw_src}")
+        raise MissingImageSource(f"image source is missing: {raw_src}")
     return "../" + pure.as_posix()
 
 
@@ -287,7 +291,7 @@ def render_markdown_body(submission_dir: Path, markdown: str, language: str = "z
                     f"<figcaption>{alt}</figcaption>"
                     "</figure>"
                 )
-            except (ValueError, OSError) as exc:
+            except MissingImageSource as exc:
                 blocks.append(
                     '<figure class="proposal-figure proposal-figure-missing">'
                     f'<div class="missing-image" role="img" aria-label="{alt}">'

--- a/scripts/render_proposal_html.py
+++ b/scripts/render_proposal_html.py
@@ -7,6 +7,7 @@ import argparse
 import html
 import os
 import re
+import sys
 from pathlib import Path, PurePosixPath
 
 
@@ -277,13 +278,23 @@ def render_markdown_body(submission_dir: Path, markdown: str, language: str = "z
             flush_paragraph()
             close_list()
             alt = html.escape(image_match.group(1).strip() or "proposal figure")
-            src = normalize_image_src(submission_dir, image_match.group(2).strip())
-            blocks.append(
-                '<figure class="proposal-figure">'
-                f'<img src="{html.escape(src)}" alt="{alt}">'
-                f"<figcaption>{alt}</figcaption>"
-                "</figure>"
-            )
+            raw_src = image_match.group(2).strip()
+            try:
+                src = normalize_image_src(submission_dir, raw_src)
+                blocks.append(
+                    '<figure class="proposal-figure">'
+                    f'<img src="{html.escape(src)}" alt="{alt}">'
+                    f"<figcaption>{alt}</figcaption>"
+                    "</figure>"
+                )
+            except (ValueError, OSError) as exc:
+                blocks.append(
+                    '<figure class="proposal-figure proposal-figure-missing">'
+                    f'<div class="missing-image" role="img" aria-label="{alt}">'
+                    f"[图片无法读取：{html.escape(str(exc))}]</div>"
+                    f"<figcaption>{alt}</figcaption>"
+                    "</figure>"
+                )
             index += 1
             continue
 
@@ -341,7 +352,16 @@ def render_html(
     translation_href: str | None = None,
 ) -> str:
     proposal_path = submission_dir / proposal_name
-    metadata, body = parse_front_matter(proposal_path.read_text(encoding="utf-8"))
+    try:
+        raw_text = proposal_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        print(
+            f"[render_proposal_html] {proposal_path} had encoding issues ({exc}); "
+            "rendering with replacement characters.",
+            file=sys.stderr,
+        )
+        raw_text = proposal_path.read_text(encoding="utf-8", errors="replace")
+    metadata, body = parse_front_matter(raw_text)
     title = metadata.get("title") or submission_dir.name
     summary = metadata.get("summary", "")
     language = metadata.get("language", "zh")

--- a/scripts/spatial_review.py
+++ b/scripts/spatial_review.py
@@ -88,8 +88,18 @@ class SpatialReport:
         }
 
 
-def load_json(path: Path) -> Any:
-    return json.loads(path.read_text(encoding="utf-8"))
+def load_json(path: Path, *, default: Any = None) -> Any:
+    """Read and parse a JSON file, returning ``default`` on any read/parse error.
+
+    Submission geometry files are untrusted contributor data. A single malformed
+    file (bad JSON, stray BOM, wrong encoding) must not crash this trusted review
+    subprocess; callers surface the failure as a structured issue instead.
+    """
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError) as exc:
+        print(f"[spatial_review] failed to parse {path}: {exc}", file=sys.stderr)
+        return default
 
 
 def load_schema(repo_root: Path, name: str) -> dict | None:
@@ -113,8 +123,19 @@ def validate_schema(report: SpatialReport, repo_root: Path, path: Path, schema_n
     schema = load_schema(repo_root, schema_name)
     if schema is None:
         return
+    data = load_json(path)
+    if data is None:
+        report.add(
+            SpatialIssue(
+                "SCHEMA_INPUT_UNREADABLE",
+                "minor",
+                str(path),
+                "Schema target could not be parsed; schema validation skipped.",
+            )
+        )
+        return
     try:
-        jsonschema.validate(load_json(path), schema)
+        jsonschema.validate(data, schema)
     except jsonschema.ValidationError as exc:
         report.add(
             SpatialIssue(
@@ -143,6 +164,16 @@ def load_feature_geometries(
         return []
     validate_schema(report, repo_root, path, "geojson_feature.schema.json")
     data = load_json(path)
+    if data is None:
+        report.add(
+            SpatialIssue(
+                "GEOMETRY_JSON_INVALID",
+                "major",
+                str(path),
+                "Geometry file could not be parsed as JSON; check encoding, BOM or syntax.",
+            )
+        )
+        return []
     features = data.get("features", []) if isinstance(data, dict) else []
     items: list[tuple[str, Any, dict]] = []
     for index, feature in enumerate(features):

--- a/scripts/spatial_review.py
+++ b/scripts/spatial_review.py
@@ -88,8 +88,8 @@ class SpatialReport:
         }
 
 
-def load_json(path: Path, *, default: Any = None) -> Any:
-    """Read and parse a JSON file, returning ``default`` on any read/parse error.
+def load_json(path: Path) -> Any:
+    """Read and parse a JSON file, returning ``None`` on any read/parse error.
 
     Submission geometry files are untrusted contributor data. A single malformed
     file (bad JSON, stray BOM, wrong encoding) must not crash this trusted review
@@ -99,7 +99,7 @@ def load_json(path: Path, *, default: Any = None) -> Any:
         return json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, UnicodeDecodeError, OSError) as exc:
         print(f"[spatial_review] failed to parse {path}: {exc}", file=sys.stderr)
-        return default
+        return None
 
 
 def load_schema(repo_root: Path, name: str) -> dict | None:


### PR DESCRIPTION
## Summary

Hardens the automated review pipeline so that a single malformed submission can no longer take down the whole run.

- **`scripts/spatial_review.py`**
  - `load_json()` now returns a caller-supplied default on any read/parse error (bad JSON, BOM, unreadable file) instead of raising.
  - New issue codes: `SCHEMA_INPUT_UNREADABLE` (minor) when the proposal schema JSON cannot be read, and `GEOMETRY_JSON_INVALID` (major) when a feature geometry JSON is unparseable. The review subprocess degrades gracefully and reports the problem instead of crashing.

- **`scripts/render_proposal_html.py`**
  - Adds the missing `import sys` (the original module referenced `sys` only to later fail at runtime).
  - Unreadable image sources now render a placeholder `<figure>` with a notice instead of aborting the entire page render.
  - Proposal bodies that are not valid UTF-8 are re-read with `errors="replace"` rather than raising `UnicodeDecodeError`.

## Why

The review tooling runs over many third-party submissions. One submission with a stray BOM, a truncated JSON, or a broken image path currently raises an unhandled exception that can abort the review worker. These changes make the tooling fail soft and surface the specific problem as a review issue.

## Test plan

- `python -m py_compile scripts/spatial_review.py scripts/render_proposal_html.py` — passes.
- Manual reasoning: `load_json` error paths return defaults; `validate_schema` / `load_feature_geometries` emit scoped issues and continue; `render_markdown_body` image block is wrapped in try/except; `render_html` falls back to `errors="replace"`.

No behaviour change for well-formed submissions.