### PR TITLE
fix: protect exhibit renderer inputs

### DIFF
--- a/scripts/render_exhibit.py
+++ b/scripts/render_exhibit.py
@@ -718,6 +718,10 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
+        output = args.output.resolve()
+        for label, input_path in (("proposal", args.proposal), ("exhibit", args.exhibit)):
+            if output == input_path.resolve():
+                raise ExhibitError(f"output must not overwrite the {label} input: {input_path}")
         rendered = render_html(args.proposal, args.exhibit)
     except ExhibitError as exc:
         parser.error(str(exc))

--- a/tests/test_render_exhibit_output_boundary.py
+++ b/tests/test_render_exhibit_output_boundary.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "render_exhibit.py"
+
+
+class RenderExhibitOutputBoundaryTests(unittest.TestCase):
+    def test_output_cannot_overwrite_an_input(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            proposal = root / "proposal.md"
+            exhibit = root / "exhibit.json"
+            proposal.write_text("---\ntitle: Test\n---\n\n# Test\n", encoding="utf-8")
+            exhibit.write_text(json.dumps({"version": 1, "modules": []}), encoding="utf-8")
+
+            for label, output in (("proposal", proposal), ("exhibit", exhibit)):
+                with self.subTest(label=label):
+                    original = output.read_bytes()
+                    completed = subprocess.run(
+                        [sys.executable, str(SCRIPT), str(proposal), str(exhibit), str(output)],
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+
+                    self.assertNotEqual(completed.returncode, 0)
+                    self.assertIn(f"output must not overwrite the {label} input", completed.stderr)
+                    self.assertEqual(output.read_bytes(), original)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`render_exhibit.py` accepts three paths but does not prevent the output from being the same file as `proposal` or `exhibit`. Because rendering completes before the final write, the command exits successfully and then replaces its Markdown or JSON source with generated HTML.

Reproduction on current `main`:

```bash
python3 scripts/render_exhibit.py \
  examples/agent-civic-loop/proposal.md \
  examples/agent-civic-loop/exhibit.json \
  examples/agent-civic-loop/proposal.md
# exits 0 and proposal.md now starts with <!doctype html>
```

## Change

Resolve the output and both input paths before rendering, reject either identity overlap, and leave the source bytes untouched. Normal output paths retain the existing rendering behavior.

## Verification

- `python3 -m unittest tests.test_render_exhibit_output_boundary -v` - passed with proposal and exhibit overlap subtests
- normal smoke render of `examples/agent-civic-loop` produced a non-empty external HTML file
- `python3 -m py_compile scripts/render_exhibit.py tests/test_render_exhibit_output_boundary.py`
- `git diff --check`
