### PR TITLE
fix: match portal collections by path identity

### DIFF
--- a/scripts/render_portal.py
+++ b/scripts/render_portal.py
@@ -266,7 +266,16 @@ def load_collections(collections_dir: Path | None, cards: list[dict[str, Any]]) 
     if not collections_dir.is_dir():
         raise PortalError(f"{collections_dir}: collections path must be a directory")
 
-    card_lookup = {card["source_path"]: card for card in cards}
+    repo_root = collections_dir.resolve().parent
+
+    def proposal_identity(raw_path: str) -> Path:
+        path = Path(raw_path)
+        return (path if path.is_absolute() else repo_root / path).resolve()
+
+    card_lookup = {
+        proposal_identity(text(card["source_path"])): card
+        for card in cards
+    }
     collections: list[dict[str, Any]] = []
     for path in sorted(collections_dir.glob("*.json")):
         try:
@@ -286,7 +295,7 @@ def load_collections(collections_dir: Path | None, cards: list[dict[str, Any]]) 
             if not isinstance(item, dict):
                 raise PortalError(f"{path}: each collection item must be an object")
             proposal_ref = safe_proposal_ref(item.get("proposal"))
-            matched = card_lookup.get(proposal_ref)
+            matched = card_lookup.get(proposal_identity(proposal_ref))
             rendered_items.append(
                 {
                     "proposal": proposal_ref,

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -82,10 +82,18 @@ tracks: ["civic-agent-governance"]
             collections = load_collections(collections_dir, [card])
             html = render_portal([card], "Collection Portal", collections=collections)
 
+            collection_item = collections[0]["items"][0]
+            self.assertTrue(collection_item["loaded"])
+            self.assertEqual(
+                collection_item["url"],
+                "../examples/agent-civic-loop/index.html",
+            )
             self.assertIn("精选专题", html)
             self.assertIn("最佳 AI 治理", html)
             self.assertIn("治理闭环", html)
             self.assertIn("Collection Test", html)
+            self.assertIn('../examples/agent-civic-loop/index.html', html)
+            self.assertNotIn("未载入 portal", html)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`render_portal.py` stores each card's `source_path` exactly as its proposal argument. The documented CLI accepts paths, so an absolute proposal path produces an absolute card key. Collection items use validated repository-relative references such as `examples/agent-civic-loop`, and their string lookup therefore misses the loaded card.

The main card still renders, masking the defect, while the collection section shows an empty title, `未载入 portal`, and no detail link.

Reproduction on current `main`:

```bash
python3 scripts/render_portal.py \
  --output /tmp/portal.html \
  --collections-dir collections \
  "$PWD/examples/agent-civic-loop"
```

## Change

Resolve both loaded card paths and validated collection proposal references against the collection directory's repository root, then match their filesystem identities. Relative proposal arguments continue to work, while absolute arguments now populate the same collection entry and detail URL.

## Verification

- `python3 -m unittest tests.test_collections tests.test_scenarios -v` - 3 passed
- the collection regression uses an absolute proposal path and now checks loaded state, detail URL, rendered link, and absence of the unloaded placeholder
- `python3 -m py_compile scripts/render_portal.py tests/test_collections.py`
- `git diff --check`

A broader gallery run reached unrelated partial-clone baseline failures because this lightweight checkout does not contain the hundreds of submission blobs referenced by `submissions-data.js`; the portal collection and scenario tests are dependency-free and pass.
