### PR TITLE
fix: require canonical gallery registry paths

### DIFF
--- a/scripts/generate_submissions_data.py
+++ b/scripts/generate_submissions_data.py
@@ -24,6 +24,9 @@ from front_matter import parse_front_matter as parse_front_matter_document
 
 
 PUBLICATION_FILE = "gallery-publication.json"
+PUBLICATION_PATH_RE = re.compile(
+    r"^submissions/[A-Za-z0-9-]{1,39}/[a-z0-9][a-z0-9-]{2,63}$"
+)
 
 
 REQUIRED_PACKAGE_FILES = {
@@ -410,11 +413,11 @@ def load_publication_registry(repo_root: Path) -> dict[str, dict[str, Any]]:
             raise SystemExit(f"{PUBLICATION_FILE}: entries[{index}].reviewed_by must be a GitHub login")
         if not isinstance(entry["reviewed_package_sha256"], str) or not re.fullmatch(r"[0-9a-f]{64}", entry["reviewed_package_sha256"]):
             raise SystemExit(f"{PUBLICATION_FILE}: entries[{index}].reviewed_package_sha256 must be a lowercase SHA-256")
-        rel = entry["path"].strip().rstrip("/")
+        rel = entry["path"]
+        if not PUBLICATION_PATH_RE.fullmatch(rel):
+            raise SystemExit(f"{PUBLICATION_FILE}: invalid submission path {rel}")
         if rel in registry:
             raise SystemExit(f"{PUBLICATION_FILE}: duplicate entry for {rel}")
-        if not rel.startswith("submissions/") or len(Path(rel).parts) != 3:
-            raise SystemExit(f"{PUBLICATION_FILE}: invalid submission path {rel}")
         if entry.get("published") is True and not (repo_root / rel / "proposal.md").is_file():
             raise SystemExit(f"{PUBLICATION_FILE}: published submission does not exist: {rel}")
         if entry.get("featured") is True and entry.get("published") is not True:

--- a/tests/test_gallery_publication_paths.py
+++ b/tests/test_gallery_publication_paths.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from generate_submissions_data import (  # noqa: E402
+    PUBLICATION_PATH_RE,
+    build_data,
+    load_publication_registry,
+)
+
+
+def held_entry(path: str) -> dict[str, object]:
+    return {
+        "path": path,
+        "published": False,
+        "featured": False,
+        "review_status": "not_approved",
+        "quality_tier": "qualified",
+        "reviewed_by": "maintainer",
+        "reviewed_at": "2026-08-12",
+        "rights_reviewed": False,
+        "reviewed_package_sha256": "0" * 64,
+        "selection_reason_zh": "维护者暂停公开展示",
+        "selection_reason_en": "Held from public display",
+        "selected_at": "2026-08-12",
+    }
+
+
+class GalleryPublicationPathTests(unittest.TestCase):
+    def write_registry(self, root: Path, path: str) -> None:
+        (root / "gallery-publication.json").write_text(
+            json.dumps({"version": 1, "entries": [held_entry(path)]}),
+            encoding="utf-8",
+        )
+
+    def test_noncanonical_hold_paths_are_rejected(self) -> None:
+        invalid_paths = [
+            "submissions//alice/example",
+            "submissions/./alice/example",
+            "submissions/alice/example/",
+            "submissions/alice/Example",
+            "submissions/alice/ex",
+        ]
+        for path in invalid_paths:
+            with self.subTest(path=path), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                self.write_registry(root, path)
+
+                with self.assertRaisesRegex(SystemExit, "invalid submission path"):
+                    load_publication_registry(root)
+
+    def test_runtime_path_pattern_matches_published_schema(self) -> None:
+        schema = json.loads(
+            (REPO_ROOT / "schema" / "gallery-publication.schema.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        schema_pattern = schema["properties"]["entries"]["items"]["properties"]["path"][
+            "pattern"
+        ]
+
+        self.assertEqual(schema_pattern, PUBLICATION_PATH_RE.pattern)
+
+    def test_canonical_hold_key_excludes_discovered_submission(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            proposal = root / "submissions" / "alice" / "example" / "proposal.md"
+            proposal.parent.mkdir(parents=True)
+            proposal.write_text("# Held proposal\n", encoding="utf-8")
+            self.write_registry(root, "submissions/alice/example")
+
+            self.assertEqual([], build_data(root))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enforce the published gallery registry path pattern at runtime
- reject dot segments, duplicate/trailing separators, invalid owners, and invalid slugs
- keep publication/hold keys identical to discovered submission paths

## Problem
The schema requires `submissions/<github-login>/<slug>`, but `load_publication_registry()` only inspected `Path(rel).parts` after stripping the value. Inputs such as `submissions//alice/example` were accepted and stored under that noncanonical string. `build_data()` later looked up the canonical key `submissions/alice/example`, missed the `published:false` hold, and published the merged proposal by default.

## Tests
- `python3 -m unittest -v tests.test_gallery_publication_paths tests.test_submissions_gallery.TestSubmissionsGallery.test_registry_can_explicitly_hold_a_merged_submission tests.test_submissions_gallery.TestSubmissionsGallery.test_publication_registry_rejects_missing_selection_metadata tests.test_submissions_gallery.TestSubmissionsGallery.test_publication_registry_rejects_invalid_date_and_flag_types`
- `python3 -m py_compile scripts/generate_submissions_data.py tests/test_gallery_publication_paths.py`
- `git diff --check`

The new tests cover five noncanonical path forms, runtime/schema pattern parity, and a canonical hold excluding a discovered proposal.

## Related work
#2108 adds schema state relationships but does not change the existing path pattern or runtime path handling. #306 and #1471 modify gallery readiness classification only. The path validation change is isolated and uses a separate test module.
