### PR TITLE
fix: publish valid source drafts transactionally

### DIFF
--- a/scripts/prepare_source_registry_draft.py
+++ b/scripts/prepare_source_registry_draft.py
@@ -13,7 +13,9 @@ import csv
 import datetime as dt
 import hashlib
 import json
+import os
 import re
+import tempfile
 import urllib.parse
 from pathlib import Path
 from typing import Any
@@ -24,7 +26,7 @@ from discover_public_sources import (
     content_type_kind,
     parse_dateish,
 )
-from validate_data_registry import validate_registry
+from validate_data_registry import RegistryReport, validate_registry
 
 
 DEFAULT_DISCOVERY_CSV = "brief/discovery/candidate-sources.csv"
@@ -252,10 +254,35 @@ def build_draft(
     }
 
 
-def write_registry_json(data: dict[str, Any], path: Path) -> None:
+def serialize_registry_json(data: dict[str, Any]) -> str:
     serializable = {key: value for key, value in data.items() if not key.startswith("_")}
+    return json.dumps(serializable, ensure_ascii=False, indent=2) + "\n"
+
+
+def validate_and_publish_draft(
+    data: dict[str, Any], repo_root: Path, path: Path
+) -> RegistryReport:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(serializable, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as stream:
+            stream.write(serialize_registry_json(data))
+            temporary = Path(stream.name)
+        report = validate_registry(repo_root, temporary)
+        if report.ok:
+            os.replace(temporary, path)
+            temporary = None
+        return report
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
 
 
 def main() -> int:
@@ -293,8 +320,7 @@ def main() -> int:
         limit=args.limit,
         include_existing=args.include_existing,
     )
-    write_registry_json(draft, out_path)
-    report = validate_registry(repo_root, out_path)
+    report = validate_and_publish_draft(draft, repo_root, out_path)
     summary = {
         "ok": report.ok,
         "input": input_path.relative_to(repo_root).as_posix() if input_path.is_relative_to(repo_root) else str(input_path),

--- a/tests/test_source_registry_draft.py
+++ b/tests/test_source_registry_draft.py
@@ -20,6 +20,49 @@ def write_csv(path: Path, rows: list[dict[str, str]], fields: list[str]) -> None
 
 
 class SourceRegistryDraftTests(unittest.TestCase):
+    def test_invalid_draft_does_not_replace_existing_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "data").mkdir()
+            existing_path = root / "data" / "source_registry.json"
+            existing_path.write_text(
+                json.dumps({"schema_version": "0.1.0", "updated_date": "2026-08-12", "sources": []}),
+                encoding="utf-8",
+            )
+            seed_path = root / "seed.csv"
+            write_csv(
+                seed_path,
+                [{"id": "bad", "title": "Bad source", "url": "ftp://example.com/source", "topic": "test"}],
+                ["id", "title", "url", "topic"],
+            )
+            out_path = root / "draft.json"
+            original = b'{"existing":"maintainer draft"}\n'
+            out_path.write_bytes(original)
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "prepare_source_registry_draft.py"),
+                    "--repo-root",
+                    str(root),
+                    "--input",
+                    str(seed_path),
+                    "--existing-registry",
+                    str(existing_path),
+                    "--out",
+                    str(out_path),
+                    "--json",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 1, completed.stdout + completed.stderr)
+            self.assertFalse(json.loads(completed.stdout)["ok"])
+            self.assertEqual(out_path.read_bytes(), original)
+            self.assertEqual(list(root.glob(".draft.json.*.tmp")), [])
+
     def test_seed_csv_generates_needs_review_draft_and_skips_existing_urls(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Problem

`prepare_source_registry_draft.py` wrote `--out` before validating the generated registry. If a discovery row produced an invalid record, such as a `public_url` with an `ftp://` URL, the command correctly returned 1 but had already replaced an existing maintainer draft with invalid output.

Reproduction on current `main`:

```bash
printf '%s\n' 'id,title,url,topic' \
  'bad,Bad source,ftp://example.com/source,test' > seed.csv
printf '%s\n' '{"existing":"maintainer draft"}' > draft.json
python3 scripts/prepare_source_registry_draft.py \
  --input seed.csv --out draft.json --json
# exits 1, but draft.json now contains the invalid generated registry
```

## Change

- serialize the candidate into a temporary file beside the requested output;
- validate that exact serialized file;
- atomically replace `--out` only after validation succeeds;
- remove the temporary file on validation failure while preserving any existing output.

The successful generation path and JSON summary remain unchanged.

## Verification

- `python3 -m unittest tests.test_source_registry_draft tests.test_data_registry -v` - 8 passed
- `python3 -m py_compile scripts/prepare_source_registry_draft.py tests/test_source_registry_draft.py`
- `git diff --check`
