### PR TITLE
fix: keep review packets out of submissions

### DIFF
--- a/scripts/export_review_packet.py
+++ b/scripts/export_review_packet.py
@@ -135,6 +135,19 @@ def inside_repo(path: Path, repo_root: Path) -> bool:
         return False
 
 
+def validate_output_dir(repo_root: Path, out_dir: Path) -> None:
+    """Keep maintainer-only review artifacts out of participant packages."""
+    try:
+        relative = out_dir.resolve().relative_to(repo_root.resolve())
+    except ValueError:
+        return
+    if relative.parts and relative.parts[0] == "submissions":
+        raise ReviewPacketError(
+            "review packet output must not be inside submissions/; "
+            "use .maintainer-review/ or an external directory"
+        )
+
+
 def discover_submission_dirs(repo_root: Path) -> list[Path]:
     submissions_root = repo_root / "submissions"
     return sorted(path.parent for path in submissions_root.glob("*/*/proposal.md"))
@@ -891,6 +904,7 @@ def export_review_packet(
     include_pdf: bool = False,
     pdf_engine: str = "auto",
 ) -> dict[str, str]:
+    validate_output_dir(repo_root, out_dir)
     packets = [load_submission_packet(repo_root, path) for path in submission_dirs]
     out_dir.mkdir(parents=True, exist_ok=True)
     markdown_path = out_dir / "review-packet.md"

--- a/tests/test_review_packet_output_boundary.py
+++ b/tests/test_review_packet_output_boundary.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from export_review_packet import ReviewPacketError, validate_output_dir  # noqa: E402
+
+
+class ReviewPacketOutputBoundaryTests(unittest.TestCase):
+    def test_submission_output_is_rejected_before_writes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            out_dir = repo_root / "submissions" / "alice" / "plan" / "review"
+
+            with self.assertRaisesRegex(ReviewPacketError, "must not be inside submissions"):
+                validate_output_dir(repo_root, out_dir)
+
+        self.assertFalse(out_dir.exists())
+
+    def test_local_maintainer_and_external_outputs_are_allowed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as external:
+            repo_root = Path(tmp)
+
+            validate_output_dir(repo_root, repo_root / ".maintainer-review" / "packet")
+            validate_output_dir(repo_root, Path(external) / "packet")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Reject review-packet output directories inside `submissions/` before any maintainer-only artifact is written.

## Reproduction

On current `main`, the exporter accepts a participant package as its output directory:

```bash
python3 scripts/export_review_packet.py \
  submissions/alice/plan \
  --repo-root . \
  --out submissions/alice/plan
```

It writes `review-packet.md`, `review-packet.html`, and `packet-manifest.json` into the submission. This conflicts with the documented review-artifact boundary in `docs/maintainer-workflow.md`, pollutes participant package scope, and can invalidate manifest hashes.

## Change

- Resolve the requested output path before processing submissions.
- Reject any resolved path under the repository's `submissions/` tree.
- Keep the default `.maintainer-review/` location and external offline directories valid.
- Apply the guard in `export_review_packet()` so direct Python callers receive the same protection as the CLI.

## Verification

```bash
python3 -m unittest tests.test_review_packet_output_boundary tests.test_export_review_packet -v
python3 -m py_compile scripts/export_review_packet.py tests/test_review_packet_output_boundary.py
git diff --check
```

All five focused and existing review-packet tests pass.
