### PR TITLE
fix: bound standard reference fetches

### DIFF
--- a/scripts/fetch_standard_references.py
+++ b/scripts/fetch_standard_references.py
@@ -15,6 +15,7 @@ import json
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from datetime import date
@@ -24,6 +25,10 @@ from typing import Any
 
 
 DEFAULT_USER_AGENT = "Mozilla/5.0 (compatible; haidian-ai-standards-fetcher/0.1)"
+ALLOWED_URL_SCHEMES = {"http", "https"}
+REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
+MAX_REDIRECTS = 5
+MAX_RESPONSE_BYTES = 10 * 1024 * 1024
 
 
 @dataclass
@@ -85,6 +90,11 @@ class VisibleTextParser(HTMLParser):
         return "\n\n".join(lines)
 
 
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        return None
+
+
 def slugify(value: str) -> str:
     slug = re.sub(r"[^a-z0-9-]+", "-", value.lower()).strip("-")
     slug = re.sub(r"-{2,}", "-", slug)
@@ -107,18 +117,84 @@ def decode_html(raw: bytes, content_type: str | None) -> str:
 
 
 def fetch_url(url: str, timeout: float) -> FetchResult:
-    request = urllib.request.Request(url, headers={"User-Agent": DEFAULT_USER_AGENT})
-    try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:
-            raw = response.read()
-            content_type = response.headers.get("content-type")
-            final_url = response.geturl()
-    except urllib.error.HTTPError as exc:
-        return FetchResult(False, f"http_{exc.code}", error=str(exc), final_url=url)
-    except urllib.error.URLError as exc:
-        return FetchResult(False, "url_error", error=str(exc.reason), final_url=url)
-    except TimeoutError as exc:
-        return FetchResult(False, "timeout", error=str(exc), final_url=url)
+    opener = urllib.request.build_opener(NoRedirectHandler())
+    current_url = url
+    response = None
+    for redirect_count in range(MAX_REDIRECTS + 1):
+        try:
+            scheme = urllib.parse.urlsplit(current_url).scheme.lower()
+        except ValueError as exc:
+            return FetchResult(False, "invalid_url", error=str(exc), final_url=current_url)
+        if scheme not in ALLOWED_URL_SCHEMES:
+            return FetchResult(
+                False,
+                "unsupported_url_scheme",
+                error=f"URL scheme must be http or https: {scheme or 'missing'}",
+                final_url=current_url,
+            )
+        request = urllib.request.Request(
+            current_url, headers={"User-Agent": DEFAULT_USER_AGENT}
+        )
+        try:
+            response = opener.open(request, timeout=timeout)
+            break
+        except urllib.error.HTTPError as exc:
+            if exc.code not in REDIRECT_STATUS_CODES:
+                return FetchResult(
+                    False, f"http_{exc.code}", error=str(exc), final_url=current_url
+                )
+            location = exc.headers.get("location") or exc.headers.get("uri")
+            exc.close()
+            if not location:
+                return FetchResult(
+                    False,
+                    "redirect_missing_location",
+                    error=f"HTTP {exc.code} response has no Location header",
+                    final_url=current_url,
+                )
+            if redirect_count == MAX_REDIRECTS:
+                return FetchResult(
+                    False,
+                    "too_many_redirects",
+                    error=f"redirect limit exceeded ({MAX_REDIRECTS})",
+                    final_url=current_url,
+                )
+            current_url = urllib.parse.urljoin(current_url, location)
+        except urllib.error.URLError as exc:
+            return FetchResult(
+                False, "url_error", error=str(exc.reason), final_url=current_url
+            )
+        except (TimeoutError, ValueError) as exc:
+            status = "timeout" if isinstance(exc, TimeoutError) else "invalid_url"
+            return FetchResult(False, status, error=str(exc), final_url=current_url)
+
+    if response is None:
+        return FetchResult(False, "url_error", error="request produced no response", final_url=current_url)
+    with response:
+        content_type = response.headers.get("content-type")
+        final_url = response.geturl()
+        content_length = response.headers.get("content-length")
+        try:
+            declared_length = int(content_length) if content_length is not None else None
+        except ValueError:
+            declared_length = None
+        if declared_length is not None and declared_length > MAX_RESPONSE_BYTES:
+            return FetchResult(
+                False,
+                "response_too_large",
+                error=f"declared response size exceeds {MAX_RESPONSE_BYTES} bytes",
+                final_url=final_url,
+                content_type=content_type,
+            )
+        raw = response.read(MAX_RESPONSE_BYTES + 1)
+    if len(raw) > MAX_RESPONSE_BYTES:
+        return FetchResult(
+            False,
+            "response_too_large",
+            error=f"response exceeds {MAX_RESPONSE_BYTES} bytes",
+            final_url=final_url,
+            content_type=content_type,
+        )
 
     parser = VisibleTextParser()
     parser.feed(decode_html(raw, content_type))

