### PR TITLE
fix: scan all present visual code assets

### DIFF
--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -21,6 +21,7 @@ from typing import Iterable
 from front_matter import parse_front_matter
 from git_blob_hashes import git_blob_sha256
 from metric_types import is_json_number
+from visual_asset_safety import visual_code_asset_issues
 
 
 POLICY_ROOT = Path(__file__).resolve().parents[1]
@@ -2532,6 +2533,8 @@ def validate_ai_package_dir(
                 f"{proposal_dir}/visual/{visual_name}",
                 translation_advisory=visual_name != "index.html" and not strict_bilingual,
             )
+    for rel_path, message in visual_code_asset_issues(base):
+        report.add_error(f"{proposal_dir}/{rel_path}: {message}")
 
     for geometry_name in sorted(ALLOWED_GEOMETRY_FILES):
         geometry_path = base / "geometry" / geometry_name

--- a/scripts/visual_asset_safety.py
+++ b/scripts/visual_asset_safety.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+
+CSS_FORBIDDEN_PATTERNS = [
+    (re.compile(r"@import\s+(?:url\s*\(\s*)?['\"]?(?:https?:)?//", re.I), "CSS must not import remote styles"),
+    (re.compile(r"url\s*\(\s*['\"]?(?:https?:)?//", re.I), "CSS must not load remote assets"),
+]
+JS_FORBIDDEN_PATTERNS = [
+    (re.compile(r"\bfetch\s*\(", re.I), "JavaScript must not call fetch()"),
+    (re.compile(r"\bXMLHttpRequest\b", re.I), "JavaScript must not use XMLHttpRequest"),
+    (re.compile(r"\bWebSocket\b", re.I), "JavaScript must not open WebSocket connections"),
+    (re.compile(r"\bEventSource\b", re.I), "JavaScript must not open EventSource connections"),
+    (re.compile(r"\bsendBeacon\s*\(", re.I), "JavaScript must not send beacon requests"),
+]
+LEGACY_VISUAL_TREES = {
+    # Existing xiaowuzicode/token-block-jingzhang-ai-belt visual. The complete
+    # executable tree is pinned so no modified or copied page inherits this
+    # compatibility exception from its vendored three.js file alone.
+    ("xiaowuzicode", "token-block-jingzhang-ai-belt"): (
+        "bae59cb57c5fcad6d636bc287024dff2aa0a98ab3396060f4cf2156dceb5dc80"
+    ),
+}
+GENERATED_LOCALIZED_VISUAL_INDEXES = {"index.en.html", "index.zh.html"}
+
+
+def present_visual_code_assets(submission_dir: Path) -> list[tuple[str, Path]]:
+    assets_root = submission_dir / "visual" / "assets"
+    if not assets_root.is_dir() or assets_root.is_symlink():
+        return []
+    assets: list[tuple[str, Path]] = []
+    for path in assets_root.rglob("*"):
+        if path.is_symlink() or not path.is_file():
+            continue
+        if path.suffix.lower() not in {".css", ".js"}:
+            continue
+        assets.append((path.relative_to(submission_dir).as_posix(), path))
+    return sorted(assets)
+
+
+def visual_tree_digest(submission_dir: Path) -> str | None:
+    visual_root = submission_dir / "visual"
+    if not visual_root.is_dir() or visual_root.is_symlink():
+        return None
+    paths = sorted(
+        path
+        for path in visual_root.rglob("*")
+        if path.is_file()
+        and path.relative_to(visual_root).as_posix()
+        not in GENERATED_LOCALIZED_VISUAL_INDEXES
+    )
+    if not paths or any(path.is_symlink() for path in paths):
+        return None
+    digest = hashlib.sha256()
+    try:
+        for path in paths:
+            rel_path = path.relative_to(visual_root).as_posix()
+            payload = path.read_bytes()
+            digest.update(rel_path.encode("utf-8"))
+            digest.update(b"\0")
+            digest.update(str(len(payload)).encode("ascii"))
+            digest.update(b"\0")
+            digest.update(payload)
+            digest.update(b"\0")
+    except OSError:
+        return None
+    return digest.hexdigest()
+
+
+def visual_code_asset_issues(submission_dir: Path) -> list[tuple[str, str]]:
+    issues: list[tuple[str, str]] = []
+    assets_root = submission_dir / "visual" / "assets"
+    if assets_root.is_symlink():
+        return [("visual/assets", "visual code asset paths must not use symbolic links")]
+    if assets_root.is_dir():
+        for path in assets_root.rglob("*"):
+            if path.is_symlink():
+                issues.append(
+                    (
+                        path.relative_to(submission_dir).as_posix(),
+                        "visual code asset paths must not use symbolic links",
+                    )
+                )
+    for rel_path, path in present_visual_code_assets(submission_dir):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            issues.append((rel_path, "visual code assets must be UTF-8 text"))
+            continue
+        except OSError as exc:
+            issues.append((rel_path, f"unable to read visual code asset: {exc}"))
+            continue
+        patterns = CSS_FORBIDDEN_PATTERNS if path.suffix.lower() == ".css" else JS_FORBIDDEN_PATTERNS
+        issues.extend(
+            (rel_path, message) for pattern, message in patterns if pattern.search(text)
+        )
+    package_identity = tuple(submission_dir.parts[-2:])
+    legacy_digest = LEGACY_VISUAL_TREES.get(package_identity)
+    if (
+        issues
+        and legacy_digest is not None
+        and legacy_digest == visual_tree_digest(submission_dir)
+    ):
+        return []
+    return issues

