### PR TITLE
fix: keep maintainer review on trusted scripts

### DIFF
--- a/scripts/maintainer_review.py
+++ b/scripts/maintainer_review.py
@@ -18,9 +18,8 @@ DEFAULT_OUTPUT_ROOT = ".maintainer-review"
 
 
 def script_path(repo_root: Path, name: str) -> Path:
-    candidate = repo_root / "scripts" / name
-    if candidate.exists():
-        return candidate
+    # repo_root can be a participant-controlled PR checkout. Review commands
+    # must always execute the maintainer worker's trusted script version.
     return SCRIPT_DIR / name
 
 

--- a/tests/test_maintainer_review_trusted_script.py
+++ b/tests/test_maintainer_review_trusted_script.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import maintainer_review  # noqa: E402
+
+
+class MaintainerReviewTrustedScriptTests(unittest.TestCase):
+    def test_script_path_ignores_participant_checkout_script(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            checkout = Path(tmp)
+            untrusted = checkout / "scripts" / "self_check_submission.py"
+            untrusted.parent.mkdir()
+            untrusted.write_text("raise RuntimeError('participant code ran')\n", encoding="utf-8")
+
+            resolved = maintainer_review.script_path(checkout, untrusted.name)
+
+            self.assertEqual(REPO_ROOT / "scripts" / untrusted.name, resolved)
+
+    def test_review_command_uses_trusted_self_check_script(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            checkout = Path(tmp)
+            submission = checkout / "submissions" / "alice" / "proposal"
+            submission.mkdir(parents=True)
+            untrusted = checkout / "scripts" / "self_check_submission.py"
+            untrusted.parent.mkdir()
+            untrusted.write_text("raise RuntimeError('participant code ran')\n", encoding="utf-8")
+            output = checkout / "review-output"
+            self_check = {
+                "returncode": 1,
+                "ok": False,
+                "stdout": {},
+                "stderr": "fixture failure",
+            }
+            with mock.patch.object(
+                maintainer_review, "run_json_command", return_value=self_check
+            ) as run_command, mock.patch.object(
+                maintainer_review,
+                "build_review_input",
+                return_value={
+                    "submission_dir": "submissions/alice/proposal",
+                    "rubric_dimensions": [],
+                },
+            ):
+                maintainer_review.run_maintainer_review(
+                    checkout, submission, "alice", output
+                )
+
+            command = run_command.call_args.args[0]
+            self.assertEqual(
+                REPO_ROOT / "scripts" / "self_check_submission.py", Path(command[1])
+            )
+            self.assertNotEqual(untrusted, Path(command[1]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- always run the maintainer worker's trusted `self_check_submission.py`
- ignore same-named scripts in a participant-controlled review checkout
- add dependency-free path and command-level regressions

## Problem
`review_submission.py` and `self_check_submission.py` intentionally resolve executables from their own trusted script directory. `maintainer_review.py` was the exception: its `script_path()` preferred `<repo_root>/scripts/self_check_submission.py` whenever present. Maintainer review commonly receives a PR checkout as `repo_root`, so a participant could modify that Python file and have the trusted review host execute it before producing a recommendation.

## Tests
- `python3 -m unittest -v tests.test_maintainer_review_trusted_script tests.test_trusted_review_scripts`
- `python3 -m py_compile scripts/maintainer_review.py tests/test_maintainer_review_trusted_script.py`
- `git diff --check`

## Related work
#1944 changes documentation/help text in this script. #1515 changes subprocess encoding. #1386 changes review-readiness semantics. None changes executable resolution; this patch is limited to `script_path()` and a separate test module.
