### PR TITLE
fix: fail empty manifest audits

### DIFF
--- a/scripts/validate_manifest_schema.py
+++ b/scripts/validate_manifest_schema.py
@@ -29,6 +29,12 @@ def main() -> int:
         paths = manifest_paths(repo_root)
     else:
         paths = [(repo_root / item).resolve() for item in args.manifests]
+    selection_error = None
+    if not paths:
+        selection_error = (
+            f"no submission manifests found under {repo_root}; "
+            "check --repo-root and sparse checkout configuration"
+        )
 
     results = []
     for path in paths:
@@ -63,6 +69,8 @@ def main() -> int:
         "strict": args.strict,
         "results": results,
     }
+    if selection_error:
+        payload["error"] = selection_error
     legacy_findings = [
         finding
         for item in results
@@ -84,6 +92,8 @@ def main() -> int:
     else:
         mode = "strict" if args.strict else "advisory"
         print(f"Manifest schema audit ({mode}): {payload['valid']}/{payload['total']} valid")
+        if selection_error:
+            print(f"Audit error: {selection_error}")
         for item in invalid:
             print(f"- {item['path']}: {len(item['errors'])} schema error(s)")
             for error in item["errors"][:5]:
@@ -99,6 +109,8 @@ def main() -> int:
                     f"- {item['path']}: legacy role advisory "
                     f"{finding['path']} ({finding['role']}): {detail}"
                 )
+    if selection_error:
+        return 2
     return 1 if args.strict and invalid else 0
 
 

--- a/tests/test_validate_manifest_schema_cli.py
+++ b/tests/test_validate_manifest_schema_cli.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "validate_manifest_schema.py"
+
+
+class ValidateManifestSchemaCliTests(unittest.TestCase):
+    def run_audit(self, root: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--repo-root", str(root), *arguments],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_strict_json_audit_rejects_empty_manifest_set(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            completed = self.run_audit(Path(tmp), "--all", "--strict", "--json")
+
+        self.assertEqual(2, completed.returncode)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(0, payload["total"])
+        self.assertEqual([], payload["results"])
+        self.assertIn("no submission manifests found", payload["error"])
+
+    def test_advisory_audit_rejects_missing_repository_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "missing-root"
+            completed = self.run_audit(missing, "--all")
+
+        self.assertEqual(2, completed.returncode)
+        self.assertIn("Manifest schema audit (advisory): 0/0 valid", completed.stdout)
+        self.assertIn("Audit error: no submission manifests found", completed.stdout)
+
+    def test_existing_manifest_uses_normal_schema_result_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path = root / "submissions" / "alice" / "sample" / "manifest.json"
+            manifest_path.parent.mkdir(parents=True)
+            manifest_path.write_text("{}", encoding="utf-8")
+
+            completed = self.run_audit(root, "--all", "--json")
+
+        self.assertEqual(0, completed.returncode)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(1, payload["total"])
+        self.assertEqual(1, payload["invalid"])
+        self.assertNotIn("error", payload)
+        self.assertEqual(
+            "submissions/alice/sample/manifest.json", payload["results"][0]["path"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fail manifest corpus audits when no manifests were selected
- keep JSON mode machine-readable with the existing counts plus a top-level error
- distinguish selection/configuration failure (exit 2) from strict schema failure (exit 1)

## Problem
`validate_manifest_schema.py --all --strict` returned success for an empty directory or a nonexistent `--repo-root`, reporting `0/0 valid`. The repository currently has hundreds of manifests, so an incorrect path or incomplete sparse checkout could silently turn a strict gate into a no-op.

## Tests
- `python3 -m unittest -v tests.test_validate_manifest_schema_cli tests.test_manifest_schema`
- `python3 -m py_compile scripts/validate_manifest_schema.py tests/test_validate_manifest_schema_cli.py`
- `git diff --check`

The new CLI tests cover strict JSON output on an empty root, advisory text output on a missing root, and the unchanged normal result path when one invalid manifest is actually present.
