### PR TITLE
fix: require exact front matter delimiters

### DIFF
--- a/scripts/front_matter.py
+++ b/scripts/front_matter.py
@@ -1,5 +1,7 @@
 """Dependency-free parsing for the repository's Markdown front matter."""
 
+import re
+
 BLOCK_SCALARS = {">", ">-", "|", "|-"}
 
 
@@ -35,14 +37,17 @@ def _block_value(lines: list[str], style: str) -> str:
 
 def parse_front_matter(text: str) -> tuple[dict[str, str], str]:
     """Parse scalar front matter, including folded and literal block strings."""
-    text = text.lstrip("\ufeff\n")
-    if not text.startswith("---\n"):
+    text = text.lstrip("\ufeff\r\n")
+    opening = re.match(r"^---[ \t]*\r?\n", text)
+    if opening is None:
         return {}, text
-    end = text.find("\n---", 4)
-    if end == -1:
+    closing = re.search(r"(?m)^---[ \t]*\r?$", text[opening.end() :])
+    if closing is None:
         return {}, text
-    lines = text[4:end].splitlines()
-    body = text[end + len("\n---") :].lstrip("\n")
+    closing_start = opening.end() + closing.start()
+    closing_end = opening.end() + closing.end()
+    lines = text[opening.end() : closing_start].splitlines()
+    body = text[closing_end:].lstrip("\r\n")
     metadata: dict[str, str] = {}
     index = 0
     while index < len(lines):

--- a/tests/test_front_matter.py
+++ b/tests/test_front_matter.py
@@ -58,6 +58,26 @@ summary: >-
         self.assertEqual(parse_front_matter("Body"), ({}, "Body"))
         self.assertEqual(parse_front_matter("---\nsummary: x"), ({}, "---\nsummary: x"))
 
+    def test_crlf_front_matter_preserves_crlf_body(self) -> None:
+        text = '---\r\ntitle: "CRLF proposal"\r\nsummary: >-\r\n  First line.\r\n  Second line.\r\n---\r\nBody\r\n'
+
+        metadata, body = parse_front_matter(text)
+
+        self.assertEqual(metadata["title"], "CRLF proposal")
+        self.assertEqual(metadata["summary"], "First line. Second line.")
+        self.assertEqual(body, "Body\r\n")
+        self.assertEqual(parse_gallery_front_matter(text), metadata)
+
+    def test_delimiter_must_occupy_the_complete_line(self) -> None:
+        for false_delimiter in ("---suffix", "----"):
+            with self.subTest(false_delimiter=false_delimiter):
+                text = f"---\ntitle: Test\n{false_delimiter}\nBody\n"
+                self.assertEqual(parse_front_matter(text), ({}, text))
+
+        metadata, body = parse_front_matter("---  \ntitle: Test\n---\t\nBody\n")
+        self.assertEqual(metadata, {"title": "Test"})
+        self.assertEqual(body, "Body\n")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- recognize front matter in CRLF Markdown documents
- require opening and closing delimiters to occupy complete lines
- preserve the original newline style in the returned body

## Problem
The shared parser only recognized LF input and searched for the first `\n---` prefix. As a result, a normal CRLF proposal returned no metadata, while lines such as `---not-a-delimiter` and `----` were incorrectly consumed as closing delimiters. Gallery metadata extraction uses this same parser.

## Tests
- `python3 -m unittest -v tests.test_front_matter tests.test_submission_workflow.ProposalSchemaTests`
- `git diff --check`

The gallery generated-data test was also invoked in this blob-filtered clone, but its 704 tracked submission files are intentionally not materialized here, so the generator sees zero physical proposals and reports the checked-in gallery as stale. The direct gallery parser parity assertion is included in `tests.test_front_matter`.
