### PR TITLE
fix: fail empty bilingual audits

### DIFF
--- a/scripts/audit_bilingual_backfill.py
+++ b/scripts/audit_bilingual_backfill.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 from collections import Counter
 import re
 from pathlib import Path
@@ -111,16 +112,24 @@ def audit_pair(directory: Path) -> list[str]:
     return failures
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=ROOT)
+    args = parser.parse_args(argv)
+    repo_root = args.repo_root.resolve()
+
     failures: list[tuple[Path, list[str]]] = []
-    directories = proposal_dirs(ROOT, [])
+    directories = proposal_dirs(repo_root, [])
+    if not directories:
+        print("Audit failed: no bilingual submissions found under submissions/*/*/proposal.md")
+        return 2
     for directory in directories:
         problems = audit_pair(directory)
         if problems:
             failures.append((directory, problems))
     if failures:
         for directory, problems in failures:
-            print(directory.relative_to(ROOT))
+            print(directory.relative_to(repo_root))
             for problem in problems:
                 print(f"  - {problem}")
         print(f"Audit failed for {len(failures)} of {len(directories)} submissions")

--- a/tests/test_bilingual_audit_cli.py
+++ b/tests/test_bilingual_audit_cli.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "audit_bilingual_backfill.py"
+
+
+class BilingualAuditCliTests(unittest.TestCase):
+    def run_audit(self, repo_root: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--repo-root", str(repo_root)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_empty_submission_corpus_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            completed = self.run_audit(Path(tmp))
+
+        self.assertEqual(2, completed.returncode)
+        self.assertIn("no bilingual submissions found", completed.stdout)
+        self.assertNotIn("Audit passed for 0", completed.stdout)
+
+    def test_valid_bilingual_pair_is_audited(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            submission = repo_root / "submissions" / "alice" / "example"
+            submission.mkdir(parents=True)
+            (submission / "proposal.md").write_text(
+                """---
+title: Example
+language: zh
+translation_file: proposal.en.md
+---
+# Example
+
+[data:metrics.json#site_area]
+""",
+                encoding="utf-8",
+            )
+            (submission / "proposal.en.md").write_text(
+                """---
+title: Example
+language: en
+translation_of: proposal.md
+---
+# Example
+
+[data:metrics.json#site_area]
+""",
+                encoding="utf-8",
+            )
+
+            completed = self.run_audit(repo_root)
+
+        self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+        self.assertIn("Audit passed for 1 bilingual submissions", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Make the maintainer-wide bilingual backfill audit fail when it discovers no proposal corpus, instead of reporting `Audit passed for 0 bilingual submissions`.

## Reproduction

On current `main`, run the documented audit against an empty or incorrectly rooted checkout:

```bash
tmp=$(mktemp -d)
python3 scripts/audit_bilingual_backfill.py --repo-root "$tmp"
```

Before this change, the script had no configurable root and the same empty-corpus code path returned success. In a sparse checkout without `submissions/`, that makes the documented corpus audit look complete while examining nothing.

## Change

- Add a `--repo-root` option so the corpus boundary is explicit and testable.
- Return exit code 2 with a clear diagnostic when no `submissions/*/*/proposal.md` files are discovered.
- Keep the existing per-pair checks and exit code 1 behavior unchanged.
- Add CLI regressions for both an empty corpus and a valid bilingual pair.

## Verification

```bash
python3 -m unittest tests.test_bilingual_audit_cli -v
python3 -m py_compile scripts/audit_bilingual_backfill.py tests/test_bilingual_audit_cli.py
git diff --check
```

The two focused tests pass. The broader `tests.test_bilingual_backfill` module also passed 22 dependency-independent tests; its image fixture still requires the repository's configured Arial Unicode font, which is absent in this Linux checkout.
