### PR TITLE
fix: reject nonstandard manifest JSON constants

### DIFF
--- a/scripts/validate_manifest_schema.py
+++ b/scripts/validate_manifest_schema.py
@@ -15,6 +15,10 @@ from pathlib import Path
 from manifest_schema import legacy_role_findings, manifest_paths, schema_errors
 
 
+def reject_nonstandard_constant(value: str) -> None:
+    raise ValueError(f"invalid JSON constant: {value}")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo-root", default=".")
@@ -34,8 +38,11 @@ def main() -> int:
     for path in paths:
         manifest = None
         try:
-            manifest = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            manifest = json.loads(
+                path.read_text(encoding="utf-8"),
+                parse_constant=reject_nonstandard_constant,
+            )
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
             errors = [f"unable to read manifest: {exc}"]
         else:
             if not isinstance(manifest, dict):

--- a/tests/test_manifest_schema_json.py
+++ b/tests/test_manifest_schema_json.py
@@ -1,0 +1,91 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "validate_manifest_schema.py"
+
+
+def manifest(extension_data: object) -> dict:
+    return {
+        "schema_version": "0.2.0",
+        "package_id": "sample-package",
+        "project_id": "centennial-jingzhang-ai-belt",
+        "site_package_version": "0.1.0",
+        "submission_stage": "formal",
+        "submission_type": "ai_agent",
+        "agent": {
+            "agent_id": "sample-agent",
+            "agent_name": "Sample Agent",
+            "model": "Model 1",
+        },
+        "generated_at": "2026-08-10T00:00:00Z",
+        "files": [
+            {"path": "evidence.json", "role": "evidence_data", "required": True}
+        ],
+        "validation_claim": {
+            "self_checked": True,
+            "known_blockers": [],
+            "readiness_contract": "persisted-self-check-v1",
+            "extensions": {
+                "x-test": {"schema_version": "1.0", "data": extension_data}
+            },
+        },
+    }
+
+
+class ManifestSchemaJsonTests(unittest.TestCase):
+    def run_audit(self, raw_manifest: str) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "manifest.json").write_text(raw_manifest, encoding="utf-8")
+            return subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--repo-root",
+                    str(root),
+                    "--manifest",
+                    "manifest.json",
+                    "--strict",
+                    "--json",
+                ],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+    def test_nonstandard_numeric_constants_are_invalid_json(self):
+        marker = '"NONSTANDARD_CONSTANT"'
+        base = json.dumps(manifest("NONSTANDARD_CONSTANT"))
+
+        for constant in ("NaN", "Infinity", "-Infinity"):
+            with self.subTest(constant=constant):
+                result = self.run_audit(base.replace(marker, constant))
+                payload = json.loads(result.stdout)
+
+                self.assertEqual(result.returncode, 1, result.stdout)
+                self.assertEqual(payload["valid"], 0)
+                self.assertEqual(payload["invalid"], 1)
+                self.assertFalse(payload["results"][0]["valid"])
+                self.assertTrue(
+                    any(constant in error for error in payload["results"][0]["errors"]),
+                    payload["results"][0]["errors"],
+                )
+
+    def test_standard_extension_data_remains_valid(self):
+        result = self.run_audit(json.dumps(manifest({"score": 1.5})))
+        payload = json.loads(result.stdout)
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(payload["valid"], 1)
+        self.assertEqual(payload["invalid"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject `NaN`, `Infinity`, and `-Infinity` while decoding manifests
- keep strict audit output machine-readable and include the offending token in its error
- preserve support for standard scalar and structured extension data

## Reproduction

Python JSON decoding accepts nonstandard numeric constants by default. A valid `0.2.0` manifest with `validation_claim.extensions.x-test.data: NaN` therefore completed `validate_manifest_schema.py --strict --json` with exit code 0 and reported `valid: 1`, even though the file is not portable JSON. `Infinity` and `-Infinity` behaved identically.

## Root cause

The audit used the default `json.loads()` constant parser. The extension `data` schema intentionally accepts any JSON value, so schema validation had no reason to reject Python's non-finite float result.

## Validation

- `python3 -m unittest tests.test_manifest_schema_json tests.test_manifest_schema` (17 passed)
- `python3 -m py_compile scripts/validate_manifest_schema.py tests/test_manifest_schema_json.py`
- `git diff --check`