### PR TITLE
fix: protect exhibit generator inputs

### DIFF
--- a/scripts/generate_exhibit.py
+++ b/scripts/generate_exhibit.py
@@ -222,8 +222,20 @@ def main() -> int:
     output = Path(args.output) if args.output else submission_dir / "exhibit.json"
     output_resolved = output.resolve()
     for label, input_path in generation_inputs(repo_root, submission_dir):
-        if output_resolved == input_path.resolve():
+        if output_resolved == input_path.resolve() or (
+            output.exists() and output.samefile(input_path)
+        ):
             parser.error(f"output must not overwrite the {label} input: {input_path}")
+    submissions_root = (repo_root / "submissions").resolve()
+    default_output = (submission_dir / "exhibit.json").resolve()
+    if (
+        output_resolved != default_output
+        and output_resolved.is_relative_to(submissions_root)
+        and output_resolved.exists()
+    ):
+        parser.error(
+            f"output must not overwrite an existing file inside submissions/: {output}"
+        )
 
     exhibit = build_exhibit(repo_root, submission_dir)
     validate_against_schema(repo_root, exhibit)

--- a/scripts/generate_exhibit.py
+++ b/scripts/generate_exhibit.py
@@ -38,7 +38,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import stat
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -88,6 +91,33 @@ def generation_inputs(repo_root: Path, submission_dir: Path) -> list[tuple[str, 
             found.append((label, path))
             seen.add(resolved)
     return found
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        output_mode = stat.S_IMODE(path.stat().st_mode)
+    except OSError:
+        output_mode = 0o644
+    fd, temp_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temp_path = Path(temp_name)
+    try:
+        os.chmod(temp_path, output_mode)
+        handle = os.fdopen(fd, "w", encoding="utf-8")
+        fd = -1
+        with handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        temp_path.unlink(missing_ok=True)
 
 
 def pick_image(submission_dir: Path, candidates: tuple[str, ...]) -> str | None:
@@ -220,6 +250,7 @@ def main() -> int:
     if not submission_dir.is_absolute():
         submission_dir = repo_root / submission_dir
     output = Path(args.output) if args.output else submission_dir / "exhibit.json"
+    output_lexical = Path(os.path.abspath(output))
     output_resolved = output.resolve()
     for label, input_path in generation_inputs(repo_root, submission_dir):
         if output_resolved == input_path.resolve() or (
@@ -227,15 +258,13 @@ def main() -> int:
         ):
             parser.error(f"output must not overwrite the {label} input: {input_path}")
     submissions_root = (repo_root / "submissions").resolve()
-    default_output = (submission_dir / "exhibit.json").resolve()
-    if (
-        output_resolved != default_output
-        and output_resolved.is_relative_to(submissions_root)
-        and output_resolved.exists()
+    default_output = Path(os.path.abspath(submission_dir / "exhibit.json"))
+    if output_lexical != default_output and any(
+        candidate.is_relative_to(submissions_root)
+        for candidate in (output_lexical, output_resolved)
     ):
-        parser.error(
-            f"output must not overwrite an existing file inside submissions/: {output}"
-        )
+        action = "overwrite an existing file" if output.exists() else "write a new file"
+        parser.error(f"output must not {action} inside submissions/: {output}")
 
     exhibit = build_exhibit(repo_root, submission_dir)
     validate_against_schema(repo_root, exhibit)
@@ -251,8 +280,7 @@ def main() -> int:
         print(f"{output}: up to date")
         return 0
 
-    output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(rendered, encoding="utf-8")
+    atomic_write_text(output, rendered)
     print(str(output))
     return 0
 

--- a/scripts/generate_exhibit.py
+++ b/scripts/generate_exhibit.py
@@ -57,6 +57,39 @@ SPATIAL_IMAGE_CANDIDATES = (
 )
 
 
+def generation_inputs(repo_root: Path, submission_dir: Path) -> list[tuple[str, Path]]:
+    manifest_path = submission_dir / "manifest.json"
+    inputs = [
+        ("proposal", submission_dir / "proposal.md"),
+        ("self-check", submission_dir / "self_check.json"),
+        ("manifest", manifest_path),
+        ("publication registry", repo_root / "gallery-publication.json"),
+        ("exhibit schema", repo_root / "schema" / "exhibit.schema.json"),
+    ]
+    figures = submission_dir / "assets" / "figures"
+    inputs.extend(("proposal figure", path) for path in sorted(figures.glob("*.png")))
+    if manifest_path.is_file():
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            manifest = None
+        files = manifest.get("files") if isinstance(manifest, dict) else None
+        if isinstance(files, list):
+            inputs.extend(
+                ("reviewed package artifact", submission_dir / item["path"])
+                for item in files
+                if isinstance(item, dict) and isinstance(item.get("path"), str)
+            )
+    found: list[tuple[str, Path]] = []
+    seen: set[Path] = set()
+    for label, path in inputs:
+        resolved = path.resolve()
+        if path.exists() and resolved not in seen:
+            found.append((label, path))
+            seen.add(resolved)
+    return found
+
+
 def pick_image(submission_dir: Path, candidates: tuple[str, ...]) -> str | None:
     for rel in candidates:
         if (submission_dir / rel).exists():
@@ -187,6 +220,10 @@ def main() -> int:
     if not submission_dir.is_absolute():
         submission_dir = repo_root / submission_dir
     output = Path(args.output) if args.output else submission_dir / "exhibit.json"
+    output_resolved = output.resolve()
+    for label, input_path in generation_inputs(repo_root, submission_dir):
+        if output_resolved == input_path.resolve():
+            parser.error(f"output must not overwrite the {label} input: {input_path}")
 
     exhibit = build_exhibit(repo_root, submission_dir)
     validate_against_schema(repo_root, exhibit)

--- a/tests/test_generate_exhibit_output_boundary.py
+++ b/tests/test_generate_exhibit_output_boundary.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import stat
 import subprocess
 import sys
 import tempfile
@@ -24,7 +25,8 @@ class GenerateExhibitOutputBoundaryTests(unittest.TestCase):
         proposal = submission / "proposal.md"
         proposal.write_text(
             f'---\ntitle: "{slug}"\nsummary: "Sample published exhibit"\n'
-            f'author_github: "{author}"\n---\n# Sample\n',
+            f'author_github: "{author}"\ntracks: ["sample-track"]\n'
+            'scenarios: ["sample-scenario"]\n---\n# Sample\n',
             encoding="utf-8",
         )
         figure.write_bytes(b"fixture image")
@@ -71,6 +73,9 @@ class GenerateExhibitOutputBoundaryTests(unittest.TestCase):
         sys.path.insert(0, str(ROOT / "scripts"))
         from generate_submissions_data import package_sha256
 
+        schema = root / "schema" / "exhibit.schema.json"
+        schema.parent.mkdir()
+        schema.write_bytes((ROOT / "schema" / "exhibit.schema.json").read_bytes())
         registry = root / "gallery-publication.json"
         registry.write_text(
             json.dumps(
@@ -115,6 +120,7 @@ class GenerateExhibitOutputBoundaryTests(unittest.TestCase):
             ("self-check", own_files["self-check"]),
             ("manifest", own_files["manifest"]),
             ("publication registry", registry),
+            ("exhibit schema", schema),
             ("proposal figure", own_files["proposal figure"]),
             ("reviewed package artifact", own_files["reviewed package artifact"]),
         ], other_files
@@ -140,56 +146,175 @@ class GenerateExhibitOutputBoundaryTests(unittest.TestCase):
         )
 
     def test_output_cannot_overwrite_generation_inputs(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            submission, inputs, _other_files = self.make_fixture(root)
+        labels = (
+            "proposal",
+            "self-check",
+            "manifest",
+            "publication registry",
+            "exhibit schema",
+            "proposal figure",
+            "reviewed package artifact",
+        )
+        for label in labels:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                submission, inputs, _other_files = self.make_fixture(root)
+                input_path = dict(inputs)[label]
+                original = input_path.read_bytes()
 
-            for label, input_path in inputs:
-                with self.subTest(label=label):
-                    original = input_path.read_bytes()
-                    result = self.run_generator(root, submission, input_path)
+                result = self.run_generator(root, submission, input_path)
 
-                    self.assertNotEqual(result.returncode, 0)
-                    self.assertIn(f"output must not overwrite the {label} input", result.stderr)
-                    self.assertEqual(input_path.read_bytes(), original)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(f"output must not overwrite the {label} input", result.stderr)
+                self.assertEqual(input_path.read_bytes(), original)
 
     def test_output_cannot_overwrite_another_published_package(self):
+        labels = (
+            "proposal",
+            "self-check",
+            "manifest",
+            "reviewed package artifact",
+            "proposal figure",
+        )
+        for label in labels:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                submission, _inputs, other_files = self.make_fixture(root)
+                target = other_files[label]
+                original = target.read_bytes()
+
+                result = self.run_generator(root, submission, target)
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    "output must not overwrite an existing file inside submissions/",
+                    result.stderr,
+                )
+                self.assertEqual(target.read_bytes(), original)
+
+    def test_output_cannot_overwrite_input_through_hardlink(self):
+        labels = (
+            "proposal",
+            "self-check",
+            "manifest",
+            "publication registry",
+            "exhibit schema",
+            "proposal figure",
+            "reviewed package artifact",
+        )
+        for label in labels:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                submission, inputs, _other_files = self.make_fixture(root)
+                target = dict(inputs)[label]
+                alias = root / f"{label.replace(' ', '-')}-alias"
+                os.link(target, alias)
+                original = target.read_bytes()
+
+                result = self.run_generator(root, submission, alias)
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(f"output must not overwrite the {label} input", result.stderr)
+                self.assertEqual(target.read_bytes(), original)
+
+    def test_output_cannot_overwrite_input_through_symlink(self):
+        for package in ("selected", "other"):
+            with self.subTest(package=package), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                submission, inputs, other_files = self.make_fixture(root)
+                target = (
+                    dict(inputs)["proposal"]
+                    if package == "selected"
+                    else other_files["proposal"]
+                )
+                alias = root / f"{package}-proposal-symlink.md"
+                alias.symlink_to(target)
+                original = target.read_bytes()
+
+                result = self.run_generator(root, submission, alias)
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(target.read_bytes(), original)
+
+    def test_external_hardlink_to_other_package_is_replaced_atomically(self):
+        labels = (
+            "proposal",
+            "self-check",
+            "manifest",
+            "reviewed package artifact",
+            "proposal figure",
+        )
+        for label in labels:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                submission, _inputs, other_files = self.make_fixture(root)
+                target = other_files[label]
+                alias = root / f"external-{label.replace(' ', '-')}-hardlink"
+                os.link(target, alias)
+                original = target.read_bytes()
+
+                result = self.run_generator(root, submission, alias)
+
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertEqual(target.read_bytes(), original)
+                self.assertFalse(alias.samefile(target))
+                self.assertEqual(json.loads(alias.read_text(encoding="utf-8"))["version"], 1)
+
+    def test_default_output_alias_to_other_package_is_replaced_atomically(self):
+        for alias_kind in ("symlink", "hardlink"):
+            with self.subTest(alias_kind=alias_kind), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                submission, _inputs, other_files = self.make_fixture(root)
+                target = other_files["proposal"]
+                output = submission / "exhibit.json"
+                if alias_kind == "symlink":
+                    output.symlink_to(target)
+                else:
+                    os.link(target, output)
+                original = target.read_bytes()
+
+                result = self.run_generator(root, submission)
+
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertEqual(target.read_bytes(), original)
+                self.assertFalse(output.is_symlink())
+                self.assertFalse(output.samefile(target))
+                self.assertEqual(json.loads(output.read_text(encoding="utf-8"))["version"], 1)
+
+    def test_output_cannot_create_files_in_another_package(self):
+        targets = (
+            "exhibit.json",
+            "assets/figures/injected.png",
+            "report/proposal.html",
+        )
+        for relative in targets:
+            with self.subTest(relative=relative), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                submission, _inputs, other_files = self.make_fixture(root)
+                other_submission = other_files["proposal"].parent
+                output = other_submission / relative
+
+                result = self.run_generator(root, submission, output)
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("output must not write a new file inside submissions/", result.stderr)
+                self.assertFalse(output.exists())
+
+    def test_dangling_symlink_inside_submissions_cannot_escape(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             submission, _inputs, other_files = self.make_fixture(root)
+            outside = root / "outside" / "escaped.json"
+            outside.parent.mkdir()
+            output = other_files["proposal"].parent / "dangling-output.json"
+            output.symlink_to(outside)
 
-            for label in (
-                "proposal",
-                "manifest",
-                "reviewed package artifact",
-                "proposal figure",
-            ):
-                with self.subTest(label=label):
-                    target = other_files[label]
-                    original = target.read_bytes()
-                    result = self.run_generator(root, submission, target)
-
-                    self.assertNotEqual(result.returncode, 0)
-                    self.assertIn(
-                        "output must not overwrite an existing file inside submissions/",
-                        result.stderr,
-                    )
-                    self.assertEqual(target.read_bytes(), original)
-
-    def test_output_cannot_overwrite_input_through_hardlink(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            submission, inputs, _other_files = self.make_fixture(root)
-            proposal = dict(inputs)["proposal"]
-            alias = root / "proposal-alias.md"
-            os.link(proposal, alias)
-            original = proposal.read_bytes()
-
-            result = self.run_generator(root, submission, alias)
+            result = self.run_generator(root, submission, output)
 
             self.assertNotEqual(result.returncode, 0)
-            self.assertIn("output must not overwrite the proposal input", result.stderr)
-            self.assertEqual(proposal.read_bytes(), original)
+            self.assertIn("output must not write a new file inside submissions/", result.stderr)
+            self.assertTrue(output.is_symlink())
+            self.assertFalse(outside.exists())
 
     def test_default_output_can_be_regenerated(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -197,12 +322,15 @@ class GenerateExhibitOutputBoundaryTests(unittest.TestCase):
             submission, _inputs, _other_files = self.make_fixture(root)
 
             first = self.run_generator(root, submission)
+            output = submission / "exhibit.json"
+            output.chmod(0o640)
             second = self.run_generator(root, submission)
 
             self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
             self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+            self.assertEqual(stat.S_IMODE(output.stat().st_mode), 0o640)
             self.assertEqual(
-                json.loads((submission / "exhibit.json").read_text(encoding="utf-8"))["version"],
+                json.loads(output.read_text(encoding="utf-8"))["version"],
                 1,
             )
 

--- a/tests/test_generate_exhibit_output_boundary.py
+++ b/tests/test_generate_exhibit_output_boundary.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "generate_exhibit.py"
+
+
+class GenerateExhibitOutputBoundaryTests(unittest.TestCase):
+    def make_fixture(self, root: Path) -> tuple[Path, list[tuple[str, Path]]]:
+        submission = root / "submissions" / "alice" / "sample"
+        figure = submission / "assets" / "figures" / "site-overview.png"
+        figure.parent.mkdir(parents=True)
+        proposal = submission / "proposal.md"
+        proposal.write_text(
+            '---\ntitle: "Sample"\nsummary: "Sample published exhibit"\n'
+            'author_github: "alice"\n---\n# Sample\n',
+            encoding="utf-8",
+        )
+        figure.write_bytes(b"fixture image")
+        self_check = submission / "self_check.json"
+        self_check.write_text('{"checks": []}\n', encoding="utf-8")
+        evidence = submission / "evidence.json"
+        evidence.write_text('{"status": "reviewed"}\n', encoding="utf-8")
+        manifest = {
+            "files": [
+                {
+                    "path": "proposal.md",
+                    "sha256": hashlib.sha256(proposal.read_bytes()).hexdigest(),
+                },
+                {
+                    "path": "assets/figures/site-overview.png",
+                    "sha256": hashlib.sha256(figure.read_bytes()).hexdigest(),
+                },
+                {
+                    "path": "self_check.json",
+                    "sha256": hashlib.sha256(self_check.read_bytes()).hexdigest(),
+                },
+                {
+                    "path": "evidence.json",
+                    "sha256": hashlib.sha256(evidence.read_bytes()).hexdigest(),
+                },
+            ]
+        }
+        manifest_path = submission / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        sys.path.insert(0, str(ROOT / "scripts"))
+        from generate_submissions_data import package_sha256
+
+        registry = root / "gallery-publication.json"
+        registry.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "entries": [
+                        {
+                            "path": "submissions/alice/sample",
+                            "published": True,
+                            "featured": False,
+                            "review_status": "approved_for_publication",
+                            "quality_tier": "qualified",
+                            "reviewed_by": "maintainer",
+                            "reviewed_at": "2026-08-12",
+                            "rights_reviewed": True,
+                            "reviewed_package_sha256": package_sha256(submission),
+                            "selection_reason_zh": "通过内容与版权审核。",
+                            "selection_reason_en": "Approved after content and rights review.",
+                            "selected_at": "2026-08-12",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        return submission, [
+            ("proposal", proposal),
+            ("self-check", self_check),
+            ("manifest", manifest_path),
+            ("publication registry", registry),
+            ("proposal figure", figure),
+            ("reviewed package artifact", evidence),
+        ]
+
+    def run_generator(
+        self, root: Path, submission: Path, output: Path
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                str(submission),
+                "--repo-root",
+                str(root),
+                "--output",
+                str(output),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_output_cannot_overwrite_generation_inputs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission, inputs = self.make_fixture(root)
+
+            for label, input_path in inputs:
+                with self.subTest(label=label):
+                    original = input_path.read_bytes()
+                    result = self.run_generator(root, submission, input_path)
+
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(f"output must not overwrite the {label} input", result.stderr)
+                    self.assertEqual(input_path.read_bytes(), original)
+
+    def test_distinct_output_is_written(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission, _inputs = self.make_fixture(root)
+            output = root / "generated" / "exhibit.json"
+
+            result = self.run_generator(root, submission, output)
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(json.loads(output.read_text(encoding="utf-8"))["version"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_generate_exhibit_output_boundary.py
+++ b/tests/test_generate_exhibit_output_boundary.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -14,14 +15,16 @@ SCRIPT = ROOT / "scripts" / "generate_exhibit.py"
 
 
 class GenerateExhibitOutputBoundaryTests(unittest.TestCase):
-    def make_fixture(self, root: Path) -> tuple[Path, list[tuple[str, Path]]]:
-        submission = root / "submissions" / "alice" / "sample"
+    def make_submission(
+        self, root: Path, author: str, slug: str
+    ) -> tuple[Path, dict[str, Path]]:
+        submission = root / "submissions" / author / slug
         figure = submission / "assets" / "figures" / "site-overview.png"
         figure.parent.mkdir(parents=True)
         proposal = submission / "proposal.md"
         proposal.write_text(
-            '---\ntitle: "Sample"\nsummary: "Sample published exhibit"\n'
-            'author_github: "alice"\n---\n# Sample\n',
+            f'---\ntitle: "{slug}"\nsummary: "Sample published exhibit"\n'
+            f'author_github: "{author}"\n---\n# Sample\n',
             encoding="utf-8",
         )
         figure.write_bytes(b"fixture image")
@@ -51,6 +54,19 @@ class GenerateExhibitOutputBoundaryTests(unittest.TestCase):
         }
         manifest_path = submission / "manifest.json"
         manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        return submission, {
+            "proposal": proposal,
+            "self-check": self_check,
+            "manifest": manifest_path,
+            "proposal figure": figure,
+            "reviewed package artifact": evidence,
+        }
+
+    def make_fixture(
+        self, root: Path
+    ) -> tuple[Path, list[tuple[str, Path]], dict[str, Path]]:
+        submission, own_files = self.make_submission(root, "alice", "sample")
+        other_submission, other_files = self.make_submission(root, "bob", "other")
 
         sys.path.insert(0, str(ROOT / "scripts"))
         from generate_submissions_data import package_sha256
@@ -74,6 +90,20 @@ class GenerateExhibitOutputBoundaryTests(unittest.TestCase):
                             "selection_reason_zh": "通过内容与版权审核。",
                             "selection_reason_en": "Approved after content and rights review.",
                             "selected_at": "2026-08-12",
+                        },
+                        {
+                            "path": "submissions/bob/other",
+                            "published": True,
+                            "featured": False,
+                            "review_status": "approved_for_publication",
+                            "quality_tier": "qualified",
+                            "reviewed_by": "maintainer",
+                            "reviewed_at": "2026-08-12",
+                            "rights_reviewed": True,
+                            "reviewed_package_sha256": package_sha256(other_submission),
+                            "selection_reason_zh": "通过内容与版权审核。",
+                            "selection_reason_en": "Approved after content and rights review.",
+                            "selected_at": "2026-08-12",
                         }
                     ],
                 }
@@ -81,27 +111,28 @@ class GenerateExhibitOutputBoundaryTests(unittest.TestCase):
             encoding="utf-8",
         )
         return submission, [
-            ("proposal", proposal),
-            ("self-check", self_check),
-            ("manifest", manifest_path),
+            ("proposal", own_files["proposal"]),
+            ("self-check", own_files["self-check"]),
+            ("manifest", own_files["manifest"]),
             ("publication registry", registry),
-            ("proposal figure", figure),
-            ("reviewed package artifact", evidence),
-        ]
+            ("proposal figure", own_files["proposal figure"]),
+            ("reviewed package artifact", own_files["reviewed package artifact"]),
+        ], other_files
 
     def run_generator(
-        self, root: Path, submission: Path, output: Path
+        self, root: Path, submission: Path, output: Path | None = None
     ) -> subprocess.CompletedProcess[str]:
+        command = [
+            sys.executable,
+            str(SCRIPT),
+            str(submission),
+            "--repo-root",
+            str(root),
+        ]
+        if output is not None:
+            command.extend(["--output", str(output)])
         return subprocess.run(
-            [
-                sys.executable,
-                str(SCRIPT),
-                str(submission),
-                "--repo-root",
-                str(root),
-                "--output",
-                str(output),
-            ],
+            command,
             cwd=ROOT,
             capture_output=True,
             text=True,
@@ -111,7 +142,7 @@ class GenerateExhibitOutputBoundaryTests(unittest.TestCase):
     def test_output_cannot_overwrite_generation_inputs(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            submission, inputs = self.make_fixture(root)
+            submission, inputs, _other_files = self.make_fixture(root)
 
             for label, input_path in inputs:
                 with self.subTest(label=label):
@@ -122,10 +153,63 @@ class GenerateExhibitOutputBoundaryTests(unittest.TestCase):
                     self.assertIn(f"output must not overwrite the {label} input", result.stderr)
                     self.assertEqual(input_path.read_bytes(), original)
 
+    def test_output_cannot_overwrite_another_published_package(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission, _inputs, other_files = self.make_fixture(root)
+
+            for label in (
+                "proposal",
+                "manifest",
+                "reviewed package artifact",
+                "proposal figure",
+            ):
+                with self.subTest(label=label):
+                    target = other_files[label]
+                    original = target.read_bytes()
+                    result = self.run_generator(root, submission, target)
+
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(
+                        "output must not overwrite an existing file inside submissions/",
+                        result.stderr,
+                    )
+                    self.assertEqual(target.read_bytes(), original)
+
+    def test_output_cannot_overwrite_input_through_hardlink(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission, inputs, _other_files = self.make_fixture(root)
+            proposal = dict(inputs)["proposal"]
+            alias = root / "proposal-alias.md"
+            os.link(proposal, alias)
+            original = proposal.read_bytes()
+
+            result = self.run_generator(root, submission, alias)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("output must not overwrite the proposal input", result.stderr)
+            self.assertEqual(proposal.read_bytes(), original)
+
+    def test_default_output_can_be_regenerated(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission, _inputs, _other_files = self.make_fixture(root)
+
+            first = self.run_generator(root, submission)
+            second = self.run_generator(root, submission)
+
+            self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+            self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+            self.assertEqual(
+                json.loads((submission / "exhibit.json").read_text(encoding="utf-8"))["version"],
+                1,
+            )
+
     def test_distinct_output_is_written(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            submission, _inputs = self.make_fixture(root)
+            submission, _inputs, _other_files = self.make_fixture(root)
             output = root / "generated" / "exhibit.json"
 
             result = self.run_generator(root, submission, output)


### PR DESCRIPTION
## Summary

- reject exhibit output paths that alias inputs used to build or approve the exhibit
- protect selected-package inputs with resolved-path and same-file checks
- allow only the selected package's lexical default exhibit.json or paths fully outside submissions/
- reject existing and new cross-package paths plus lexical symlink escapes
- write through a flushed and fsynced same-directory temporary file followed by os.replace, so allowed hardlink or symlink outputs are detached without truncating their previous target
- preserve the output mode when replacing an existing file

## Reproduction

On main, generate_exhibit.py SUBMISSION --output SUBMISSION/proposal.md completes with exit code 0 and replaces the proposal source with generated exhibit JSON. The same overwrite is possible for the publication registry, manifest-declared reviewed artifacts, and inputs in every published package read by load_publication_registry().

The previous PR head closed direct and resolved-path aliases but left two combined cases:

- an output outside submissions/ hardlinked to another published package's proposal, manifest, evidence, self-check, or figure was truncated through the shared inode
- the selected package's default exhibit.json could be pre-created as a symlink or hardlink to another package's input, causing the default-output exemption to overwrite that victim

The previous head also allowed creating new outputs inside another package and allowed a lexically in-submissions dangling symlink to create its target outside the repository.

## Implementation

Output policy checks both a lexical absolute path and its resolved path. A non-default output is rejected when either path is under submissions/. The default exemption is based only on the selected package's lexical exhibit.json path, so resolving an alias cannot widen the exemption.

Writes use a temporary file in the output directory, preserve the output mode when replacing an existing path, flush and fsync the file, then call os.replace. Replacing the output directory entry detaches hardlink and symlink aliases while leaving their prior targets unchanged.

## Validation

Rebased onto main at 233853bfdfdd7309f1f6e8de616a94c052f89235.

- isolated review environment installed from requirements-review.txt
- python -m unittest tests.test_generate_exhibit_output_boundary tests.test_agent_scaffold_and_self_check (43 passed)
- python -m py_compile scripts/generate_exhibit.py tests/test_generate_exhibit_output_boundary.py
- git diff --check upstream/main...HEAD
- current real publication registry loads successfully with 0 entries
- a real unapproved submission is rejected with exit code 1 and creates no external output

The focused suite now has 10 test methods. Every destructive subtest builds a fresh fixture, so a main-side overwrite cannot turn later assertions into stale-digest cascade failures. Coverage includes direct selected-package inputs, the exhibit schema, existing cross-package files, selected/cross symlinks, selected-package hardlinks, external hardlinks to five cross-package input classes, default-output symlink and hardlink aliases, cross-package new exhibit/figure/report paths, dangling symlink escape, default regeneration, external output, and mode preservation.

The repository's existing generate_submissions_data.py --check still reports submissions-data.js as out of date; this branch does not modify that generated file or its generator.
