### PR TITLE
fix: contain bilingual backfill discovery

### DIFF
--- a/scripts/backfill_bilingual_submissions.py
+++ b/scripts/backfill_bilingual_submissions.py
@@ -1205,6 +1205,29 @@ def is_symlink_free_contained_path(path: Path, root: Path) -> bool:
     return path.resolve().is_relative_to(root.resolve())
 
 
+def resolve_only_selection(found: list[Path], only: list[str], repo_root: Path) -> list[Path]:
+    if not only:
+        return found
+    selected: list[Path] = []
+    for raw in only:
+        candidate = Path(raw)
+        if candidate.is_absolute():
+            matches = [path for path in found if path == candidate.resolve()]
+        elif "/" in raw or "\\" in raw:
+            target = (repo_root / candidate).resolve()
+            matches = [path for path in found if path == target]
+        else:
+            matches = [path for path in found if path.name == raw]
+            if len(matches) > 1:
+                choices = ", ".join(path.relative_to(repo_root).as_posix() for path in matches)
+                raise ValueError(f"--only `{raw}` is ambiguous; use an exact path: {choices}")
+        if not matches:
+            raise ValueError(f"--only `{raw}` did not match a discovered submission")
+        if matches[0] not in selected:
+            selected.append(matches[0])
+    return sorted(selected)
+
+
 def proposal_dirs(repo_root: Path, only: list[str]) -> list[Path]:
     submissions_root = repo_root / "submissions"
     found = sorted(
@@ -1212,10 +1235,7 @@ def proposal_dirs(repo_root: Path, only: list[str]) -> list[Path]:
         for path in submissions_root.glob("*/*/proposal.md")
         if is_symlink_free_contained_path(path, submissions_root)
     )
