### PR TITLE
fix(scripts): surface silent review failures and harden scaffold writes

### DIFF
--- a/scripts/scaffold_ai_submission.py
+++ b/scripts/scaffold_ai_submission.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import hashlib
 import io
 import json
@@ -49,7 +50,13 @@ def load_json(path: Path) -> Any:
 
 def write_json(path: Path, content: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(content, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    data = json.dumps(content, ensure_ascii=False, indent=2) + "\n"
+    tmp = path.parent / (path.name + ".tmp")
+    try:
+        tmp.write_text(data, encoding="utf-8")
+        os.replace(tmp, path)
+    finally:
+        tmp.unlink(missing_ok=True)
 
 
 def sha256(path: Path) -> str:

--- a/scripts/self_check_submission.py
+++ b/scripts/self_check_submission.py
@@ -156,6 +156,18 @@ def next_actions(report: dict[str, Any]) -> list[str]:
         if stderr:
             actions.append(f"Fix deterministic validation error: {stderr}")
 
+    # Mirror the deterministic handling above for the other three checks so a
+    # hard crash (non-zero exit with no parsed errors) is never silent.
+    for key in ("spatial_review", "visual_review", "professional_review"):
+        sub = report.get(key)
+        if isinstance(sub, dict) and not sub.get("ok"):
+            sub_stdout = sub.get("stdout")
+            sub_reported = bool(isinstance(sub_stdout, dict) and sub_stdout.get("errors"))
+            if not sub_reported:
+                stderr = str(sub.get("stderr") or "").strip()
+                if stderr:
+                    actions.append(f"Fix {key} error: {stderr}")
+
     spatial = report.get("spatial_review", {})
     spatial_stdout = spatial.get("stdout") if isinstance(spatial, dict) else {}
     if isinstance(spatial_stdout, dict):

--- a/scripts/visual_review.py
+++ b/scripts/visual_review.py
@@ -99,6 +99,7 @@ class VisualMetricParser(HTMLParser):
         self.metrics: dict[str, float] = {}
         self.declarations: list[tuple[str, float]] = []
         self.nonfinite_metrics: set[str] = set()
+        self.unparseable_metrics: set[str] = set()
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         attributes = {name.lower(): value for name, value in attrs}
@@ -110,6 +111,7 @@ class VisualMetricParser(HTMLParser):
         try:
             value = float(html.unescape(raw_value))
         except ValueError:
+            self.unparseable_metrics.add(name)
             return
         if not math.isfinite(value):
             self.nonfinite_metrics.add(name)
@@ -169,6 +171,13 @@ def review_visual(submission_dir: Path) -> VisualReport:
             "major",
             display_path,
             f"HTML metric `{name}` must use a finite numeric data-value.",
+        )
+    for name in sorted(parser.unparseable_metrics):
+        report.add(
+            "VISUAL_METRIC_VALUE_NOT_NUMERIC",
+            "major",
+            display_path,
+            f"HTML metric `{name}` has a non-numeric data-value; expected a plain number.",
         )
     for name, value in declarations:
         metric = metrics.get(name)


### PR DESCRIPTION
## Summary

Three robustness fixes to the contributor-facing tooling, following up on #2087.

- **`scripts/visual_review.py`** — A `data-value` that is not a plain number (e.g. `"12km"`, `"3米"`) was previously discarded silently, so the affected metric declaration vanished with no signal. It now records the metric name in `unparseable_metrics` and emits a `VISUAL_METRIC_VALUE_NOT_NUMERIC` (major) issue, making the lost metric visible instead of silently dropped.

- **`scripts/self_check_submission.py`** — `run_json_command` already captures stderr, but `next_actions` only surfaced the deterministic check's stderr. When `spatial_review` / `visual_review` / `professional_review` subprocesses hard-crash (non-zero exit, no parsed errors), their stderr is now appended to `next_actions` exactly like the deterministic case, so a crash is never silent.

- **`scripts/scaffold_ai_submission.py`** — `write_json` (the single write path for `manifest.json`, `metrics.json`, `agent.json`, etc.) now writes to a sibling `.tmp` file and `os.replace()`s it, so an interrupted scaffold cannot leave a half-written/corrupt JSON behind.

## Why

These close the remaining silent-failure gaps in the review/self-check/scaffold pipeline so contributors get actionable diagnostics instead of mysterious FAILs, and prevent corrupt scaffolding output.

## Test plan

- `python -m py_compile scripts/visual_review.py scripts/self_check_submission.py scripts/scaffold_ai_submission.py` — passes.
- Behaviour reasoning: `unparseable_metrics` is initialised in `__init__` and reported; `next_actions` loops the three sub-checks and only appends stderr when no parsed errors exist; `write_json` uses temp + atomic replace with a cleanup `finally`.

No behaviour change for well-formed inputs.