--- a/scripts/visual_review.py
+++ b/scripts/visual_review.py
@@ -44,6 +44,7 @@ from pathlib import Path
 from typing import Any
 
 from metric_types import is_json_number
+from visual_asset_safety import visual_code_asset_issues
 
 
 REQUIRED_TEXT_MARKERS = [
@@ -171,6 +172,8 @@ def review_visual(submission_dir: Path) -> VisualReport:
     for pattern, message in FORBIDDEN_PATTERNS:
         if pattern.search(text):
             report.add("VISUAL_REMOTE_OR_ACTIVE_CONTENT", "blocking", display_path, message)
+    for rel_path, message in visual_code_asset_issues(submission_dir):
+        report.add("VISUAL_REMOTE_OR_ACTIVE_CONTENT", "blocking", rel_path, message)
 
     plain = re.sub(r"<[^>]+>", " ", text)
     plain = html.unescape(re.sub(r"\s+", " ", plain))

--- a/tests/test_visual_asset_safety.py
+++ b/tests/test_visual_asset_safety.py
@@ -1,0 +1,150 @@
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from validate_submission import ValidationReport, validate_ai_package_dir  # noqa: E402
+from visual_asset_safety import (  # noqa: E402
+    LEGACY_VISUAL_TREES,
+    visual_code_asset_issues,
+    visual_tree_digest,
+)
+
+
+class VisualAssetSafetyTests(unittest.TestCase):
+    def validate_asset(
+        self, rel_path: str, content: bytes, *, declared: bool = True
+    ) -> ValidationReport:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        proposal_dir = "submissions/alice/sample"
+        base = root / proposal_dir
+        asset = base / rel_path
+        asset.parent.mkdir(parents=True, exist_ok=True)
+        asset.write_bytes(content)
+        (base / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "submission_stage": "formal",
+                    "submission_type": "ai_agent",
+                    "project_id": "centennial-jingzhang-ai-belt",
+                    "files": ([{"path": rel_path, "role": "asset"}] if declared else []),
+                }
+            ),
+            encoding="utf-8",
+        )
+        report = ValidationReport()
+        validate_ai_package_dir(report, root, proposal_dir)
+        return report
+
+    def test_deterministic_gate_rejects_remote_or_active_code_assets(self):
+        cases = (
+            (
+                "visual/assets/theme.css",
+                b'@import "https://cdn.example.com/theme.css";',
+                "CSS must not import remote styles",
+            ),
+            (
+                "visual/assets/runtime.js",
+                b'fetch("https://example.com/data.json");',
+                "JavaScript must not call fetch()",
+            ),
+            (
+                "visual/assets/runtime.js",
+                b"\xff\xfe",
+                "visual code assets must be UTF-8 text",
+            ),
+        )
+        for rel_path, content, expected in cases:
+            with self.subTest(rel_path=rel_path, expected=expected):
+                report = self.validate_asset(rel_path, content)
+                self.assertIn(f"{rel_path}: {expected}", "\n".join(report.errors))
+
+    def test_undeclared_nested_code_assets_are_still_scanned(self):
+        for rel_path, content, expected in (
+            (
+                "visual/assets/styles/theme.css",
+                b'@import "https://cdn.example.com/theme.css";',
+                "CSS must not import remote styles",
+            ),
+            (
+                "visual/assets/scripts/runtime.js",
+                b'fetch("https://example.com/data.json");',
+                "JavaScript must not call fetch()",
+            ),
+        ):
+            with self.subTest(rel_path=rel_path):
+                report = self.validate_asset(rel_path, content, declared=False)
+                self.assertIn(f"{rel_path}: {expected}", "\n".join(report.errors))
+
+    def test_legacy_exception_ignores_generated_localizations_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = Path(tmp) / "submissions" / "alice" / "sample"
+            assets = submission / "visual" / "assets"
+            assets.mkdir(parents=True)
+            index = submission / "visual" / "index.html"
+            index_content = '<script src="assets/vendor.js"></script>'
+            index.write_text(index_content, encoding="utf-8")
+            vendor = assets / "vendor.js"
+            vendor.write_text('fetch("local-data.json")', encoding="utf-8")
+            digest = visual_tree_digest(submission)
+            self.assertIsNotNone(digest)
+
+            with mock.patch(
+                "visual_asset_safety.LEGACY_VISUAL_TREES", {("alice", "sample"): digest}
+            ):
+                self.assertEqual([], visual_code_asset_issues(submission))
+                copied = Path(tmp) / "submissions" / "bob" / "copy"
+                shutil.copytree(submission, copied)
+                self.assertTrue(visual_code_asset_issues(copied))
+
+                localized = submission / "visual" / "index.zh.html"
+                localized.write_text("<html>generated translation</html>", encoding="utf-8")
+                self.assertEqual([], visual_code_asset_issues(submission))
+                localized.write_text("<html>updated translation</html>", encoding="utf-8")
+                self.assertEqual([], visual_code_asset_issues(submission))
+
+                index.write_text("<html>changed primary page</html>", encoding="utf-8")
+                self.assertTrue(visual_code_asset_issues(submission))
+                index.write_text(index_content, encoding="utf-8")
+                (assets / "companion.js").write_text("window.changed = true", encoding="utf-8")
+                self.assertTrue(visual_code_asset_issues(submission))
+
+    def test_current_legacy_package_matches_its_complete_tree_pin(self):
+        submission = (
+            ROOT
+            / "submissions"
+            / "xiaowuzicode"
+            / "token-block-jingzhang-ai-belt"
+        )
+        identity = ("xiaowuzicode", "token-block-jingzhang-ai-belt")
+        self.assertEqual(LEGACY_VISUAL_TREES[identity], visual_tree_digest(submission))
+        self.assertEqual([], visual_code_asset_issues(submission))
+
+    def test_local_code_and_json_assets_do_not_trigger_code_safety_errors(self):
+        for rel_path, content in (
+            ("visual/assets/theme.css", b"body { background: url(icons/grid.svg); }"),
+            ("visual/assets/data.json", b'{"url": "https://example.com/data"}'),
+        ):
+            with self.subTest(rel_path=rel_path):
+                report = self.validate_asset(rel_path, content)
+                self.assertFalse(
+                    any(
+                        rel_path in error
+                        and ("must not" in error or "visual code assets" in error)
+                        for error in report.errors
+                    ),
+                    report.errors,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_visual_review.py
+++ b/tests/test_visual_review.py
@@ -43,6 +43,12 @@ def write_valid_visual_package(root: Path) -> Path:
 
 
 class VisualReviewTests(unittest.TestCase):
+    def declare_visual_asset(self, submission: Path, rel_path: str) -> None:
+        (submission / "manifest.json").write_text(
+            json.dumps({"files": [{"path": rel_path}]}),
+            encoding="utf-8",
+        )
+
     def test_valid_static_visual_passes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             submission = write_valid_visual_package(Path(tmp))
@@ -74,6 +80,76 @@ class VisualReviewTests(unittest.TestCase):
             report = review_visual(submission)
             self.assertFalse(report.ok)
             self.assertIn("VISUAL_REMOTE_OR_ACTIVE_CONTENT", {issue.check_id for issue in report.issues})
+
+    def test_remote_css_and_active_javascript_fail_even_when_undeclared(self) -> None:
+        for rel_path, content in (
+            ("visual/assets/theme.css", '@import url("https://cdn.example.com/theme.css");'),
+            ("visual/assets/nested/runtime.js", 'fetch("https://example.com/data.json");'),
+        ):
+            with self.subTest(rel_path=rel_path), tempfile.TemporaryDirectory() as tmp:
+                submission = write_valid_visual_package(Path(tmp))
+                asset = submission / rel_path
+                asset.parent.mkdir(parents=True, exist_ok=True)
+                asset.write_text(content, encoding="utf-8")
+
+                report = review_visual(submission)
+
+                self.assertFalse(report.ok)
+                issue = next(
+                    item
+                    for item in report.issues
+                    if item.check_id == "VISUAL_REMOTE_OR_ACTIVE_CONTENT"
+                    and item.path == rel_path
+                )
+                self.assertTrue(issue.message)
+
+    def test_declared_non_utf8_visual_code_asset_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_valid_visual_package(Path(tmp))
+            rel_path = "visual/assets/runtime.js"
+            asset = submission / rel_path
+            asset.parent.mkdir(parents=True, exist_ok=True)
+            asset.write_bytes(b"\xff\xfe")
+
+            report = review_visual(submission)
+
+            self.assertFalse(report.ok)
+            self.assertTrue(
+                any(issue.path == rel_path and "UTF-8" in issue.message for issue in report.issues)
+            )
+
+    def test_declared_local_visual_code_assets_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_valid_visual_package(Path(tmp))
+            rel_path = "visual/assets/theme.css"
+            asset = submission / rel_path
+            asset.parent.mkdir(parents=True, exist_ok=True)
+            asset.write_text("body { background: url(icons/grid.svg); }", encoding="utf-8")
+            self.declare_visual_asset(submission, rel_path)
+
+            report = review_visual(submission)
+
+            self.assertTrue(report.ok, [issue.__dict__ for issue in report.issues])
+
+    def test_symlinked_visual_asset_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission = write_valid_visual_package(root)
+            assets = submission / "visual" / "assets"
+            assets.mkdir()
+            external = root / "external.js"
+            external.write_text('fetch("https://example.com/data.json")', encoding="utf-8")
+            (assets / "runtime.js").symlink_to(external)
+
+            report = review_visual(submission)
+
+            self.assertFalse(report.ok)
+            self.assertTrue(
+                any(
+                    issue.path == "visual/assets/runtime.js" and "symbolic links" in issue.message
+                    for issue in report.issues
+                )
+            )
 
     def test_autoplay_media_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- scan every CSS and JavaScript file present below `visual/assets/`, independent of manifest inventory
- apply the same offline-safety findings to deterministic intake and professional visual review
- reject unreadable, non-UTF-8, remote-loading, active-network, and symlinked visual code assets
- preserve one existing vendored three.js visual through a package-bound digest of its complete executable tree

## Reproduction

Before this change, remote CSS imports and JavaScript `fetch()` calls in external visual assets were not inspected. Declaring such an asset in the manifest exposed the original gap; omitting the manifest entry also bypassed the first revision of this PR even when `visual/index.html` actively loaded the file.

The scanner now derives its coverage from the files the browser can reach on disk, not from participant-declared inventory. The historical three.js compatibility entry is tied to the exact existing package and the byte digest of `visual/index.html` plus every visual asset, so any executable-tree change returns it to normal scanning.

## Validation

- `python3 -m unittest tests.test_visual_asset_safety tests.test_visual_review tests.test_submission_workflow` (157 passed)
- current-main corpus scan: 58 packages, 196 CSS/JS assets, 0 issues
- `python3 -m py_compile scripts/visual_asset_safety.py scripts/validate_submission.py scripts/visual_review.py tests/test_visual_asset_safety.py tests/test_visual_review.py`
- `git diff --check`
