### PR TITLE
fix: reject malformed self-check subprocess output

### DIFF
--- a/scripts/self_check_submission.py
+++ b/scripts/self_check_submission.py
@@ -45,17 +45,28 @@ def run_json_command(command: list[str]) -> dict[str, Any]:
         check=False,
         env=environment,
     )
-    parsed: Any = {}
+    parsed: Any = None
+    parse_error = ""
     stdout = completed.stdout or ""
     stderr = completed.stderr or ""
     if stdout.strip():
         try:
             parsed = json.loads(stdout)
-        except json.JSONDecodeError:
-            parsed = {"raw_stdout": stdout}
+        except json.JSONDecodeError as exc:
+            parse_error = f"invalid JSON output: {exc.msg} at line {exc.lineno}"
+    else:
+        parse_error = "command produced no JSON output"
+    if not parse_error and not isinstance(parsed, dict):
+        parse_error = f"JSON output must be an object, got {type(parsed).__name__}"
+    if parse_error:
+        diagnostic = parse_error
+        if stderr.strip():
+            diagnostic = f"{diagnostic}; {stderr.strip()}"
+        stderr = diagnostic
+        parsed = {"raw_stdout": stdout} if stdout else {}
     return {
         "returncode": completed.returncode,
-        "ok": completed.returncode == 0,
+        "ok": completed.returncode == 0 and not parse_error,
         "stdout": parsed,
         "stderr": stderr.strip(),
     }

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -109,7 +109,30 @@ class SelfCheckEncodingTests(unittest.TestCase):
         )
         self.assertEqual("1", run.call_args.kwargs["env"]["PYTHONUTF8"])
         self.assertEqual("utf-8", run.call_args.kwargs["env"]["PYTHONIOENCODING"])
-        self.assertEqual({"returncode": 1, "ok": False, "stdout": {}, "stderr": ""}, result)
+        self.assertEqual(
+            {
+                "returncode": 1,
+                "ok": False,
+                "stdout": {},
+                "stderr": "command produced no JSON output",
+            },
+            result,
+        )
+
+    def test_run_json_command_requires_json_object_output(self) -> None:
+        fixtures = [
+            ("print('not json')", "invalid JSON output"),
+            ("print('[]')", "JSON output must be an object, got list"),
+            ("print('null')", "JSON output must be an object, got NoneType"),
+            ("pass", "command produced no JSON output"),
+        ]
+        for script, expected_error in fixtures:
+            with self.subTest(script=script):
+                result = run_json_command([sys.executable, "-c", script])
+
+                self.assertEqual(0, result["returncode"])
+                self.assertFalse(result["ok"])
+                self.assertIn(expected_error, result["stderr"])
 
 
 def run_scaffold(output_dir: Path, stage: str = "formal", cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess:


### PR DESCRIPTION
## Summary
- require every self-check child command to return a JSON object before its gate can pass
- turn empty, malformed, array, null, and scalar output into stable diagnostics
- preserve the child return code and raw stdout for troubleshooting

## Problem
`run_json_command()` treated any zero exit code as `ok: true`, even when stdout was empty, malformed JSON, or a JSON array/scalar. All four pre-submit gates share this wrapper. A child that regressed to `print([])` could therefore be recorded as passing; the list then reached `infer_stage()` and raised `AttributeError` instead of producing a self-check report.

## Tests
- `python3 -m unittest -v tests.test_agent_scaffold_and_self_check.SelfCheckEncodingTests`
- `python3 -m py_compile scripts/self_check_submission.py tests/test_agent_scaffold_and_self_check.py`
- `git diff --check`

The complete scaffold module was also invoked. Its dependency-free tests reached this new regression successfully, while the blob-filtered clone lacks the materialized `skills/urban-design-ai-submission/SKILL.md` fixture and review dependencies, leaving one unrelated docs fixture error and 22 dependency skips.