-    if not only:
-        return found
-    wanted = set(only)
-    return [path for path in found if path.name in wanted or path.as_posix() in wanted]
+    return resolve_only_selection(found, only, repo_root)
 
 
 def backfill_proposal(
@@ -1302,10 +1322,13 @@ def main() -> int:
     args = parser.parse_args()
 
     repo_root = args.repo_root.resolve()
-    zh_to_en, en_to_zh = load_glossary(repo_root / "docs" / "terminology-glossary.md")
-    dirs = proposal_dirs(repo_root, args.only)
+    try:
+        dirs = proposal_dirs(repo_root, args.only)
+    except ValueError as exc:
+        parser.error(str(exc))
     if args.limit:
         dirs = dirs[: args.limit]
+    zh_to_en, en_to_zh = load_glossary(repo_root / "docs" / "terminology-glossary.md")
     directions: set[tuple[str, str]] = set()
     for directory in dirs:
         front, body = parse_front_matter((directory / "proposal.md").read_text(encoding="utf-8"))

--- a/scripts/backfill_bilingual_submissions.py
+++ b/scripts/backfill_bilingual_submissions.py
@@ -1190,8 +1190,28 @@ def extract_legacy_translation(body: str, target_language: str) -> str | None:
     return translated_body
 
 
+def is_symlink_free_contained_path(path: Path, root: Path) -> bool:
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        return False
+    current = root
+    if current.is_symlink():
+        return False
+    for part in relative.parts:
+        current /= part
+        if current.is_symlink():
+            return False
+    return path.resolve().is_relative_to(root.resolve())
+
+
 def proposal_dirs(repo_root: Path, only: list[str]) -> list[Path]:
-    found = sorted(path.parent for path in (repo_root / "submissions").glob("*/*/proposal.md"))
+    submissions_root = repo_root / "submissions"
+    found = sorted(
+        path.parent
+        for path in submissions_root.glob("*/*/proposal.md")
+        if is_symlink_free_contained_path(path, submissions_root)
+    )
     if not only:
         return found
     wanted = set(only)

--- a/scripts/backfill_bilingual_submissions.py
+++ b/scripts/backfill_bilingual_submissions.py
@@ -1224,6 +1224,8 @@ def backfill_proposal(
     force: bool,
 ) -> tuple[bool, str]:
     proposal_path = submission_dir / "proposal.md"
+    if proposal_path.is_symlink():
+        return False, "refusing to read or write through symlink `proposal.md`"
     text = proposal_path.read_text(encoding="utf-8")
     front, body = parse_front_matter(text)
     if not front:
@@ -1232,6 +1234,8 @@ def backfill_proposal(
     target_language = "en" if source_language == "zh" else "zh"
     translation_name = f"proposal.{target_language}.md"
     translation_path = submission_dir / translation_name
+    if translation_path.is_symlink():
+        return False, f"refusing to write through symlink `{translation_name}`"
     if translation_path.exists() and not force:
         return False, "translation already exists"
 

--- a/tests/test_bilingual_backfill.py
+++ b/tests/test_bilingual_backfill.py
@@ -17,6 +17,7 @@ from backfill_bilingual_artifacts import (  # noqa: E402
 )
 from backfill_bilingual_submissions import (  # noqa: E402
     LocalTranslator,
+    backfill_proposal,
     extract_legacy_translation,
     parse_front_matter,
     proposal_dirs,
@@ -27,6 +28,15 @@ from backfill_bilingual_submissions import (  # noqa: E402
 
 
 class BilingualBackfillTests(unittest.TestCase):
+    class StubTranslator:
+        batch_size = 4
+
+        def translate(self, text: str) -> str:
+            return f"EN:{text}"
+
+        def translate_many(self, texts: list[str]) -> list[str]:
+            return [self.translate(text) for text in texts]
+
     def test_proposal_discovery_rejects_symlinked_packages_and_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "repo"
@@ -57,6 +67,35 @@ class BilingualBackfillTests(unittest.TestCase):
             )
 
             self.assertEqual([regular], proposal_dirs(root, []))
+
+    def test_backfill_refuses_translation_symlinks(self) -> None:
+        for target_exists, force in ((False, False), (True, True)):
+            with self.subTest(target_exists=target_exists, force=force), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                package = root / "submissions" / "alice" / "sample"
+                package.mkdir(parents=True)
+                (package / "proposal.md").write_text(
+                    '---\ntitle: "示例"\nsummary: "摘要"\nlanguage: "zh"\n---\n# 示例\n\n正文\n',
+                    encoding="utf-8",
+                )
+                outside = root / "outside.md"
+                if target_exists:
+                    outside.write_text("outside original\n", encoding="utf-8")
+                (package / "proposal.en.md").symlink_to(outside)
+                original = outside.read_bytes() if target_exists else None
+
+                changed, message = backfill_proposal(
+                    package,
+                    {("zh", "en"): self.StubTranslator()},
+                    force=force,
+                )
+
+                self.assertFalse(changed)
+                self.assertIn("refusing to write through symlink", message)
+                if target_exists:
+                    self.assertEqual(outside.read_bytes(), original)
+                else:
+                    self.assertFalse(outside.exists())
 
     def test_front_matter_parser_accepts_utf8_bom(self) -> None:
         front, body = parse_front_matter("\ufeff---\nlanguage: zh\n---\n正文\n")

--- a/tests/test_bilingual_backfill.py
+++ b/tests/test_bilingual_backfill.py
@@ -1,5 +1,7 @@
 import hashlib
 import json
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -67,6 +69,52 @@ class BilingualBackfillTests(unittest.TestCase):
             )
 
             self.assertEqual([regular], proposal_dirs(root, []))
+
+    def test_only_rejects_ambiguous_slug_and_accepts_exact_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            first = root / "submissions" / "alice" / "same-slug"
+            second = root / "submissions" / "bob" / "same-slug"
+            for package in (first, second):
+                package.mkdir(parents=True)
+                (package / "proposal.md").write_text("proposal", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "ambiguous"):
+                proposal_dirs(root, ["same-slug"])
+            self.assertEqual([first], proposal_dirs(root, ["submissions/alice/same-slug"]))
+            self.assertEqual([second], proposal_dirs(root, [str(second)]))
+
+    def test_only_rejects_empty_selection(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            package = root / "submissions" / "alice" / "sample"
+            package.mkdir(parents=True)
+            (package / "proposal.md").write_text("proposal", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "did not match"):
+                proposal_dirs(root, ["missing"])
+
+    def test_cli_reports_selection_errors_before_loading_runtime(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            package = root / "submissions" / "alice" / "sample"
+            package.mkdir(parents=True)
+            (package / "proposal.md").write_text("proposal", encoding="utf-8")
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "scripts" / "backfill_bilingual_submissions.py"),
+                    "--repo-root",
+                    str(root),
+                    "--only",
+                    "missing",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn("did not match a discovered submission", completed.stderr)
 
     def test_backfill_refuses_translation_symlinks(self) -> None:
         for target_exists, force in ((False, False), (True, True)):

--- a/tests/test_bilingual_backfill.py
+++ b/tests/test_bilingual_backfill.py
@@ -19,6 +19,7 @@ from backfill_bilingual_submissions import (  # noqa: E402
     LocalTranslator,
     extract_legacy_translation,
     parse_front_matter,
+    proposal_dirs,
     set_front_fields,
     split_long_text,
     translate_body,
@@ -26,6 +27,37 @@ from backfill_bilingual_submissions import (  # noqa: E402
 
 
 class BilingualBackfillTests(unittest.TestCase):
+    def test_proposal_discovery_rejects_symlinked_packages_and_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            submissions = root / "submissions"
+            regular = submissions / "alice" / "regular"
+            regular.mkdir(parents=True)
+            (regular / "proposal.md").write_text("regular", encoding="utf-8")
+
+            outside_package = Path(tmp) / "outside-package"
+            outside_package.mkdir()
+            (outside_package / "proposal.md").write_text("outside", encoding="utf-8")
+            (submissions / "alice" / "linked-package").symlink_to(
+                outside_package,
+                target_is_directory=True,
+            )
+
+            linked_file = submissions / "alice" / "linked-file"
+            linked_file.mkdir()
+            (linked_file / "proposal.md").symlink_to(outside_package / "proposal.md")
+
+            outside_owner = Path(tmp) / "outside-owner"
+            owner_package = outside_owner / "linked-owner-package"
+            owner_package.mkdir(parents=True)
+            (owner_package / "proposal.md").write_text("outside owner", encoding="utf-8")
+            (submissions / "linked-owner").symlink_to(
+                outside_owner,
+                target_is_directory=True,
+            )
+
+            self.assertEqual([regular], proposal_dirs(root, []))
+
     def test_front_matter_parser_accepts_utf8_bom(self) -> None:
         front, body = parse_front_matter("\ufeff---\nlanguage: zh\n---\n正文\n")
         self.assertEqual(["language: zh"], front)


### PR DESCRIPTION
## Summary

- exclude proposal paths that traverse a symlink at the submissions root, owner, package, or `proposal.md` component
- verify every discovered proposal resolves inside the repository submissions root
- keep ordinary submission packages discoverable

## Reproduction

Given `submissions/alice/linked -> TARGET` where `TARGET/proposal.md` is outside the repository, `proposal_dirs()` currently returns the linked package. `backfill_proposal()` then creates `TARGET/proposal.en.md` and rewrites `TARGET/proposal.md` with translation metadata. A direct `proposal.md` symlink has the same write-through behavior.

The intake validator already rejects symlinked submission paths; this change applies the same trust boundary before the maintainer backfill performs writes.

## Validation

- `python3 -m unittest tests.test_bilingual_backfill.BilingualBackfillTests.test_proposal_discovery_rejects_symlinked_packages_and_files`
- full `tests.test_bilingual_backfill`: 22 tests passed; the remaining existing figure-render test requires Arial Unicode, covered by #808
- `python3 -m py_compile scripts/backfill_bilingual_submissions.py tests/test_bilingual_backfill.py`
- `git diff --check`