### PR TITLE
fix: derive exhibit boundary readiness from geometry

### DIFF
--- a/scripts/generate_exhibit.py
+++ b/scripts/generate_exhibit.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Any
 
 from validate_submission import parse_front_matter, parse_track_metadata
-from generate_submissions_data import load_publication_registry
+from generate_submissions_data import has_official_geometry, load_publication_registry
 
 
 COVER_CANDIDATES = (
@@ -42,26 +42,6 @@ def pick_image(submission_dir: Path, candidates: tuple[str, ...]) -> str | None:
     for path in sorted((submission_dir / "assets" / "figures").glob("*.png")):
         return path.relative_to(submission_dir).as_posix()
     return None
-
-
-def boundary_readiness(submission_dir: Path) -> bool:
-    """Return True when the package is on official (not provisional) geometry."""
-    self_check = submission_dir / "self_check.json"
-    if not self_check.exists():
-        return False
-    try:
-        data = json.loads(self_check.read_text(encoding="utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError):
-        return False
-    checks = data.get("checks") if isinstance(data, dict) else None
-    if not isinstance(checks, list):
-        return False
-    relevant = {"BOUNDARY_TRUST", "KEY_AREAS_TRUST"}
-    seen: dict[str, str] = {}
-    for item in checks:
-        if isinstance(item, dict) and item.get("check_id") in relevant:
-            seen[str(item["check_id"])] = str(item.get("severity", ""))
-    return bool(seen) and all(severity == "info" for severity in seen.values())
 
 
 def build_exhibit(repo_root: Path, submission_dir: Path) -> dict[str, Any]:
@@ -90,7 +70,7 @@ def build_exhibit(repo_root: Path, submission_dir: Path) -> dict[str, Any]:
     publication = load_publication_registry(repo_root).get(rel)
     if not publication or publication.get("published") is not True:
         raise SystemExit(f"{rel}: submission is not approved for public display in gallery-publication.json")
-    official = boundary_readiness(submission_dir)
+    official = has_official_geometry(submission_dir)
     readiness = "官方边界就绪" if official else "临时边界，保留精度警示并待正式数据发布后复算；不阻断内容评分"
 
     return {

--- a/tests/test_generate_exhibit_boundary.py
+++ b/tests/test_generate_exhibit_boundary.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import generate_exhibit  # noqa: E402
+
+
+def write_collection(path: Path, properties: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": item,
+                        "geometry": {
+                            "type": "Polygon",
+                            "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]],
+                        },
+                    }
+                    for item in properties
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class GenerateExhibitBoundaryTests(unittest.TestCase):
+    def make_geometry(self, root: Path, *, provisional_key_area: bool = False) -> Path:
+        submission = root / "submissions" / "alice" / "example"
+        official = {
+            "official_boundary": True,
+            "geometry_role": "official_constraint",
+        }
+        write_collection(submission / "geometry" / "site_boundary.geojson", [official])
+        key_areas = [dict(official) for _ in range(3)]
+        if provisional_key_area:
+            key_areas[-1] = {
+                "official_boundary": False,
+                "geometry_role": "provisional_constraint",
+            }
+        write_collection(submission / "geometry" / "key_areas.geojson", key_areas)
+        (submission / "assets" / "figures").mkdir(parents=True)
+        (submission / "assets" / "figures" / "site-overview.png").write_bytes(b"png")
+        (submission / "proposal.md").write_text(
+            "---\ntitle: Example\nsummary: A complete exhibit summary.\n---\n# Example\n",
+            encoding="utf-8",
+        )
+        return submission
+
+    def build_exhibit(self, repo_root: Path, submission: Path) -> dict:
+        publication = {
+            "published": True,
+            "featured": False,
+            "selection_reason_zh": "Selected for the fixture.",
+        }
+        rel = submission.relative_to(repo_root).as_posix()
+        with mock.patch.object(
+            generate_exhibit,
+            "load_publication_registry",
+            return_value={rel: publication},
+        ):
+            return generate_exhibit.build_exhibit(repo_root, submission)
+
+    def test_complete_official_geometry_is_ready_without_legacy_self_check_signals(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = self.make_geometry(Path(tmp))
+            (submission / "self_check.json").write_text(
+                json.dumps(
+                    {
+                        "checks": [
+                            {"check_id": "DETERMINISTIC_VALIDATION", "severity": "blocking"},
+                            {"check_id": "SPATIAL_REVIEW", "severity": "blocking"},
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            exhibit = self.build_exhibit(Path(tmp), submission)
+
+        self.assertIn("官方边界就绪", exhibit["hero"]["caption"])
+        self.assertNotIn("临时边界", exhibit["hero"]["caption"])
+
+    def test_any_provisional_key_area_keeps_exhibit_provisional(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = self.make_geometry(Path(tmp), provisional_key_area=True)
+
+            exhibit = self.build_exhibit(Path(tmp), submission)
+
+        self.assertIn("临时边界", exhibit["hero"]["caption"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Derive exhibit boundary readiness from the package's actual site and key-area GeoJSON instead of legacy `self_check.json` check IDs.

## Reproduction

`self_check_submission.py --mark-self-checked` replaces the scaffold's `BOUNDARY_TRUST` and `KEY_AREAS_TRUST` entries with the four persisted gate results:

```text
DETERMINISTIC_VALIDATION
SPATIAL_REVIEW
VISUAL_PACKAGING
PROFESSIONAL_EVIDENCE
```

`generate_exhibit.py::boundary_readiness()` still searched for the two removed IDs. Consequently, a fully official package produced the provisional caption:

```text
临时边界，保留精度警示并待正式数据发布后复算
```

The old helper also returned true if only one of its two expected IDs was present with `severity=info`, so incomplete legacy evidence could fail open.

## Change

- Reuse `generate_submissions_data.has_official_geometry()`, the existing gallery classification rule.
- Require non-empty site geometry, at least three key-area features, and `official_boundary=true` plus `geometry_role=official_constraint` on every relevant feature.
- Remove the stale self-check inference.
- Add dependency-free `build_exhibit()` regressions for a fully official package with persisted gate-only self-check data and for a package with one provisional key area.

## Verification

```bash
python3 -m unittest tests.test_generate_exhibit_boundary -v
python3 -m py_compile scripts/generate_exhibit.py tests/test_generate_exhibit_boundary.py
git diff --check
```

Both focused regressions pass. The existing scaffold-to-exhibit integration test is dependency-gated and skipped in this checkout because the optional geospatial review dependencies are absent.
