### PR TITLE
[投稿跟进] 持久化四门自检证据

### DIFF
--- a/submissions/mmmmxxkk/jingzhang-time-commons/manifest.json
+++ b/submissions/mmmmxxkk/jingzhang-time-commons/manifest.json
@@ -191,7 +191,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "728abc45fb504f0667479d759e2d8f9a947c87fdfe079c762c9474ee9d134f1b"
+      "sha256": "873cf92febbaea4218aca4f6ae077ac57d9bd50658c4b1eba2338db52d0df024"
     },
     {
       "path": "sources.json",
@@ -261,8 +261,9 @@
     }
   ],
   "validation_claim": {
-    "self_checked": false,
+    "self_checked": true,
     "known_blockers": [],
-    "data_confidence": "high"
+    "data_confidence": "high",
+    "readiness_contract": "persisted-self-check-v1"
   }
 }

--- a/submissions/mmmmxxkk/jingzhang-time-commons/self_check.json
+++ b/submissions/mmmmxxkk/jingzhang-time-commons/self_check.json
@@ -1,54 +1,215 @@
 {
+  "ok": true,
+  "submission_dir": "submissions/mmmmxxkk/jingzhang-time-commons",
+  "pr_author": "mmmmxxkk",
+  "stage": "formal",
+  "deterministic_validation": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "errors": [],
+      "warnings": [
+        "submissions/mmmmxxkk/jingzhang-time-commons/geometry/site_boundary.geojson: uses provisional boundary; do not treat it as an official redline or precise-area basis. Organizer data gaps do not block content scoring; recalculate when official geometry is supplied",
+        "submissions/mmmmxxkk/jingzhang-time-commons/assets/figures/key-areas.png: bilingual contract requires en display counterpart `assets/figures/key-areas.en.png`; legacy v1 package remains compatible",
+        "submissions/mmmmxxkk/jingzhang-time-commons/assets/figures/land-use-structure.png: bilingual contract requires en display counterpart `assets/figures/land-use-structure.en.png`; legacy v1 package remains compatible",
+        "submissions/mmmmxxkk/jingzhang-time-commons/assets/figures/metrics-evidence.png: bilingual contract requires en display counterpart `assets/figures/metrics-evidence.en.png`; legacy v1 package remains compatible",
+        "submissions/mmmmxxkk/jingzhang-time-commons/assets/figures/mobility-bluegreen.png: bilingual contract requires en display counterpart `assets/figures/mobility-bluegreen.en.png`; legacy v1 package remains compatible",
+        "submissions/mmmmxxkk/jingzhang-time-commons/assets/figures/root-market-concept-render.png: bilingual contract requires en display counterpart `assets/figures/root-market-concept-render.en.png`; legacy v1 package remains compatible",
+        "submissions/mmmmxxkk/jingzhang-time-commons/assets/figures/site-overview.png: bilingual contract requires en display counterpart `assets/figures/site-overview.en.png`; legacy v1 package remains compatible",
+        "submissions/mmmmxxkk/jingzhang-time-commons/drawings/a0-boards.pdf: bilingual contract requires en display counterpart `drawings/a0-boards.en.pdf`; legacy v1 package remains compatible",
+        "submissions/mmmmxxkk/jingzhang-time-commons/drawings/a3-booklet.pdf: bilingual contract requires en display counterpart `drawings/a3-booklet.en.pdf`; legacy v1 package remains compatible",
+        "submissions/mmmmxxkk/jingzhang-time-commons/report/proposal.html: bilingual contract requires en display counterpart `report/proposal.en.html`; legacy v1 package remains compatible",
+        "submissions/mmmmxxkk/jingzhang-time-commons/visual/index.html: bilingual contract requires en display counterpart `visual/index.en.html`; legacy v1 package remains compatible"
+      ],
+      "proposal_files": [
+        "submissions/mmmmxxkk/jingzhang-time-commons/proposal.md"
+      ],
+      "changelog_files": [],
+      "changed_files": [
+        "submissions/mmmmxxkk/jingzhang-time-commons/agent.json",
+        "submissions/mmmmxxkk/jingzhang-time-commons/assets/figures/key-areas.png",
+        "submissions/mmmmxxkk/jingzhang-time-commons/assets/figures/land-use-structure.png",
+        "submissions/mmmmxxkk/jingzhang-time-commons/assets/figures/metrics-evidence.png",
+        "submissions/mmmmxxkk/jingzhang-time-commons/assets/figures/mobility-bluegreen.png",
+        "submissions/mmmmxxkk/jingzhang-time-commons/assets/figures/root-market-concept-render.png",
+        "submissions/mmmmxxkk/jingzhang-time-commons/assets/figures/site-overview.png",
+        "submissions/mmmmxxkk/jingzhang-time-commons/assumptions.json",
+        "submissions/mmmmxxkk/jingzhang-time-commons/compliance_matrix.json",
+        "submissions/mmmmxxkk/jingzhang-time-commons/design_depth_matrix.json",
+        "submissions/mmmmxxkk/jingzhang-time-commons/drawings/a0-boards.pdf",
+        "submissions/mmmmxxkk/jingzhang-time-commons/drawings/a3-booklet.pdf",
+        "submissions/mmmmxxkk/jingzhang-time-commons/geometry/buildings.geojson",
+        "submissions/mmmmxxkk/jingzhang-time-commons/geometry/constraints.geojson",
+        "submissions/mmmmxxkk/jingzhang-time-commons/geometry/green_space.geojson",
+        "submissions/mmmmxxkk/jingzhang-time-commons/geometry/key_areas.geojson",
+        "submissions/mmmmxxkk/jingzhang-time-commons/geometry/land_use.geojson",
+        "submissions/mmmmxxkk/jingzhang-time-commons/geometry/phasing.geojson",
+        "submissions/mmmmxxkk/jingzhang-time-commons/geometry/public_space.geojson",
+        "submissions/mmmmxxkk/jingzhang-time-commons/geometry/roads.geojson",
+        "submissions/mmmmxxkk/jingzhang-time-commons/geometry/site_boundary.geojson",
+        "submissions/mmmmxxkk/jingzhang-time-commons/manifest.json",
+        "submissions/mmmmxxkk/jingzhang-time-commons/metrics.json",
+        "submissions/mmmmxxkk/jingzhang-time-commons/proposal.en.md",
+        "submissions/mmmmxxkk/jingzhang-time-commons/proposal.md",
+        "submissions/mmmmxxkk/jingzhang-time-commons/report/copyright_statement.md",
+        "submissions/mmmmxxkk/jingzhang-time-commons/report/narrative.md",
+        "submissions/mmmmxxkk/jingzhang-time-commons/report/proposal.html",
+        "submissions/mmmmxxkk/jingzhang-time-commons/self_check.json",
+        "submissions/mmmmxxkk/jingzhang-time-commons/sources.json",
+        "submissions/mmmmxxkk/jingzhang-time-commons/standard_matrix.json",
+        "submissions/mmmmxxkk/jingzhang-time-commons/visual/assets/osm-access-nodes.json",
+        "submissions/mmmmxxkk/jingzhang-time-commons/visual/assets/osm-analysis-source.json",
+        "submissions/mmmmxxkk/jingzhang-time-commons/visual/assets/osm-baseline.json",
+        "submissions/mmmmxxkk/jingzhang-time-commons/visual/assets/osm-facilities.json",
+        "submissions/mmmmxxkk/jingzhang-time-commons/visual/assets/peer-theme-audit.json",
+        "submissions/mmmmxxkk/jingzhang-time-commons/visual/assets/retention-data-contract.json",
+        "submissions/mmmmxxkk/jingzhang-time-commons/visual/assets/root-market-concept-render.prompt.json",
+        "submissions/mmmmxxkk/jingzhang-time-commons/visual/index.html"
+      ],
+      "ai_package_stages": {
+        "submissions/mmmmxxkk/jingzhang-time-commons": "formal"
+      },
+      "total_bytes": 11177019,
+      "maintainer_bypass": false
+    },
+    "stderr": ""
+  },
+  "spatial_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "stage": "formal",
+      "issues": [
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-001",
+          "expected": null,
+          "actual": null
+        },
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-002",
+          "expected": null,
+          "actual": null
+        },
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-003",
+          "expected": null,
+          "actual": null
+        }
+      ],
+      "metrics": {
+        "site_area_sqm": 11412825.386,
+        "green_space_area_sqm": 1190077.727,
+        "public_space_area_sqm": 92263.802,
+        "building_footprint_area_sqm": 1386505.057,
+        "green_ratio": 0.104275,
+        "public_space_ratio": 0.008084
+      }
+    },
+    "stderr": ""
+  },
+  "visual_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "issues": [],
+      "metrics_seen": {
+        "site_area_sqm": 11412825.386,
+        "green_ratio": 0.104275,
+        "public_space_ratio": 0.008084
+      }
+    },
+    "stderr": ""
+  },
+  "professional_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "issues": [],
+      "summary": {
+        "standard_matrix_items": 6,
+        "design_depth_items": 15,
+        "known_metric_refs_required": 21,
+        "proposal_format_version": "2",
+        "evidence_contract": "section-anchors-plus-structured-audit",
+        "proposal_reference_counts": {
+          "source": 19,
+          "standard": 0,
+          "depth": 10,
+          "data": 8,
+          "metric": 16
+        }
+      }
+    },
+    "stderr": ""
+  },
+  "spatial_issue_ids": [
+    "KEY_AREA_PROVISIONAL",
+    "KEY_AREA_PROVISIONAL",
+    "KEY_AREA_PROVISIONAL"
+  ],
+  "visual_issue_ids": [],
+  "professional_issue_ids": [],
+  "missing_review_dependencies": [],
+  "can_enter_formal_review": true,
+  "package_type": "professional_design_package",
+  "review_status": "formal-review-ready",
+  "next_actions": [
+    "Review legacy bilingual compatibility warning: submissions/mmmmxxkk/jingzhang-time-commons/assets/figures/key-areas.png: bilingual contract requires en display counterpart `assets/figures/key-areas.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/mmmmxxkk/jingzhang-time-commons/assets/figures/land-use-structure.png: bilingual contract requires en display counterpart `assets/figures/land-use-structure.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/mmmmxxkk/jingzhang-time-commons/assets/figures/metrics-evidence.png: bilingual contract requires en display counterpart `assets/figures/metrics-evidence.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/mmmmxxkk/jingzhang-time-commons/assets/figures/mobility-bluegreen.png: bilingual contract requires en display counterpart `assets/figures/mobility-bluegreen.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/mmmmxxkk/jingzhang-time-commons/assets/figures/root-market-concept-render.png: bilingual contract requires en display counterpart `assets/figures/root-market-concept-render.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/mmmmxxkk/jingzhang-time-commons/assets/figures/site-overview.png: bilingual contract requires en display counterpart `assets/figures/site-overview.en.png`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/mmmmxxkk/jingzhang-time-commons/drawings/a0-boards.pdf: bilingual contract requires en display counterpart `drawings/a0-boards.en.pdf`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/mmmmxxkk/jingzhang-time-commons/drawings/a3-booklet.pdf: bilingual contract requires en display counterpart `drawings/a3-booklet.en.pdf`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/mmmmxxkk/jingzhang-time-commons/report/proposal.html: bilingual contract requires en display counterpart `report/proposal.en.html`; legacy v1 package remains compatible",
+    "Review legacy bilingual compatibility warning: submissions/mmmmxxkk/jingzhang-time-commons/visual/index.html: bilingual contract requires en display counterpart `visual/index.en.html`; legacy v1 package remains compatible"
+  ],
   "schema_version": "0.1.0",
   "checks": [
     {
-      "check_id": "BOUNDARY_TRUST",
+      "check_id": "DETERMINISTIC_VALIDATION",
       "result": "pass",
-      "severity": "major",
-      "target": "geometry/site_boundary.geojson",
-      "message": "Provisional boundary remains explicit and replaceable."
+      "severity": "blocking",
+      "target": "validate_local_submission.py",
+      "message": "deterministic_validation: PASS"
     },
     {
-      "check_id": "KEY_AREAS_TRUST",
+      "check_id": "SPATIAL_REVIEW",
       "result": "pass",
-      "severity": "major",
-      "target": "geometry/key_areas.geojson",
-      "message": "Three key areas remain provisional rough polygons."
+      "severity": "blocking",
+      "target": "spatial_review.py",
+      "message": "spatial_review: PASS"
     },
     {
-      "check_id": "LAND_USE_TOPOLOGY",
+      "check_id": "VISUAL_PACKAGING",
       "result": "pass",
-      "severity": "major",
-      "target": "geometry/land_use.geojson",
-      "message": "Six shared-edge bands partition the submitted boundary."
+      "severity": "blocking",
+      "target": "visual_review.py",
+      "message": "visual_review: PASS"
     },
     {
-      "check_id": "OSM_BASELINE_REPRODUCIBLE",
+      "check_id": "PROFESSIONAL_EVIDENCE",
       "result": "pass",
-      "severity": "major",
-      "target": "visual/assets/osm-analysis-source.json",
-      "message": "OSMnx source, requirements, method, attribution, outputs and limitations are packaged."
-    },
-    {
-      "check_id": "RETENTION_CLAIM_BOUNDARY",
-      "result": "pass",
-      "severity": "major",
-      "target": "visual/assets/retention-data-contract.json",
-      "message": "Retention outcomes remain unknown and no individual displacement-risk score is allowed."
-    },
-    {
-      "check_id": "SCENARIO_SAFETY",
-      "result": "pass",
-      "severity": "major",
-      "target": "proposal.md",
-      "message": "Twelve scenarios share non-AI baseline, human review, appeal, pause and exit gates."
-    },
-    {
-      "check_id": "VISUAL_STATIC",
-      "result": "pass",
-      "severity": "info",
-      "target": "visual/index.html",
-      "message": "Offline static HTML uses local assets and inline CSS."
+      "severity": "blocking",
+      "target": "professional_review.py",
+      "message": "professional_review: PASS"
     }
   ]
 }


### PR DESCRIPTION
## 根因

当前 `main` 引入 `readiness_contract=persisted-self-check-v1`：`ready_for_review` 包应把四门自检结果持久化到 `self_check.json`，并在 manifest 中声明 `validation_claim.self_checked=true`。本投稿的四门检查一直通过，但文件仍是历史检查清单格式，只得到 legacy compatibility warning。

## 修订

- 使用当前主线官方命令 `self_check_submission.py --mark-self-checked --json` 重跑；
- 将完整 deterministic / spatial / visual / professional 结果写入 `self_check.json`；
- 刷新 manifest 中 `self_check.json` 的 SHA-256；
- 设置 `validation_claim.self_checked=true` 与 `readiness_contract=persisted-self-check-v1`。

没有修改设计、边界、指标或多模态内容。新的多模态任务书条款是 capability-based 推荐，不是用装饰性媒体替代证据的理由。

## 结果

- deterministic validation: PASS
- spatial review: PASS
- visual review: PASS
- professional review: PASS
- `can_enter_formal_review=true`
- `missing_review_dependencies=[]`

既有非阻塞边界与历史双语 counterpart 提醒继续保留。
