### PR TITLE
fix: invalidate reviews after artifact backfill

### DIFF
--- a/scripts/backfill_bilingual_artifacts.py
+++ b/scripts/backfill_bilingual_artifacts.py
@@ -482,6 +482,7 @@ def backfill_manifests(dirs: list[Path]) -> int:
             continue
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         items = manifest.setdefault("files", [])
+        original_items = json.dumps(items, ensure_ascii=False, sort_keys=True)
         by_path = {
             str(item.get("path")): item
             for item in items
@@ -504,9 +505,20 @@ def backfill_manifests(dirs: list[Path]) -> int:
                 continue
             primary_item = by_path.get(primary)
             if primary_item is None:
+                role = (
+                    "rendered_proposal_html"
+                    if primary == "report/proposal.html"
+                    else "visualization"
+                    if primary == "visual/index.html"
+                    else "drawing"
+                    if primary.startswith("drawings/")
+                    else "proposal_figure"
+                    if primary.startswith("assets/figures/")
+                    else "narrative"
+                )
                 primary_item = {
                     "path": primary,
-                    "role": "narrative" if primary.endswith((".md", ".html")) else "figure",
+                    "role": role,
                     "required": primary in {"proposal.md", "report/proposal.html", "visual/index.html"},
                 }
                 items.append(primary_item)
@@ -532,6 +544,10 @@ def backfill_manifests(dirs: list[Path]) -> int:
             rel = item.get("path")
             if rel and rel != "manifest.json" and (directory / rel).is_file():
                 item["sha256"] = sha256(directory / rel)
+        if json.dumps(items, ensure_ascii=False, sort_keys=True) != original_items:
+            validation_claim = manifest.get("validation_claim")
+            if isinstance(validation_claim, dict):
+                validation_claim["self_checked"] = False
         manifest_path.write_text(
             json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
         )

--- a/tests/test_bilingual_artifact_manifest_freshness.py
+++ b/tests/test_bilingual_artifact_manifest_freshness.py
@@ -1,0 +1,84 @@
+import hashlib
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from backfill_bilingual_artifacts import backfill_manifests  # noqa: E402
+
+
+class BilingualArtifactManifestFreshnessTests(unittest.TestCase):
+    def write_package(self, root: Path) -> Path:
+        directory = root / "submissions" / "alice" / "example"
+        for relative, content in {
+            "proposal.md": '---\ntitle: "Example"\nlanguage: "en"\n---\nBody\n',
+            "proposal.zh.md": '---\ntitle: "示例"\nlanguage: "zh"\ntranslation_of: "proposal.md"\n---\n正文\n',
+            "report/proposal.html": "primary report",
+            "report/proposal.zh.html": "translated report",
+            "visual/index.html": "primary visual",
+            "visual/index.zh.html": "translated visual",
+            "drawings/a3-booklet.pdf": "primary drawing",
+            "drawings/a3-booklet.zh.pdf": "translated drawing",
+        }.items():
+            path = directory / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+        (directory / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "files": [
+                        {
+                            "path": "proposal.md",
+                            "role": "narrative",
+                            "required": True,
+                            "sha256": hashlib.sha256(
+                                (directory / "proposal.md").read_bytes()
+                            ).hexdigest(),
+                        }
+                    ],
+                    "validation_claim": {"self_checked": True},
+                }
+            ),
+            encoding="utf-8",
+        )
+        return directory
+
+    def test_changed_artifact_inventory_invalidates_review_freshness(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = self.write_package(Path(tmp))
+
+            backfill_manifests([directory])
+
+            manifest = json.loads((directory / "manifest.json").read_text(encoding="utf-8"))
+            items = {item["path"]: item for item in manifest["files"]}
+            self.assertFalse(manifest["validation_claim"]["self_checked"])
+            self.assertEqual("rendered_proposal_html", items["report/proposal.html"]["role"])
+            self.assertEqual("visualization", items["visual/index.html"]["role"])
+            self.assertEqual("drawing", items["drawings/a3-booklet.pdf"]["role"])
+            self.assertEqual(
+                "report/proposal.html",
+                items["report/proposal.zh.html"]["translation_of"],
+            )
+
+    def test_unchanged_artifact_inventory_preserves_fresh_review(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = self.write_package(Path(tmp))
+            backfill_manifests([directory])
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["validation_claim"]["self_checked"] = True
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+            backfill_manifests([directory])
+
+            refreshed = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertTrue(refreshed["validation_claim"]["self_checked"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`backfill_bilingual_artifacts.py manifests` registers newly generated HTML, PDF, and figure counterparts and refreshes their manifest hashes, but it preserves `validation_claim.self_checked=true` even when those records or bytes changed.

That leaves the package claiming a fresh four-gate review after the display artifacts covered by that review have changed. It also assigns generic roles when a display artifact was absent from the historical manifest: report and visual HTML become `narrative`, and drawings become `figure`, despite the published manifest contract defining specific roles for each.

## Change

- compare the manifest file inventory before and after artifact registration/hash refresh;
- set `validation_claim.self_checked=false` when the inventory actually changes;
- preserve `self_checked` on an idempotent rerun with no manifest changes;
- assign `rendered_proposal_html`, `visualization`, `drawing`, and `proposal_figure` to newly registered display artifacts;
- add dependency-free regression coverage in a separate test module.

This complements #773, which invalidates review freshness when the proposal translation stage changes Markdown. This PR covers the subsequent HTML/PDF/figure artifact stage.

## Verification

- `python3 -m unittest tests.test_bilingual_artifact_manifest_freshness tests.test_bilingual_backfill.BilingualBackfillTests.test_manifest_backfill_registers_language_counterparts_and_hashes` (3 passed)
- `python3 -m py_compile scripts/backfill_bilingual_artifacts.py tests/test_bilingual_artifact_manifest_freshness.py`
- `git diff --check`

The complete bilingual suites ran 24 tests: 23 passed; the existing localized-figure test requires Arial Unicode, which is absent in this Linux environment and is already addressed by open PR #808's Noto CJK fallback.
