### PR TITLE
fix: align exhibit schema path safety

### DIFF
--- a/schema/exhibit.schema.json
+++ b/schema/exhibit.schema.json
@@ -34,7 +34,7 @@
         },
         "cover": {
           "type": "string",
-          "pattern": "^assets/.+\\.(png|jpg|jpeg|webp|gif)$"
+          "pattern": "^assets[\\\\/](?!\\.\\.(?:[\\\\/]|$))(?!.*[\\\\/]\\.\\.(?:[\\\\/]|$)).+\\.(png|jpg|jpeg|webp|gif)$"
         },
         "tags": {
           "type": "array",
@@ -97,7 +97,7 @@
         },
         "image": {
           "type": "string",
-          "pattern": "^assets/.+\\.(png|jpg|jpeg|webp|gif)$"
+          "pattern": "^assets[\\\\/](?!\\.\\.(?:[\\\\/]|$))(?!.*[\\\\/]\\.\\.(?:[\\\\/]|$)).+\\.(png|jpg|jpeg|webp|gif)$"
         },
         "caption": {
           "type": "string",
@@ -150,11 +150,13 @@
         },
         "detail": {
           "type": "string",
-          "maxLength": 120
+          "maxLength": 120,
+          "pattern": "^(?![\\\\/])(?!.*:[\\\\/][\\\\/])(?!\\.\\.(?:[\\\\/]|$))(?!.*[\\\\/]\\.\\.(?:[\\\\/]|$)).*$"
         },
         "showcase": {
           "type": "string",
-          "maxLength": 160
+          "maxLength": 160,
+          "pattern": "^(?![\\\\/])(?!.*:[\\\\/][\\\\/])(?!\\.\\.(?:[\\\\/]|$))(?!.*[\\\\/]\\.\\.(?:[\\\\/]|$)).*$"
         }
       },
       "additionalProperties": false

--- a/tests/test_exhibit_schema_paths.py
+++ b/tests/test_exhibit_schema_paths.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import unittest
+from pathlib import Path
+
+import jsonschema
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from render_exhibit import ExhibitError, safe_asset_path  # noqa: E402
+from render_portal import PortalError, safe_local_link  # noqa: E402
+
+
+SCHEMA = json.loads((ROOT / "schema" / "exhibit.schema.json").read_text(encoding="utf-8"))
+VALIDATOR = jsonschema.Draft202012Validator(SCHEMA)
+TEMPLATE = json.loads((ROOT / "templates" / "exhibit.json").read_text(encoding="utf-8"))
+
+
+class ExhibitSchemaPathTests(unittest.TestCase):
+    def test_template_and_safe_local_paths_are_valid(self) -> None:
+        VALIDATOR.validate(TEMPLATE)
+        cases = (
+            ("card", "cover", "assets/cover.png"),
+            ("card", "cover", "assets\\cover.png"),
+            ("hero", "image", "assets/figures/hero image.webp"),
+            ("hero", "image", "assets/figures\\hero.png"),
+            ("links", "detail", "report/index.html"),
+            ("links", "detail", "report\\index.html"),
+            ("links", "detail", "report//index.html"),
+            ("links", "showcase", "visual/index.html?mode=full#view"),
+        )
+        for parent, field, value in cases:
+            with self.subTest(field=f"{parent}.{field}", value=value):
+                data = copy.deepcopy(TEMPLATE)
+                data[parent][field] = value
+                VALIDATOR.validate(data)
+
+    def test_asset_paths_rejected_by_renderer_are_rejected_by_schema(self) -> None:
+        paths = (
+            "assets/../secret.png",
+            "assets/figures/../../secret.png",
+            "assets\\..\\secret.png",
+        )
+        for parent, field in (("card", "cover"), ("hero", "image")):
+            for value in paths:
+                with self.subTest(field=f"{parent}.{field}", value=value):
+                    with self.assertRaises(ExhibitError):
+                        safe_asset_path(value)
+                    data = copy.deepcopy(TEMPLATE)
+                    data[parent][field] = value
+                    with self.assertRaises(jsonschema.ValidationError):
+                        VALIDATOR.validate(data)
+
+    def test_links_rejected_by_portal_are_rejected_by_schema(self) -> None:
+        paths = (
+            "../outside.html",
+            "report/../../outside.html",
+            "/absolute.html",
+            "//example.com/view",
+            "https://example.com/view",
+            "report\\..\\outside.html",
+        )
+        for field in ("detail", "showcase"):
+            for value in paths:
+                with self.subTest(field=field, value=value):
+                    with self.assertRaises(PortalError):
+                        safe_local_link(value, "index.html")
+                    data = copy.deepcopy(TEMPLATE)
+                    data["links"][field] = value
+                    with self.assertRaises(jsonschema.ValidationError):
+                        VALIDATOR.validate(data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject exhibit asset traversal paths that `safe_asset_path()` already refuses
- reject external, absolute, and traversal links that `safe_local_link()` already refuses
- preserve path forms the renderers intentionally normalize, including repeated separators and backslashes
- test the schema against the real renderer and portal path helpers

## Reproduction

The published exhibit schema currently accepts paths that cannot be rendered:

```json
{"card": {"cover": "assets/../secret.png"}}
{"hero": {"image": "assets/figures/../../secret.png"}}
{"links": {"detail": "../outside.html"}}
{"links": {"showcase": "https://example.com/view"}}
```

All of these pass `schema/exhibit.schema.json`, while `safe_asset_path()` or `safe_local_link()` rejects them. Schema-aware editors and generators therefore report an exhibit as valid even though portal or exhibit rendering fails later.

## Root cause

The asset patterns only checked the `assets/` prefix and extension. Link fields had length limits but no local-path constraint.

## Verification

```text
python3 -m unittest tests.test_exhibit_schema_paths -v
Ran 3 tests ... OK

python3 -m py_compile tests/test_exhibit_schema_paths.py
git diff --check
```

The tests exercise the actual path helpers and the Draft 2020-12 schema together. They cover valid template paths, normalized separators, asset traversal, link traversal, absolute paths, and external URLs. A separate schema/runtime matrix confirms matching decisions for representative path forms.

The merged exhibit corpus contains no path that violates the tightened rules.

## Scope

No open pull request modifies `schema/exhibit.schema.json`. PR #1944 touches the renderer and portal for documentation-only changes; this patch does not modify those files. It is based on `main` at `d9b9363e`.
