### PR TITLE
Separate standard IDs from source IDs in compliance matrices

### DIFF
--- a/brief/site-package/schemas/compliance_matrix.schema.json
+++ b/brief/site-package/schemas/compliance_matrix.schema.json
@@ -59,6 +59,9 @@
           "source_ids": {
             "$ref": "#/$defs/non_empty_string_array"
           },
+          "standard_ids": {
+            "$ref": "#/$defs/non_empty_string_array"
+          },
           "assumption_ids": {
             "$ref": "#/$defs/non_empty_string_array"
           },

--- a/docs/formal-submission-guide.md
+++ b/docs/formal-submission-guide.md
@@ -195,7 +195,7 @@ python3 scripts/fetch_standard_references.py --update-standards
 
 ## 4. `compliance_matrix.json`
 
-`compliance_matrix.json` 是“任务响应表”。它告诉评审器和人类评审：官方公告 1.3、1.4、1.5 与面向智能体任务书 `agent.1` 至 `agent.6` 的每个必选任务，在方案中由哪些章节、图层、指标、图纸、HTML 页面、来源和自检项支撑。
+`compliance_matrix.json` 是“任务响应表”。它告诉评审器和人类评审：官方公告 1.3、1.4、1.5 与面向智能体任务书 `agent.1` 至 `agent.6` 的每个必选任务，在方案中由哪些章节、图层、指标、图纸、HTML 页面、来源、标准和自检项支撑。`source_ids` 只填写 `sources.json` / 中央来源登记中的来源 ID；专业标准 ID 应填写到独立的 `standard_ids`，并同时在 `standard_matrix.json` 中声明，不得混入 `source_ids`。
 
 必须覆盖这些 `requirement_id`：
 
@@ -238,6 +238,7 @@ agent.6 一带全球AI创新活动体系与长期运营设计
   "drawings": ["drawings/a3-booklet.pdf", "drawings/a0-boards.pdf"],
   "visual_sections": ["建筑与更新项目", "任务覆盖"],
   "source_ids": ["OFFICIAL-ANNOUNCEMENT", "OFFICIAL-DESIGN-BOUNDARY"],
+  "standard_ids": ["MOHURD-URBAN-DESIGN-MEASURES"],
   "assumption_ids": ["A-CONTROLS-001"],
   "self_check_ids": ["LAND_USE_TOPOLOGY", "BOUNDARY_TRUST"]
 }

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1767,7 +1767,12 @@ def validate_readiness_claim(
         )
 
 
-def validate_compliance_matrix_file(report: ValidationReport, path: Path, display_path: str) -> None:
+def validate_compliance_matrix_file(
+    report: ValidationReport,
+    path: Path,
+    display_path: str,
+    known_standard_ids: set[str] | None = None,
+) -> None:
     data = load_json_file(report, path, display_path)
     if not isinstance(data, dict):
         return
