### PR TITLE
fix: contain resolved public source paths

### DIFF
--- a/scripts/validate_sources.py
+++ b/scripts/validate_sources.py
@@ -153,8 +153,25 @@ def validate_source_item(
             except ValueError as exc:
                 report.add_error(f"{prefix}: {exc}")
             else:
-                if not (repo_root / local_path).is_file():
-                    report.add_error(f"{prefix}: referenced path is missing: {local_path}")
+                try:
+                    resolved = (repo_root / local_path).resolve(strict=True)
+                except FileNotFoundError:
+                    report.add_error(
+                        f"{prefix}: referenced path is missing: {local_path}"
+                    )
+                except (OSError, RuntimeError):
+                    report.add_error(
+                        f"{prefix}: referenced path could not be resolved: {local_path}"
+                    )
+                else:
+                    if not resolved.is_relative_to(repo_root):
+                        report.add_error(
+                            f"{prefix}: referenced path escapes repo: {local_path}"
+                        )
+                    elif not resolved.is_file():
+                        report.add_error(
+                            f"{prefix}: referenced path is missing: {local_path}"
+                        )
 
     if url_value is not None:
         if not isinstance(url_value, str) or not url_value.startswith("https://"):

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -136,6 +136,44 @@ class PublicSourcesTests(unittest.TestCase):
             report = validate_source_index(root)
             self.assertTrue(report.ok, report.errors)
 
+    def test_symlinked_local_path_cannot_escape_repo(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            root = workspace / "repo"
+            outside = workspace / "outside"
+            outside.mkdir()
+            (outside / "public-brief.md").write_text(
+                "outside evidence", encoding="utf-8"
+            )
+            root.mkdir()
+            try:
+                (root / "brief").symlink_to(outside, target_is_directory=True)
+            except OSError as exc:
+                self.skipTest(f"symlinks unavailable: {exc}")
+            self.write_json(root, "sources/public-sources.json", VALID_INDEX)
+
+            report = validate_source_index(root)
+
+            self.assertFalse(report.ok)
+            self.assertIn("referenced path escapes repo", "\n".join(report.errors))
+
+    def test_symlink_loop_returns_validation_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            try:
+                (root / "loop-a").symlink_to("loop-b", target_is_directory=True)
+                (root / "loop-b").symlink_to("loop-a", target_is_directory=True)
+            except OSError as exc:
+                self.skipTest(f"symlinks unavailable: {exc}")
+            bad_index = copy.deepcopy(VALID_INDEX)
+            bad_index["sources"][0]["path"] = "loop-a/evidence.md"
+            self.write_json(root, "sources/public-sources.json", bad_index)
+
+            report = validate_source_index(root)
+
+            self.assertFalse(report.ok)
+            self.assertIn("referenced path could not be resolved", "\n".join(report.errors))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

The public-source index validator rejects absolute paths and lexical `..`, but checks `(repo_root / path).is_file()` without verifying the resolved target remains inside the repository. A repository-local symlink can therefore make an indexed `path` point to an arbitrary file outside the public repository while validation reports `ok: true`.

Minimal reproduction on current `main`:

```bash
ln -s /outside/location local
# sources/public-sources.json contains path: local/evidence.txt
python3 scripts/validate_sources.py --json
# reports PASS when /outside/location/evidence.txt exists
```

## Change

Resolve each normalized local source path, require the result to remain under the resolved repository root, then perform the existing regular-file check. Ordinary repository files and links whose targets remain inside the repository continue to validate.

## Verification

- `python3 -m unittest tests.test_public_sources -v` - 6 passed
- regression covers a directory symlink resolving to an existing file outside the temporary repository
- `python3 -m py_compile scripts/validate_sources.py tests/test_public_sources.py`
- `git diff --check`
