### PR TITLE
fix: enforce complete proposal schema contract

### DIFF
--- a/schema/proposal.schema.json
+++ b/schema/proposal.schema.json
@@ -130,17 +130,18 @@
       "if": {
         "properties": {
           "metadata": {
-            "properties": {
-              "proposal_format_version": {"const": "2"},
-              "bilingual_contract_version": {"const": "1"}
-            },
-            "required": ["proposal_format_version", "bilingual_contract_version"]
+            "required": ["bilingual_contract_version"]
           }
         }
       },
       "then": {
         "properties": {
-          "metadata": {"required": ["translation_file"]}
+          "metadata": {
+            "properties": {
+              "proposal_format_version": {"const": "2"}
+            },
+            "required": ["proposal_format_version", "translation_file"]
+          }
         }
       }
     },
@@ -155,7 +156,23 @@
       },
       "then": {
         "properties": {
-          "sections": {"contains": {"const": "设计依据与资料清单"}}
+          "sections": {
+            "allOf": [
+              {"contains": {"const": "设计依据与资料清单"}},
+              {"contains": {"const": "三层范围工作框架"}},
+              {"contains": {"const": "统筹研究范围产业与未来城市研究"}},
+              {"contains": {"const": "总体设计范围城市更新与控规深度城市设计"}},
+              {"contains": {"const": "重点区域详细设计"}},
+              {"contains": {"const": "AI 创新生态、人才画像与 AI+ 场景"}},
+              {"contains": {"const": "用地、建筑规模与拆改留方案"}},
+              {"contains": {"const": "交通、轨道、市政与公共服务设施"}},
+              {"contains": {"const": "蓝绿空间、公共空间与城市风貌"}},
+              {"contains": {"const": "更新项目清单、实施政策与分期计划"}},
+              {"contains": {"const": "指标体系、面积复算与合规矩阵"}},
+              {"contains": {"const": "风险、版权与合规说明"}},
+              {"contains": {"const": "参考资料"}}
+            ]
+          }
         }
       }
     },
@@ -170,7 +187,23 @@
       },
       "then": {
         "properties": {
-          "sections": {"contains": {"const": "Design Basis and Source List"}}
+          "sections": {
+            "allOf": [
+              {"contains": {"const": "Design Basis and Source List"}},
+              {"contains": {"const": "Three-Level Scope Framework"}},
+              {"contains": {"const": "Coordinated Research Area: Industry and Future City Research"}},
+              {"contains": {"const": "Overall Design Area: Urban Renewal and Regulatory-Plan-Level Urban Design"}},
+              {"contains": {"const": "Detailed Design of Key Areas"}},
+              {"contains": {"const": "AI Innovation Ecosystem, Personas, and AI+ Scenarios"}},
+              {"contains": {"const": "Land Use, Building Scale, and Retain-Renovate-Demolish Strategy"}},
+              {"contains": {"const": "Transport, Rail, Municipal Infrastructure, and Public Services"}},
+              {"contains": {"const": "Blue-Green Network, Public Space, and Urban Character"}},
+              {"contains": {"const": "Renewal Projects, Implementation Policy, and Phasing"}},
+              {"contains": {"const": "Metrics, Area Recalculation, and Compliance Matrix"}},
+              {"contains": {"const": "Risk, Copyright, and Compliance"}},
+              {"contains": {"const": "References"}}
+            ]
+          }
         }
       }
     }

--- a/tests/test_proposal_schema_contract.py
+++ b/tests/test_proposal_schema_contract.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+import jsonschema
+
+from scripts.validate_submission import REQUIRED_SECTIONS, REQUIRED_SECTIONS_EN
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class ProposalSchemaContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.schema = json.loads(
+            (REPO_ROOT / "schema" / "proposal.schema.json").read_text(encoding="utf-8")
+        )
+
+    def payload(self, language: str, sections: list[str]) -> dict[str, object]:
+        return {
+            "metadata": {
+                "title": "Complete proposal",
+                "author_github": "alice",
+                "language": language,
+                "license": "CC-BY-4.0",
+                "summary": "A complete proposal with every required section.",
+            },
+            "sections": sections,
+        }
+
+    def test_requires_every_language_specific_section(self) -> None:
+        for language, required_sections in (
+            ("zh", REQUIRED_SECTIONS),
+            ("en", REQUIRED_SECTIONS_EN),
+        ):
+            jsonschema.validate(self.payload(language, required_sections), self.schema)
+            for missing_index, missing_section in enumerate(required_sections):
+                sections = list(required_sections)
+                sections[missing_index] = required_sections[0 if missing_index else 1]
+                with self.subTest(language=language, missing=missing_section):
+                    with self.assertRaises(jsonschema.ValidationError):
+                        jsonschema.validate(self.payload(language, sections), self.schema)
+
+    def test_bilingual_contract_requires_v2_translation_metadata(self) -> None:
+        payload = self.payload("zh", REQUIRED_SECTIONS)
+        metadata = payload["metadata"]
+        assert isinstance(metadata, dict)
+        metadata.update(
+            {
+                "proposal_format_version": "2",
+                "bilingual_contract_version": "1",
+                "translation_file": "proposal.en.md",
+            }
+        )
+        jsonschema.validate(payload, self.schema)
+
+        for missing_key in ("proposal_format_version", "translation_file"):
+            invalid = json.loads(json.dumps(payload))
+            del invalid["metadata"][missing_key]
+            with self.subTest(missing=missing_key):
+                with self.assertRaises(jsonschema.ValidationError):
+                    jsonschema.validate(invalid, self.schema)
+
+        payload["metadata"]["proposal_format_version"] = "1"
+        with self.assertRaises(jsonschema.ValidationError):
+            jsonschema.validate(payload, self.schema)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- require all 13 language-specific proposal sections instead of accepting repeated copies of one heading
- require proposal format v2 and a translation file whenever the bilingual contract is enabled
- add focused schema regression coverage for every Chinese and English required section

## Validation
- `python3 -m unittest tests.test_proposal_schema_contract tests.test_submission_workflow.ProposalSchemaTests`
- `Draft202012Validator.check_schema(schema)`
- `git diff --check`