--- a/tests/test_fetch_standard_reference_network_bounds.py
+++ b/tests/test_fetch_standard_reference_network_bounds.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import email.message
+import unittest
+from unittest import mock
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import fetch_standard_references as fetcher  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        body: bytes,
+        url: str = "https://example.com/final",
+        content_length: str | None = None,
+    ) -> None:
+        self.body = body
+        self.url = url
+        self.headers = email.message.Message()
+        self.headers["content-type"] = "text/html; charset=utf-8"
+        if content_length is not None:
+            self.headers["content-length"] = content_length
+        self.read_sizes: list[int] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def close(self) -> None:
+        pass
+
+    def geturl(self) -> str:
+        return self.url
+
+    def read(self, size: int) -> bytes:
+        self.read_sizes.append(size)
+        return self.body[:size]
+
+
+class RedirectBody:
+    def read(self, *args):
+        raise AssertionError("redirect response body must not be read")
+
+    def close(self) -> None:
+        pass
+
+
+def redirect_error(source: str, location: str):
+    headers = email.message.Message()
+    headers["location"] = location
+    return fetcher.urllib.error.HTTPError(source, 302, "Found", headers, RedirectBody())
+
+
+class FetchStandardReferenceNetworkBoundsTests(unittest.TestCase):
+    def test_initial_non_http_schemes_are_rejected_without_opening(self) -> None:
+        for url in ("file:///tmp/private.html", "data:text/html,private"):
+            with self.subTest(url=url), mock.patch.object(
+                fetcher.urllib.request.OpenerDirector, "open"
+            ) as open_request:
+                result = fetcher.fetch_url(url, 1)
+
+            self.assertFalse(result.ok)
+            self.assertEqual("unsupported_url_scheme", result.status)
+            open_request.assert_not_called()
+
+    def test_redirect_body_is_not_read_and_relative_target_is_followed(self) -> None:
+        final = FakeResponse(b"<p>official</p>", "https://example.com/final")
+        with mock.patch.object(
+            fetcher.urllib.request.OpenerDirector,
+            "open",
+            side_effect=[redirect_error("https://example.com/start", "/final"), final],
+        ) as open_request:
+            result = fetcher.fetch_url("https://example.com/start", 1)
+
+        self.assertTrue(result.ok)
+        self.assertEqual("https://example.com/final", open_request.call_args_list[1].args[0].full_url)
+        self.assertEqual([fetcher.MAX_RESPONSE_BYTES + 1], final.read_sizes)
+
+    def test_redirect_to_non_http_scheme_is_rejected_before_second_request(self) -> None:
+        with mock.patch.object(
+            fetcher.urllib.request.OpenerDirector,
+            "open",
+            side_effect=[redirect_error("https://example.com/start", "file:///tmp/private")],
+        ) as open_request:
+            result = fetcher.fetch_url("https://example.com/start", 1)
+
+        self.assertFalse(result.ok)
+        self.assertEqual("unsupported_url_scheme", result.status)
+        self.assertEqual(1, open_request.call_count)
+
+    def test_redirect_limit_is_enforced(self) -> None:
+        redirects = [
+            redirect_error(f"https://example.com/{index}", f"/{index + 1}")
+            for index in range(fetcher.MAX_REDIRECTS + 1)
+        ]
+        with mock.patch.object(
+            fetcher.urllib.request.OpenerDirector, "open", side_effect=redirects
+        ):
+            result = fetcher.fetch_url("https://example.com/0", 1)
+
+        self.assertFalse(result.ok)
+        self.assertEqual("too_many_redirects", result.status)
+
+    def test_actual_response_size_boundary_is_enforced(self) -> None:
+        for extra, ok in ((0, True), (1, False)):
+            with self.subTest(extra=extra):
+                response = FakeResponse(b"x" * (fetcher.MAX_RESPONSE_BYTES + extra))
+                with mock.patch.object(
+                    fetcher.urllib.request.OpenerDirector, "open", return_value=response
+                ):
+                    result = fetcher.fetch_url("https://example.com/start", 1)
+
+                self.assertEqual(ok, result.ok)
+                self.assertEqual(
+                    "fetched" if ok else "response_too_large", result.status
+                )
+
+    def test_oversized_content_length_fails_before_reading(self) -> None:
+        response = FakeResponse(
+            b"small", content_length=str(fetcher.MAX_RESPONSE_BYTES + 1)
+        )
+        with mock.patch.object(
+            fetcher.urllib.request.OpenerDirector, "open", return_value=response
+        ):
+            result = fetcher.fetch_url("https://example.com/start", 1)
+
+        self.assertFalse(result.ok)
+        self.assertEqual("response_too_large", result.status)
+        self.assertEqual([], response.read_sizes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- restrict standard reference requests and every redirect target to HTTP(S)
- replace automatic redirects with a five-hop loop that never reads intermediate bodies
- cap final responses at 10 MiB using both declared and actual byte limits

## Problem
`fetch_url()` accepted `file:` and `data:` URLs as successful official snapshots and read final responses without a size limit. Adding a bounded final `read()` alone is insufficient: Python's default `HTTPRedirectHandler` calls an unbounded `fp.read()` on every 30x response before following it, so a large redirect body still consumed unbounded memory.

## Tests
- `python3 -m unittest -v tests.test_fetch_standard_reference_network_bounds`
- real local HTTP server: 302 with a 1 MiB body to a relative tiny target, confirming the intermediate body is closed and the final page is parsed
- `python3 -m py_compile scripts/fetch_standard_references.py tests/test_fetch_standard_reference_network_bounds.py`
- `git diff --check`

The focused tests cover `file:`/`data:` initial URLs without opening, non-HTTP redirect targets without a second request, redirect bodies whose `read()` raises if touched, redirect limits, exact/max+1 actual sizes, and oversized `Content-Length` before reading.

## Related work
#1352 rejects filename collisions; #1944 changes docs/help; #2190 preserves a prior successful snapshot when any later fetch fails. This PR owns only request scheme, redirect, and response-size boundaries, with a separate test module.
