### PR TITLE
fix: keep unreviewed sources in review queue

### DIFF
--- a/scripts/source_registry_utils.py
+++ b/scripts/source_registry_utils.py
@@ -68,14 +68,14 @@ def summarize_source_registry(registry: dict[str, Any], limit: int = 8) -> dict[
         _increment(counts["by_usable_for_formal"], formal_use)
         _increment(counts["by_authority_level"], authority)
         compact = _compact_source(source)
-        if review_status == "approved" and formal_use == "yes":
+        if review_status == "needs_review":
+            needs_review.append(compact)
+        elif review_status == "approved" and formal_use == "yes":
             approved_formal.append(compact)
         elif formal_use == "provisional_only":
             provisional.append(compact)
         elif formal_use == "background_only":
             background.append(compact)
-        elif review_status == "needs_review":
-            needs_review.append(compact)
     return {
         "registry_path": DEFAULT_SOURCE_REGISTRY_PATH,
         "updated_date": registry.get("updated_date") if isinstance(registry, dict) else None,

--- a/tests/test_source_registry_summary.py
+++ b/tests/test_source_registry_summary.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from source_registry_utils import summarize_source_registry  # noqa: E402
+
+
+def source(source_id: str, review_status: str, formal_use: str) -> dict[str, object]:
+    return {
+        "source_id": source_id,
+        "title": source_id,
+        "publisher": "Publisher",
+        "authority_level": "A0",
+        "review_status": review_status,
+        "usable_for_formal": formal_use,
+        "topics": ["test"],
+        "allowed_uses": ["test"],
+        "prohibited_uses": ["formal use before review"],
+        "url": "https://example.com/source",
+    }
+
+
+class SourceRegistrySummaryTests(unittest.TestCase):
+    def test_needs_review_takes_precedence_over_use_bucket(self) -> None:
+        registry = {
+            "sources": [
+                source("DRAFT-BACKGROUND", "needs_review", "background_only"),
+                source("DRAFT-NO", "needs_review", "no"),
+                source("APPROVED-BACKGROUND", "approved", "background_only"),
+                source("PROVISIONAL", "provisional", "provisional_only"),
+            ]
+        }
+
+        summary = summarize_source_registry(registry)
+
+        self.assertEqual(
+            [item["source_id"] for item in summary["needs_review_sources"]],
+            ["DRAFT-BACKGROUND", "DRAFT-NO"],
+        )
+        self.assertEqual(
+            [item["source_id"] for item in summary["background_sources"]],
+            ["APPROVED-BACKGROUND"],
+        )
+        self.assertEqual(
+            [item["source_id"] for item in summary["provisional_sources"]],
+            ["PROVISIONAL"],
+        )
+        self.assertEqual(summary["counts"]["by_review_status"]["needs_review"], 2)
+        self.assertEqual(summary["counts"]["by_usable_for_formal"]["background_only"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`source_registry_utils.summarize_source_registry()` assigns each source to one display/review group, but checks `usable_for_formal=background_only` before `review_status=needs_review`. A newly generated A0/A1 draft has exactly that combination, so it is exposed as an ordinary background source and disappears from `needs_review_sources` even though the registry usage rule says it must not be used until reviewed.

Reproduction on current `main`:

```python
summarize_source_registry({"sources": [{
    "source_id": "DRAFT-A0",
    "review_status": "needs_review",
    "usable_for_formal": "background_only",
    "authority_level": "A0",
}]})
# background_sources: [DRAFT-A0]
# needs_review_sources: []
```

This summary feeds maintainer review input, scaffold source guidance, and generated frontend registry data.

## Change

Give `review_status=needs_review` precedence over use buckets when building the mutually exclusive source lists. Approved background sources and provisional sources keep their existing groups, and the independent count dimensions remain unchanged.

## Verification

- `python3 -m unittest tests.test_source_registry_summary tests.test_source_registry_frontend tests.test_data_registry -v` - 9 passed
- regression covers both `background_only` and `no` unreviewed sources plus approved background and provisional controls
- `python3 -m py_compile scripts/source_registry_utils.py tests/test_source_registry_summary.py`
- `git diff --check`
