### PR TITLE
fix: enforce proposal metadata length limits

### DIFF
--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -2481,6 +2481,17 @@ def validate_proposal_file(
     for key in required_metadata:
         if not metadata.get(key):
             report.add_error(f"{proposal_path}: missing front matter field `{key}`")
+    metadata_length_limits = {
+        "title": (2, 120),
+        "summary": (10, 500),
+    }
+    for key, (minimum, maximum) in metadata_length_limits.items():
+        value = metadata.get(key)
+        if value and not minimum <= len(value) <= maximum:
+            report.add_error(
+                f"{proposal_path}: front matter `{key}` must contain {minimum} to "
+                f"{maximum} characters; got {len(value)}"
+            )
 
     author = metadata.get("author_github", "")
     if author and author.lower() != pr_author.lower() and not report.maintainer_bypass:

--- a/tests/test_proposal_metadata_lengths.py
+++ b/tests/test_proposal_metadata_lengths.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from validate_submission import (  # noqa: E402
+    REQUIRED_SECTIONS,
+    ValidationReport,
+    validate_proposal_file,
+)
+
+
+class ProposalMetadataLengthTests(unittest.TestCase):
+    def validate_metadata(self, title: str, summary: str) -> ValidationReport:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            relative = "submissions/alice/metadata-length/proposal.md"
+            proposal = root / relative
+            proposal.parent.mkdir(parents=True)
+            sections = "\n\n".join(
+                f"## {heading}\n{'完整设计证据与空间指标说明。' * 12}"
+                for heading in REQUIRED_SECTIONS
+            )
+            proposal.write_text(
+                "\n".join(
+                    [
+                        "---",
+                        f"title: {title}",
+                        'author_github: "alice"',
+                        'language: "zh"',
+                        'license: "CC-BY-4.0"',
+                        f"summary: {summary}",
+                        "---",
+                        "",
+                        "# Proposal",
+                        "",
+                        sections,
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            report = ValidationReport()
+            validate_proposal_file(report, root, relative, "alice", "alice")
+            return report
+
+    def test_title_enforces_published_length_boundaries(self) -> None:
+        summary = "s" * 10
+        for length, valid in [(1, False), (2, True), (120, True), (121, False)]:
+            with self.subTest(length=length):
+                report = self.validate_metadata("t" * length, summary)
+                length_errors = [
+                    error for error in report.errors if "front matter `title`" in error
+                ]
+                self.assertEqual([] if valid else [length], [length] * len(length_errors))
+                if not valid:
+                    self.assertIn(f"got {length}", length_errors[0])
+
+    def test_summary_enforces_published_length_boundaries(self) -> None:
+        for length, valid in [(9, False), (10, True), (500, True), (501, False)]:
+            with self.subTest(length=length):
+                report = self.validate_metadata("Valid title", "s" * length)
+                length_errors = [
+                    error for error in report.errors if "front matter `summary`" in error
+                ]
+                self.assertEqual([] if valid else [length], [length] * len(length_errors))
+                if not valid:
+                    self.assertIn(f"got {length}", length_errors[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enforce the published 2-120 character contract for proposal titles
- enforce the published 10-500 character contract for proposal summaries
- report the actual length for each violation

## Problem
`schema/proposal.schema.json` documents these bounds, but the trusted validator only checked that `title` and `summary` were non-empty. A proposal with a 121-character title or 501-character summary therefore passed intake and the gallery generator published the overlong value unchanged. One-character titles and nine-character summaries also passed despite violating the same schema.

## Tests
- `python3 -m unittest -v tests.test_proposal_metadata_lengths tests.test_front_matter tests.test_submission_workflow.ProposalSchemaTests`
- `python3 -m py_compile scripts/validate_submission.py tests/test_proposal_metadata_lengths.py`
- `git diff --check`

The focused matrix verifies title lengths 1/2/120/121 and summary lengths 9/10/500/501.

## Related work
#1471 also modifies `scripts/validate_submission.py`, but its patch is confined to persisted readiness claims, self-check validation, and validator call parameters. This change is localized to `validate_proposal_file()` metadata checks and uses a separate test module. #2113 changes section/schema relationships rather than these existing length bounds.
