### PR TITLE
fix: reject corrupt review packet evidence

### DIFF
--- a/scripts/export_review_packet.py
+++ b/scripts/export_review_packet.py
@@ -70,13 +70,20 @@ class SubmissionPacket:
     key_files: list[dict[str, Any]]
 
 
-def read_json(path: Path) -> Any:
+def read_json(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError):
-        return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except UnicodeDecodeError as exc:
+        raise ReviewPacketError(f"{path}: JSON file must be UTF-8") from exc
+    except json.JSONDecodeError as exc:
+        raise ReviewPacketError(f"{path}: invalid JSON: {exc}") from exc
+    except OSError as exc:
+        raise ReviewPacketError(f"{path}: could not read JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ReviewPacketError(f"{path}: JSON root must be an object")
+    return data
 
 
 def as_dict(value: Any) -> dict[str, Any]:

--- a/tests/test_review_packet_json_integrity.py
+++ b/tests/test_review_packet_json_integrity.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.test_export_review_packet import make_submission
+
+from scripts.export_review_packet import ReviewPacketError, export_review_packet
+
+
+class ReviewPacketJsonIntegrityTests(unittest.TestCase):
+    def test_existing_invalid_json_aborts_before_creating_output(self) -> None:
+        invalid_files = {
+            "sources.json": b'{"sources": [',
+            "risk.json": b"\xff\xfe",
+            "manifest.json": b"[]",
+        }
+        for filename, content in invalid_files.items():
+            with self.subTest(filename=filename), tempfile.TemporaryDirectory() as tmp:
+                repo_root = Path(tmp)
+                submission_dir = make_submission(repo_root, "alice", "proposal-a", "AI network")
+                (submission_dir / filename).write_bytes(content)
+                out_dir = repo_root / "packet"
+
+                with self.assertRaisesRegex(ReviewPacketError, filename):
+                    export_review_packet(repo_root, [submission_dir], out_dir, "Review packet")
+
+                self.assertFalse(out_dir.exists())
+
+    def test_missing_optional_risk_json_still_exports(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            submission_dir = make_submission(repo_root, "alice", "proposal-a", "AI network")
+            (submission_dir / "risk.json").unlink()
+            out_dir = repo_root / "packet"
+
+            files = export_review_packet(repo_root, [submission_dir], out_dir, "Review packet")
+
+            self.assertTrue(Path(files["manifest"]).is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`export_review_packet.py` treated an existing JSON file that was malformed or not UTF-8 exactly like an optional file that was absent. A corrupt `sources.json`, `assumptions.json`, `metrics.json`, `risk.json`, manifest, self-check, or agent record was silently rendered as empty data, and the command still emitted a complete-looking review packet and manifest.

For example, replacing `sources.json` with `{"sources": [` currently exits successfully and renders the public-source section as `暂无`, hiding the evidence integrity failure from reviewers.

## Change

- keep missing optional JSON files optional;
- report existing non-UTF-8, unreadable, malformed, or non-object JSON with the affected path;
- abort while loading submissions, before the packet output directory is created.

## Verification

- `python3 -m unittest tests.test_review_packet_json_integrity tests.test_export_review_packet -v` - 5 passed
- regressions cover malformed JSON, invalid UTF-8, non-object roots, output preflight, and a genuinely absent optional `risk.json`
- `python3 -m py_compile scripts/export_review_packet.py tests/test_review_packet_json_integrity.py`
- `git diff --check`

This is separate from #2209: that PR constrains the destination path, while this change validates the source evidence before rendering.
