### PR TITLE
Retry transient GitHub content download network errors

### DIFF
--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -96,6 +96,11 @@ def _retry_delay_seconds(error: urllib.error.HTTPError, attempt: int) -> float:
     return min(MAX_RETRY_DELAY_SECONDS, float(2**attempt))
 
 
+def _network_error_message(error: urllib.error.URLError) -> str:
+    """Return a bounded network error description without request credentials."""
+    return str(error.reason or "network request failed")[:300].replace("\n", " ")
+
+
 def _is_download_not_found(error: Exception, path: str) -> bool:
     """Recognize an optional manifest asset that is still absent after retries."""
     if isinstance(error, urllib.error.HTTPError):
@@ -197,6 +202,13 @@ class GitHubClient:
                         f"GitHub API download {path} failed with HTTP {error.code}: {message}"
                     ) from error
                 time.sleep(_retry_delay_seconds(error, attempt))
+            except urllib.error.URLError as error:
+                if attempt + 1 >= MAX_API_ATTEMPTS:
+                    raise RuntimeError(
+                        f"GitHub API download {path} failed after network error: "
+                        f"{_network_error_message(error)}"
+                    ) from error
+                time.sleep(min(MAX_RETRY_DELAY_SECONDS, float(2**attempt)))
         else:
             raise AssertionError("unreachable")
         if len(content) > max_bytes:

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -326,6 +326,40 @@ class GitHubApiResilienceTests(unittest.TestCase):
                     Path(temp_dir) / "asset.bin",
                 )
 
+    def test_download_network_error_retries_then_succeeds(self) -> None:
+        client = GitHubClient("token", "open-city-ai/haidian")
+        network_error = urllib.error.URLError(
+            "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed"
+        )
+        with tempfile.TemporaryDirectory() as temp_dir, patch(
+            "github_pr_validation.urllib.request.urlopen",
+            side_effect=[network_error, _Response(b"payload")],
+        ), patch("github_pr_validation.time.sleep") as sleep:
+            destination = Path(temp_dir) / "asset.bin"
+            client.download_content("fork/repo", "asset.bin", "head-sha", destination)
+            self.assertEqual(b"payload", destination.read_bytes())
+        sleep.assert_called_once_with(1.0)
+
+    def test_download_network_error_exhaustion_reports_path(self) -> None:
+        client = GitHubClient("token", "open-city-ai/haidian")
+        errors = [urllib.error.URLError("temporary resolver failure") for _ in range(4)]
+        with tempfile.TemporaryDirectory() as temp_dir, patch(
+            "github_pr_validation.urllib.request.urlopen",
+            side_effect=errors,
+        ), patch("github_pr_validation.time.sleep") as sleep:
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"GitHub API download submissions/alice/design/asset.bin failed after network error: "
+                r"temporary resolver failure",
+            ):
+                client.download_content(
+                    "fork/repo",
+                    "submissions/alice/design/asset.bin",
+                    "head-sha",
+                    Path(temp_dir) / "asset.bin",
+                )
+        self.assertEqual([call(1.0), call(2.0), call(4.0)], sleep.call_args_list)
+
 
 class PullRequestHeadGuardTests(unittest.TestCase):
     def test_head_guard_compares_event_sha_with_current_pr(self) -> None:


### PR DESCRIPTION
Fixes #2088

## Root cause

`GitHubClient.download_content()` retried retryable HTTP responses but let `urllib.error.URLError` escape immediately. A transient runner-side TLS/DNS/connection failure therefore failed trusted validation before the participant package was hydrated.

## Fix

- retry only the idempotent Contents API download on `URLError`, using the existing four-attempt bounded exponential schedule
- keep the default TLS verification and all participant/trusted-base boundaries unchanged
- fail closed after exhaustion with a bounded diagnostic that identifies the affected package path
- add recovery and exhaustion regressions, including the reported certificate-verification error shape

## Verification

- `python -m unittest tests.test_submission_workflow.GitHubApiResilienceTests -v` — 13 passed
- `python -m unittest tests.test_submission_workflow -v` — 135 passed
- `python -m py_compile scripts/github_pr_validation.py tests/test_submission_workflow.py`
- `git diff --check`