### PR TITLE
fix: replace stale submission skill installs

### DIFF
--- a/scripts/install_submission_skill.py
+++ b/scripts/install_submission_skill.py
@@ -46,19 +46,23 @@ def tree_digest(path: Path) -> str:
 
 def copy_skill(source: Path, target: Path) -> None:
     target.parent.mkdir(parents=True, exist_ok=True)
+    temporary_target = target.parent / f".{target.name}.installing"
+    if temporary_target.exists():
+        shutil.rmtree(temporary_target)
     shutil.copytree(
         source,
-        target,
-        dirs_exist_ok=True,
+        temporary_target,
         ignore=shutil.ignore_patterns("__pycache__", "*.pyc", ".DS_Store"),
     )
+    if target.exists():
+        shutil.rmtree(target)
+    temporary_target.replace(target)
 
 
 def build_report(source: Path, target: Path, installed: bool, action: str) -> dict[str, Any]:
     source_exists = (source / "SKILL.md").exists()
     target_exists = (target / "SKILL.md").exists()
     report: dict[str, Any] = {
-        "ok": source_exists and target_exists,
         "action": action,
         "skill_name": SKILL_NAME,
         "source": str(source),
@@ -76,6 +80,7 @@ def build_report(source: Path, target: Path, installed: bool, action: str) -> di
         report["up_to_date"] = report.get("source_sha256") == report.get("target_sha256")
     else:
         report["up_to_date"] = False
+    report["ok"] = source_exists and target_exists and report["up_to_date"]
     return report
 
 

--- a/tests/test_site_package_contract.py
+++ b/tests/test_site_package_contract.py
@@ -152,6 +152,49 @@ class SitePackageContractTests(unittest.TestCase):
             self.assertFalse(check_report["installed"])
             self.assertTrue(check_report["up_to_date"])
 
+    def test_submission_skill_installer_replaces_stale_installation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            command = [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "install_submission_skill.py"),
+                "--codex-home",
+                tmp,
+                "--json",
+            ]
+            first_install = subprocess.run(
+                command,
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(first_install.returncode, 0, first_install.stdout + first_install.stderr)
+
+            installed_skill = Path(tmp) / "skills" / "urban-design-ai-submission"
+            stale_file = installed_skill / "removed-reference.md"
+            stale_file.write_text("obsolete", encoding="utf-8")
+
+            check = subprocess.run(
+                [*command, "--check"],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(check.returncode, 1, check.stdout + check.stderr)
+            self.assertFalse(json.loads(check.stdout)["up_to_date"])
+
+            reinstall = subprocess.run(
+                command,
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(reinstall.returncode, 0, reinstall.stdout + reinstall.stderr)
+            self.assertTrue(json.loads(reinstall.stdout)["up_to_date"])
+            self.assertFalse(stale_file.exists())
+
     def test_professional_standards_have_local_reference_snapshots(self) -> None:
         standards_path = REPO_ROOT / "brief" / "site-package" / "standards" / "standards.json"
         standards = json.loads(standards_path.read_text(encoding="utf-8"))["standards"]


### PR DESCRIPTION
## Problem

`install_submission_skill.py` overlays the repository skill onto an existing target with `dirs_exist_ok=True`. Files removed or renamed in the source therefore remain installed indefinitely. The resulting tree has a different digest, but both install mode and `--check` still return exit code 0 because `ok` only checks for the two `SKILL.md` files.

Reproduction on current `main`:

```text
install fresh skill
add skills/urban-design-ai-submission/removed-reference.md
--check => exit 0, ok=true, up_to_date=false
reinstall => exit 0, ok=true, up_to_date=false, stale file remains
```

That makes `--check` unsuitable for automation and can leave agents following obsolete references even after reinstalling.

## Change

- copy the source skill into a clean sibling staging directory;
- replace the installed skill directory with that exact copy so deleted source files disappear;
- make report `ok` require matching source and target tree digests;
- cover stale detection and cleanup through the public CLI.

The replacement remains scoped to this named skill directory; unrelated skills and Codex home contents are untouched.

## Verification

- `python3 -m unittest tests.test_site_package_contract.SitePackageContractTests.test_submission_skill_installer_copies_skill tests.test_site_package_contract.SitePackageContractTests.test_submission_skill_installer_replaces_stale_installation` (2 passed)
- `python3 -m py_compile scripts/install_submission_skill.py tests/test_site_package_contract.py`
- `git diff --check`

The complete `tests.test_site_package_contract` module ran 11 tests: the two installer tests passed, one optional dependency test skipped, and the current default branch's unrelated `test_skill_exists` assertion failed because it expects `machine-readable urban design submission` while `SKILL.md` currently says `machine-readable urban design package`.
