### PR TITLE
fix: align publication schema state rules

### DIFF
--- a/schema/gallery-publication.schema.json
+++ b/schema/gallery-publication.schema.json
@@ -25,6 +25,30 @@
           "selection_reason_en": {"type": "string", "minLength": 5},
           "selected_at": {"type": "string", "format": "date"}
         },
+        "allOf": [
+          {
+            "if": {"properties": {"published": {"const": true}}, "required": ["published"]},
+            "then": {
+              "properties": {
+                "review_status": {"const": "approved_for_publication"},
+                "rights_reviewed": {"const": true}
+              }
+            }
+          },
+          {
+            "if": {"properties": {"featured": {"const": true}}, "required": ["featured"]},
+            "then": {
+              "properties": {
+                "published": {"const": true},
+                "quality_tier": {"const": "featured"}
+              }
+            }
+          },
+          {
+            "if": {"properties": {"quality_tier": {"const": "featured"}}, "required": ["quality_tier"]},
+            "then": {"properties": {"featured": {"const": true}}}
+          }
+        ],
         "additionalProperties": false
       }
     }

--- a/tests/test_gallery_publication_schema.py
+++ b/tests/test_gallery_publication_schema.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from pathlib import Path
+
+import jsonschema
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = json.loads(
+    (ROOT / "schema" / "gallery-publication.schema.json").read_text(encoding="utf-8")
+)
+VALIDATOR = jsonschema.Draft202012Validator(
+    SCHEMA,
+    format_checker=jsonschema.FormatChecker(),
+)
+
+
+def entry(**updates: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "path": "submissions/alice/example-proposal",
+        "published": False,
+        "featured": False,
+        "review_status": "not_approved",
+        "quality_tier": "qualified",
+        "reviewed_by": "maintainer",
+        "reviewed_at": "2026-08-12",
+        "rights_reviewed": False,
+        "reviewed_package_sha256": "0" * 64,
+        "selection_reason_zh": "维护者审核记录",
+        "selection_reason_en": "Maintainer review record",
+        "selected_at": "2026-08-12",
+    }
+    value.update(updates)
+    return value
+
+
+def registry(item: dict[str, object]) -> dict[str, object]:
+    return {"version": 1, "entries": [item]}
+
+
+class GalleryPublicationSchemaTests(unittest.TestCase):
+    def test_schema_accepts_consistent_publication_states(self) -> None:
+        cases = (
+            entry(),
+            entry(review_status="approved_for_publication", rights_reviewed=True),
+            entry(published=True, review_status="approved_for_publication", rights_reviewed=True),
+            entry(
+                published=True,
+                featured=True,
+                review_status="approved_for_publication",
+                quality_tier="featured",
+                rights_reviewed=True,
+            ),
+        )
+        for item in cases:
+            with self.subTest(item=item):
+                VALIDATOR.validate(registry(item))
+
+    def test_schema_rejects_states_rejected_by_gallery_generation(self) -> None:
+        cases = (
+            entry(published=True, rights_reviewed=True),
+            entry(published=True, review_status="approved_for_publication"),
+            entry(featured=True, quality_tier="featured"),
+            entry(
+                featured=True,
+                published=True,
+                review_status="approved_for_publication",
+                rights_reviewed=True,
+            ),
+            entry(quality_tier="featured"),
+        )
+        for item in cases:
+            with self.subTest(item=item):
+                with self.assertRaises(jsonschema.ValidationError):
+                    VALIDATOR.validate(registry(item))
+
+    def test_unknown_fields_remain_rejected(self) -> None:
+        item = copy.deepcopy(entry())
+        item["unexpected"] = True
+        with self.assertRaises(jsonschema.ValidationError):
+            VALIDATOR.validate(registry(item))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- encode the gallery generator's publication-state invariants in the published JSON Schema
- require published entries to have publication approval and completed rights review
- require featured entries to be published and use the featured quality tier
- keep unrelated unknown fields rejected

## Reproduction

`schema/gallery-publication.schema.json` is the maintainer-facing contract for `gallery-publication.json`, but it currently accepts states that `load_publication_registry()` rejects before gallery generation:

```text
published=true, review_status=not_approved
published=true, rights_reviewed=false
featured=true, published=false
featured=true, quality_tier=qualified
quality_tier=featured, featured=false
```

All five combinations validate successfully against current `main`, then fail in `scripts/generate_submissions_data.py`. Editors and schema-aware tools therefore report invalid publication records as valid.

## Root cause

The schema validates each field independently but does not express the cross-field state transitions already enforced by the generator.

## Verification

```text
python3 -m unittest tests.test_gallery_publication_schema -v
Ran 3 tests ... OK

python3 -m unittest \
  tests.test_submissions_gallery.TestSubmissionsGallery.test_publication_registry_requires_human_and_rights_approval \
  tests.test_submissions_gallery.TestSubmissionsGallery.test_publication_registry_rejects_invalid_date_and_flag_types \
  tests.test_submissions_gallery.TestSubmissionsGallery.test_publication_registry_rejects_missing_selection_metadata -v
Ran 3 tests ... OK

python3 -m py_compile tests/test_gallery_publication_schema.py
git diff --check
```

The focused tests cover four consistent states, each cross-field rejection, valid date formats, and continued rejection of unknown fields.

## Scope

No open pull request currently modifies `schema/gallery-publication.schema.json`. The runtime generator already enforces these exact rules and is unchanged. This patch is based on `main` at `d9a63788`.