@@ -1805,6 +1810,32 @@ def validate_compliance_matrix_file(report: ValidationReport, path: Path, displa
             value = item.get(key)
             if not isinstance(value, list) or not value or not all(isinstance(v, str) and v for v in value):
                 report.add_error(f"{label}: {key} must be a non-empty string array")
+        standard_ids = item.get("standard_ids")
+        if standard_ids is not None and (
+            not isinstance(standard_ids, list)
+            or not standard_ids
+            or not all(isinstance(value, str) and value for value in standard_ids)
+        ):
+            report.add_error(f"{label}: standard_ids must be a non-empty string array when present")
+        source_ids = item.get("source_ids")
+        if known_standard_ids and isinstance(source_ids, list):
+            misplaced = sorted(
+                value for value in source_ids if value in known_standard_ids
+            )
+            if misplaced:
+                report.add_warning(
+                    f"{label}: source_ids contains standard IDs that belong in standard_ids: "
+                    f"{', '.join(misplaced)}"
+                )
+        if known_standard_ids and isinstance(standard_ids, list):
+            unknown = sorted(
+                value for value in standard_ids if value not in known_standard_ids
+            )
+            if unknown:
+                report.add_warning(
+                    f"{label}: standard_ids references IDs not declared in standard_matrix.json: "
+                    f"{', '.join(unknown)}"
+                )
 
     missing = sorted(ALL_REQUIRED_TASK_IDS - covered)
     if missing:
@@ -2390,17 +2421,22 @@ def validate_ai_package_dir(
             strict=strict_simulation,
         )
 
-    compliance_path = base / "compliance_matrix.json"
-    if compliance_path.exists():
-        validate_compliance_matrix_file(
-            report, compliance_path, f"{proposal_dir}/compliance_matrix.json"
-        )
-
     standard_matrix: dict | None = None
     standard_path = base / "standard_matrix.json"
     if standard_path.exists():
         standard_matrix = validate_standard_matrix_file(
             report, repo_root, standard_path, f"{proposal_dir}/standard_matrix.json"
+        )
+
+    compliance_path = base / "compliance_matrix.json"
+    if compliance_path.exists():
+        validate_compliance_matrix_file(
+            report,
+            compliance_path,
+            f"{proposal_dir}/compliance_matrix.json",
+            collect_json_ids(standard_matrix, "standards", "standard_id")
+            if isinstance(standard_matrix, dict)
+            else set(),
         )
 
     design_depth_matrix: dict | None = None

--- a/skills/urban-design-ai-submission/SKILL.md
+++ b/skills/urban-design-ai-submission/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: urban-design-ai-submission
-description: Use when an AI agent wants to participate in the Haidian Centennial Jing-Zhang AI Innovation Belt open call, follow changing materials and community discussion, generate or repair a formal machine-readable urban design package, create accessible multimodal images, video, audio/music, Three.js interaction, or a custom cover when capable, run contributor self-checks, and prepare a GitHub PR under submissions/{login}/{slug}/ based only on public or cleared real data.
+description: Use when an AI agent wants to participate in the Haidian Centennial Jing-Zhang AI Innovation Belt open call, follow changing materials and community discussion, generate or repair a formal machine-readable urban design submission package, create accessible multimodal images, video, audio/music, Three.js interaction, or a custom cover when capable, run contributor self-checks, and prepare a GitHub PR under submissions/{login}/{slug}/ based only on public or cleared real data.
 ---
 
 # Urban Design AI Submission
@@ -227,6 +227,7 @@ submission/
 - Provisional geometry must disclose precision limits and must not claim to be an official redline, but organizer data gaps alone do not block content scoring.
 - Every announcement task in sections 1.3, 1.4, and 1.5 must be covered in `compliance_matrix.json`.
 - Every agent-open-call task in `agent_taskbook.json` (`agent.1` through `agent.6`) must be covered in `compliance_matrix.json` and explained in `proposal.md`.
+- In `compliance_matrix.json`, keep evidence namespaces separate: `source_ids` contains only source-registry or package source IDs, while professional standard IDs belong in `standard_ids` and must also be declared in `standard_matrix.json`.
 - Every mandatory professional standard must be covered in `standard_matrix.json`.
 - Every required formal design depth item must be `complete` in `design_depth_matrix.json`.
 - New `proposal.md` files must set `proposal_format_version: "2"`. Legacy files without it use v1 compatibility and do not need a bulk rewrite.

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -28,6 +28,7 @@ from validate_submission import (  # noqa: E402
     is_empty_pdf,
     media_signature_is_valid,
     validate_agent_disclosure,
+    validate_compliance_matrix_file,
     validate_media_manifest_entries,
     validate_submission,
 )
@@ -48,6 +49,50 @@ from github_pr_validation import (  # noqa: E402
     validation_paths_for,
 )
 from validate_local_submission import discover_submission_files  # noqa: E402
+
+
+class ComplianceMatrixNamespaceTests(unittest.TestCase):
+    def test_standard_ids_are_separate_from_source_ids(self) -> None:
+        requirements = []
+        for requirement_id in sorted(ALL_REQUIRED_TASK_IDS):
+            requirements.append(
+                {
+                    "requirement_id": requirement_id,
+                    "mandatory": True,
+                    "report_sections": ["section"],
+                    "geojson_layers": ["geometry/site_boundary.geojson"],
+                    "metrics": ["site_area_sqm"],
+                    "drawings": ["drawings/a3-booklet.pdf"],
+                    "visual_sections": ["overview"],
+                    "source_ids": ["SITE-PACKAGE"],
+                    "standard_ids": ["MOHURD-URBAN-DESIGN-MEASURES"],
+                    "assumption_ids": ["A-CONTROLS-001"],
+                    "self_check_ids": ["BOUNDARY_TRUST"],
+                }
+            )
+        requirements[0]["source_ids"].append("MOHURD-URBAN-DESIGN-MEASURES")
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "compliance_matrix.json"
+            path.write_text(
+                json.dumps(
+                    {"schema_version": "0.1.0", "requirements": requirements},
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+            report = ValidationReport()
+            validate_compliance_matrix_file(
+                report,
+                path,
+                "compliance_matrix.json",
+                {"MOHURD-URBAN-DESIGN-MEASURES"},
+            )
+        self.assertTrue(report.ok, report.errors)
+        self.assertIn(
+            "source_ids contains standard IDs that belong in standard_ids: "
+            "MOHURD-URBAN-DESIGN-MEASURES",
+            "\n".join(report.warnings),
+        )
 
 
 class MediaContractTests(unittest.TestCase):


### PR DESCRIPTION
Fixes #2061

## Root cause

The compliance matrix schema and participant documentation exposed only `source_ids`. Agents therefore had no machine-readable location for standards attached to a task response and could place standard IDs into the source namespace.

## Fix

- add an optional, backward-compatible `standard_ids` property to the compliance matrix schema
- document the source/standard namespace boundary in the formal guide and submission Skill
- validate optional `standard_ids` shape
- warn (without changing pass/fail or scoring) when a standard declared by `standard_matrix.json` appears in `source_ids`, or when `standard_ids` references an undeclared standard
- validate `standard_matrix.json` before the compliance matrix so the warning uses the package's actual standard IDs

Historical matrices without `standard_ids` remain valid. This does not expand the central source registry or change formal scoring.

## Verification

- `python -m unittest tests.test_submission_workflow tests.test_site_package_contract -v` — 146 passed
- `python -m py_compile scripts/validate_submission.py tests/test_submission_workflow.py`
- `python -m json.tool brief/site-package/schemas/compliance_matrix.schema.json`
- `git diff --check`