### PR TITLE
fix: keep review inputs out of submissions

### DIFF
--- a/scripts/review_submission.py
+++ b/scripts/review_submission.py
@@ -34,8 +34,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -161,13 +163,48 @@ def script_path(repo_root: Path, name: str) -> Path:
     return SCRIPT_DIR / name
 
 
-def validate_output_dir(repo_root: Path, out_dir: Path) -> None:
+def validate_output_dir(repo_root: Path, out_dir: Path, submission_dir: Path) -> None:
     try:
-        relative = out_dir.resolve().relative_to(repo_root.resolve())
-    except ValueError:
-        return
-    if relative.parts and relative.parts[0] == "submissions":
-        raise ReviewOutputError("Review output must not be written inside `submissions/`")
+        candidates = {
+            Path(os.path.abspath(out_dir)),
+            out_dir.resolve(),
+        }
+        protected_roots = {
+            repo_root.resolve() / "submissions",
+            submission_dir.resolve(),
+        }
+    except (OSError, RuntimeError) as exc:
+        raise ReviewOutputError(f"Review output path cannot be resolved safely: {exc}") from exc
+
+    for candidate in candidates:
+        if "submissions" in candidate.parts or any(
+            candidate == root or candidate.is_relative_to(root) for root in protected_roots
+        ):
+            raise ReviewOutputError("Review output must not be written inside `submissions/`")
+
+
+def write_text_atomically(path: Path, text: str) -> None:
+    mode = path.stat().st_mode & 0o777 if path.exists() else 0o644
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            os.fchmod(handle.fileno(), mode)
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+        raise
 
 
 def run_json_command(command: list[str]) -> dict:
@@ -413,17 +450,18 @@ def main() -> int:
     else:
         out_dir = repo_root / DEFAULT_OUTPUT_ROOT / submission_dir.name / "review-packet"
     try:
-        validate_output_dir(repo_root, out_dir)
+        validate_output_dir(repo_root, out_dir, submission_dir)
     except ReviewOutputError as exc:
         parser.error(str(exc))
     out_dir.mkdir(parents=True, exist_ok=True)
 
     review_input = build_review_input(repo_root, submission_dir)
-    (out_dir / "review-input.json").write_text(
-        json.dumps(review_input, ensure_ascii=False, indent=2), encoding="utf-8"
+    write_text_atomically(
+        out_dir / "review-input.json",
+        json.dumps(review_input, ensure_ascii=False, indent=2),
     )
-    (out_dir / "review-prompt.md").write_text(build_prompt(review_input), encoding="utf-8")
-    (out_dir / "advisory-review.md").write_text(build_template(review_input), encoding="utf-8")
+    write_text_atomically(out_dir / "review-prompt.md", build_prompt(review_input))
+    write_text_atomically(out_dir / "advisory-review.md", build_template(review_input))
     print(out_dir)
     return 0
 

--- a/scripts/review_submission.py
+++ b/scripts/review_submission.py
@@ -119,6 +119,10 @@ PACKAGE_FILES_INCLUDED_AS_PARTIAL_PREVIEW = {
 }
 
 
+class ReviewOutputError(ValueError):
+    pass
+
+
 def read_text(path: Path) -> str:
     if not path.exists():
         return ""
@@ -155,6 +159,15 @@ def script_path(repo_root: Path, name: str) -> Path:
     # participant-controlled scripts), so it must never supply executables to
     # the review process.
     return SCRIPT_DIR / name
+
+
+def validate_output_dir(repo_root: Path, out_dir: Path) -> None:
+    try:
+        relative = out_dir.resolve().relative_to(repo_root.resolve())
+    except ValueError:
+        return
+    if relative.parts and relative.parts[0] == "submissions":
+        raise ReviewOutputError("Review output must not be written inside `submissions/`")
 
 
 def run_json_command(command: list[str]) -> dict:
@@ -399,6 +412,10 @@ def main() -> int:
             out_dir = repo_root / out_dir
     else:
         out_dir = repo_root / DEFAULT_OUTPUT_ROOT / submission_dir.name / "review-packet"
+    try:
+        validate_output_dir(repo_root, out_dir)
+    except ReviewOutputError as exc:
+        parser.error(str(exc))
     out_dir.mkdir(parents=True, exist_ok=True)
 
     review_input = build_review_input(repo_root, submission_dir)

--- a/tests/test_review_submission_output_boundary.py
+++ b/tests/test_review_submission_output_boundary.py
@@ -1,0 +1,69 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class ReviewSubmissionOutputBoundaryTests(unittest.TestCase):
+    def test_repository_output_must_stay_under_maintainer_review(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission = root / "submissions" / "alice" / "demo"
+            submission.mkdir(parents=True)
+            proposal = submission / "proposal.md"
+            proposal.write_text("original proposal\n", encoding="utf-8")
+            out_dir = submission / "review-inputs"
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "review_submission.py"),
+                    str(submission),
+                    "--repo-root",
+                    str(root),
+                    "--out",
+                    str(out_dir),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertIn("must not be written inside `submissions/`", completed.stderr)
+            self.assertFalse(out_dir.exists())
+            self.assertEqual("original proposal\n", proposal.read_text(encoding="utf-8"))
+
+    def test_repository_maintainer_review_output_remains_allowed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission = root / "submissions" / "alice" / "demo"
+            submission.mkdir(parents=True)
+            (submission / "proposal.md").write_text("# Demo\n", encoding="utf-8")
+            out_dir = root / ".maintainer-review" / "demo" / "review-packet"
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "review_submission.py"),
+                    str(submission),
+                    "--repo-root",
+                    str(root),
+                    "--out",
+                    str(out_dir),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+            self.assertTrue((out_dir / "review-input.json").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_review_submission_output_boundary.py
+++ b/tests/test_review_submission_output_boundary.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 import tempfile
@@ -9,6 +10,24 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 class ReviewSubmissionOutputBoundaryTests(unittest.TestCase):
+    def run_review(
+        self, root: Path, submission: Path, out_dir: Path
+    ) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "review_submission.py"),
+                str(submission),
+                "--repo-root",
+                str(root),
+                "--out",
+                str(out_dir),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
     def test_repository_output_must_stay_under_maintainer_review(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -37,6 +56,76 @@ class ReviewSubmissionOutputBoundaryTests(unittest.TestCase):
             self.assertIn("must not be written inside `submissions/`", completed.stderr)
             self.assertFalse(out_dir.exists())
             self.assertEqual("original proposal\n", proposal.read_text(encoding="utf-8"))
+
+    def test_nested_repo_root_cannot_hide_submission_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            owner_root = Path(tmp) / "submissions" / "alice"
+            submission = owner_root / "demo"
+            submission.mkdir(parents=True)
+            (submission / "proposal.md").write_text("original proposal\n", encoding="utf-8")
+            out_dir = submission / "review-inputs"
+
+            completed = self.run_review(owner_root, submission, out_dir)
+
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertIn("must not be written inside `submissions/`", completed.stderr)
+            self.assertFalse(out_dir.exists())
+
+    def test_dangling_submission_output_symlink_is_rejected_lexically(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            submission = root / "submissions" / "alice" / "demo"
+            submission.mkdir(parents=True)
+            (submission / "proposal.md").write_text("original proposal\n", encoding="utf-8")
+            outside = Path(tmp) / "outside-review"
+            out_dir = submission / "review-link"
+            try:
+                out_dir.symlink_to(outside, target_is_directory=True)
+            except OSError as exc:
+                self.skipTest(f"symlinks unavailable: {exc}")
+
+            completed = self.run_review(root, submission, out_dir)
+
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertFalse(outside.exists())
+
+    def test_external_output_file_aliases_do_not_overwrite_submission(self) -> None:
+        for link_kind in ("symlink", "hardlink"):
+            for output_name in (
+                "review-input.json",
+                "review-prompt.md",
+                "advisory-review.md",
+            ):
+                with self.subTest(link_kind=link_kind, output_name=output_name):
+                    with tempfile.TemporaryDirectory() as tmp:
+                        root = Path(tmp) / "repo"
+                        submission = root / "submissions" / "alice" / "demo"
+                        submission.mkdir(parents=True)
+                        proposal = submission / "proposal.md"
+                        original = b"original proposal\n"
+                        proposal.write_bytes(original)
+                        out_dir = Path(tmp) / "external-review"
+                        out_dir.mkdir()
+                        output = out_dir / output_name
+                        try:
+                            if link_kind == "symlink":
+                                output.symlink_to(proposal)
+                            else:
+                                os.link(proposal, output)
+                        except OSError as exc:
+                            self.skipTest(f"{link_kind} unavailable: {exc}")
+
+                        completed = self.run_review(root, submission, out_dir)
+
+                        self.assertEqual(
+                            completed.returncode,
+                            0,
+                            completed.stdout + completed.stderr,
+                        )
+                        self.assertEqual(original, proposal.read_bytes())
+                        self.assertFalse(output.is_symlink())
+                        self.assertFalse(output.samefile(proposal))
+                        self.assertEqual([], list(out_dir.glob(f".{output_name}.*.tmp")))
 
     def test_repository_maintainer_review_output_remains_allowed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- reject lexical or resolved review output paths containing an exact `submissions` component, independent of `--repo-root`
- bind the guard to the selected submission as an additional fail-closed anchor
- publish the three review packet files through same-directory temporary files and `os.replace`
- preserve existing output modes while preventing file-level symlink and hardlink aliases from modifying package inputs

## Reproduction

The previous head could be bypassed by pointing `--repo-root` at `submissions/alice` and writing beneath the selected package. An otherwise external output directory could also contain `review-input.json`, `review-prompt.md`, or `advisory-review.md` as a symlink or hardlink to `proposal.md`; ordinary `write_text()` then replaced the package input bytes.

The updated guard checks both lexical and resolved output paths before creating the directory. Atomic replacement changes only the requested output directory entry, so linked victims retain their original inode and bytes.

## Validation

- `python3 -m unittest tests.test_review_submission_output_boundary tests.test_review_submission -v` (8 passed)
- same 8 tests under Python 3.9
- `python3 -m py_compile scripts/review_submission.py tests/test_review_submission_output_boundary.py`
- Python 3.9 `py_compile`
- `git diff --check upstream/main...HEAD`

The regression matrix covers nested repository roots, direct and dangling submission paths, all three fixed output names through symlink and hardlink aliases, normal maintainer output, and external output.