### PR TITLE
fix: keep peer cache out of submissions

### DIFF
--- a/scripts/read_peer_proposals.py
+++ b/scripts/read_peer_proposals.py
@@ -82,6 +82,7 @@ FIGURE_FILES = (
 DRAWING_FILES = ("drawings/a3-booklet.pdf", "drawings/a0-boards.pdf")
 VISUAL_FILES = ("report/proposal.html", "visual/index.html")
 USER_AGENT = "open-city-haidian-peer-reader/1.0"
+SCRIPT_REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 class PeerReaderError(RuntimeError):
@@ -238,11 +239,12 @@ def item_summary(item: dict[str, Any]) -> dict[str, Any]:
 def download_bundle(item: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
     base = proposal_base(item)
     output = Path(args.output_dir).expanduser().resolve() / proposal_key(item)
-    submissions_root = (Path(args.repo_root).expanduser().resolve() / "submissions").resolve()
-    if output.resolve().is_relative_to(submissions_root):
-        raise PeerReaderError(
-            f"peer download cache must stay outside the submissions tree: {output}"
-        )
+    roots = {Path(args.repo_root).expanduser().resolve(), SCRIPT_REPO_ROOT.resolve()}
+    for root in roots:
+        if output.resolve().is_relative_to((root / "submissions").resolve()):
+            raise PeerReaderError(
+                f"peer download cache must stay outside the submissions tree: {output}"
+            )
     output.mkdir(parents=True, exist_ok=True)
     files = list(DEFAULT_TEXT_FILES)
     if args.full_text:

--- a/scripts/read_peer_proposals.py
+++ b/scripts/read_peer_proposals.py
@@ -238,6 +238,11 @@ def item_summary(item: dict[str, Any]) -> dict[str, Any]:
 def download_bundle(item: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
     base = proposal_base(item)
     output = Path(args.output_dir).expanduser().resolve() / proposal_key(item)
+    submissions_root = (Path(args.repo_root).expanduser().resolve() / "submissions").resolve()
+    if output.resolve().is_relative_to(submissions_root):
+        raise PeerReaderError(
+            f"peer download cache must stay outside the submissions tree: {output}"
+        )
     output.mkdir(parents=True, exist_ok=True)
     files = list(DEFAULT_TEXT_FILES)
     if args.full_text:

--- a/scripts/read_peer_proposals.py
+++ b/scripts/read_peer_proposals.py
@@ -236,15 +236,38 @@ def item_summary(item: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def validate_cache_path(path: Path, roots: set[Path]) -> Path:
+    resolved = path.resolve()
+    submissions_roots = {(root / "submissions").resolve() for root in roots}
+    if "submissions" in resolved.parts or any(
+        resolved.is_relative_to(submissions_root) for submissions_root in submissions_roots
+    ):
+        raise PeerReaderError(
+            f"peer download cache must stay outside the submissions tree: {path}"
+        )
+    return resolved
+
+
+def validate_cache_target(target: Path, roots: set[Path]) -> None:
+    if target.is_symlink():
+        raise PeerReaderError(f"peer download cache target must not be a symlink: {target}")
+    validate_cache_path(target, roots)
+    try:
+        target_stat = target.lstat()
+    except FileNotFoundError:
+        return
+    if target_stat.st_nlink > 1:
+        raise PeerReaderError(
+            f"peer download cache target must not have multiple hard links: {target}"
+        )
+
+
 def download_bundle(item: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
     base = proposal_base(item)
-    output = Path(args.output_dir).expanduser().resolve() / proposal_key(item)
     roots = {Path(args.repo_root).expanduser().resolve(), SCRIPT_REPO_ROOT.resolve()}
-    for root in roots:
-        if output.resolve().is_relative_to((root / "submissions").resolve()):
-            raise PeerReaderError(
-                f"peer download cache must stay outside the submissions tree: {output}"
-            )
+    output = validate_cache_path(
+        Path(args.output_dir).expanduser().resolve() / proposal_key(item), roots
+    )
     output.mkdir(parents=True, exist_ok=True)
     files = list(DEFAULT_TEXT_FILES)
     if args.full_text:
@@ -256,9 +279,14 @@ def download_bundle(item: dict[str, Any], args: argparse.Namespace) -> dict[str,
     if args.include_drawings:
         files.extend(DRAWING_FILES)
 
+    targets = {rel: output / rel for rel in dict.fromkeys(files)}
+    metadata_target = output / "peer-metadata.json"
+    for target in (*targets.values(), metadata_target):
+        validate_cache_target(target, roots)
+
     downloaded: list[dict[str, Any]] = []
     skipped: list[str] = []
-    for rel in dict.fromkeys(files):
+    for rel, target in targets.items():
         repo_path = safe_repo_path(f"{base}/{rel}")
         url = f"{RAW_ROOT}/{repo_path}"
         try:
@@ -268,14 +296,15 @@ def download_bundle(item: dict[str, Any], args: argparse.Namespace) -> dict[str,
                 skipped.append(rel)
                 continue
             raise PeerReaderError(f"failed to download {url}: HTTP {exc.code}") from exc
-        target = output / rel
         target.parent.mkdir(parents=True, exist_ok=True)
+        validate_cache_target(target, roots)
         target.write_bytes(content)
         downloaded.append({"path": rel, "bytes": len(content), "source_url": url})
 
     metadata = item_summary(item)
     metadata.update({"downloaded": downloaded, "optional_missing": skipped})
-    (output / "peer-metadata.json").write_text(
+    validate_cache_target(metadata_target, roots)
+    metadata_target.write_text(
         json.dumps(metadata, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
     )
     return {"ok": True, "output_dir": str(output), **metadata}

--- a/tests/test_read_peer_output_boundary.py
+++ b/tests/test_read_peer_output_boundary.py
@@ -1,0 +1,88 @@
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from read_peer_proposals import PeerReaderError, download_bundle  # noqa: E402
+
+
+ITEM = {
+    "id": "alice/sample",
+    "sourceUrl": "submissions/alice/sample/proposal.md",
+    "proposalUrl": "proposal-view.html?id=alice%2Fsample",
+    "visualUrl": "submissions/alice/sample/visual/index.html",
+}
+
+
+def args(repo_root: Path, output_dir: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        repo_root=str(repo_root),
+        output_dir=str(output_dir),
+        max_file_mb=1,
+        full_text=False,
+        include_figures=False,
+        include_visual=False,
+        include_drawings=False,
+    )
+
+
+class ReadPeerOutputBoundaryTests(unittest.TestCase):
+    def test_cache_cannot_write_into_submissions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            submissions = root / "submissions"
+            existing = submissions / "alice" / "sample" / "proposal.md"
+            existing.parent.mkdir(parents=True)
+            existing.write_text("original proposal\n", encoding="utf-8")
+
+            with mock.patch("read_peer_proposals.fetch_bytes") as fetch:
+                with self.assertRaisesRegex(
+                    PeerReaderError, "peer download cache must stay outside"
+                ):
+                    download_bundle(ITEM, args(root, submissions))
+
+            fetch.assert_not_called()
+            self.assertEqual(existing.read_text(encoding="utf-8"), "original proposal\n")
+
+    def test_symlink_alias_to_submissions_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            submissions = root / "submissions"
+            submissions.mkdir(parents=True)
+            alias = Path(tmp) / "peer-cache"
+            alias.symlink_to(submissions, target_is_directory=True)
+
+            with mock.patch("read_peer_proposals.fetch_bytes") as fetch:
+                with self.assertRaisesRegex(
+                    PeerReaderError, "peer download cache must stay outside"
+                ):
+                    download_bundle(ITEM, args(root, alias))
+
+            fetch.assert_not_called()
+
+    def test_distinct_cache_directory_remains_supported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            cache = root / ".peer-proposals"
+
+            with mock.patch(
+                "read_peer_proposals.fetch_bytes", return_value=b"peer content\n"
+            ):
+                result = download_bundle(ITEM, args(root, cache))
+
+            output = cache / "alice" / "sample"
+            self.assertTrue(result["ok"])
+            self.assertEqual((output / "proposal.md").read_bytes(), b"peer content\n")
+            self.assertTrue((output / "peer-metadata.json").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_read_peer_output_boundary.py
+++ b/tests/test_read_peer_output_boundary.py
@@ -42,7 +42,9 @@ class ReadPeerOutputBoundaryTests(unittest.TestCase):
             existing.parent.mkdir(parents=True)
             existing.write_text("original proposal\n", encoding="utf-8")
 
-            with mock.patch("read_peer_proposals.fetch_bytes") as fetch:
+            with mock.patch(
+                "read_peer_proposals.fetch_bytes", return_value=b"peer content\n"
+            ) as fetch:
                 with self.assertRaisesRegex(
                     PeerReaderError, "peer download cache must stay outside"
                 ):
@@ -59,13 +61,55 @@ class ReadPeerOutputBoundaryTests(unittest.TestCase):
             alias = Path(tmp) / "peer-cache"
             alias.symlink_to(submissions, target_is_directory=True)
 
-            with mock.patch("read_peer_proposals.fetch_bytes") as fetch:
+            with mock.patch(
+                "read_peer_proposals.fetch_bytes", return_value=b"peer content\n"
+            ) as fetch:
                 with self.assertRaisesRegex(
                     PeerReaderError, "peer download cache must stay outside"
                 ):
                     download_bundle(ITEM, args(root, alias))
 
             fetch.assert_not_called()
+
+    def test_script_repository_is_protected_when_index_root_is_elsewhere(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            script_root = directory / "repo"
+            submissions = script_root / "submissions"
+            existing = submissions / "alice" / "sample" / "proposal.md"
+            existing.parent.mkdir(parents=True)
+            existing.write_text("original proposal\n", encoding="utf-8")
+            index_root = directory / "index-cache"
+            index_root.mkdir()
+
+            with mock.patch("read_peer_proposals.SCRIPT_REPO_ROOT", script_root), mock.patch(
+                "read_peer_proposals.fetch_bytes", return_value=b"peer content\n"
+            ) as fetch:
+                with self.assertRaisesRegex(
+                    PeerReaderError, "peer download cache must stay outside"
+                ):
+                    download_bundle(ITEM, args(index_root, submissions))
+
+            fetch.assert_not_called()
+            self.assertEqual(existing.read_text(encoding="utf-8"), "original proposal\n")
+
+    def test_running_inside_submission_still_protects_script_repository(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            script_root = Path(tmp) / "repo"
+            own_package = script_root / "submissions" / "me" / "own-package"
+            own_package.mkdir(parents=True)
+            (own_package / "proposal.md").write_text("own proposal\n", encoding="utf-8")
+
+            with mock.patch("read_peer_proposals.SCRIPT_REPO_ROOT", script_root), mock.patch(
+                "read_peer_proposals.fetch_bytes", return_value=b"peer content\n"
+            ) as fetch:
+                with self.assertRaisesRegex(
+                    PeerReaderError, "peer download cache must stay outside"
+                ):
+                    download_bundle(ITEM, args(own_package, own_package))
+
+            fetch.assert_not_called()
+            self.assertFalse((own_package / "alice" / "sample").exists())
 
     def test_distinct_cache_directory_remains_supported(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_read_peer_output_boundary.py
+++ b/tests/test_read_peer_output_boundary.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -71,6 +72,24 @@ class ReadPeerOutputBoundaryTests(unittest.TestCase):
 
             fetch.assert_not_called()
 
+    def test_symlinked_ancestor_of_submissions_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            submissions = root / "submissions"
+            submissions.mkdir(parents=True)
+            root_alias = Path(tmp) / "repo-alias"
+            root_alias.symlink_to(root, target_is_directory=True)
+
+            with mock.patch(
+                "read_peer_proposals.fetch_bytes", return_value=b"peer content\n"
+            ) as fetch:
+                with self.assertRaisesRegex(
+                    PeerReaderError, "peer download cache must stay outside"
+                ):
+                    download_bundle(ITEM, args(root, root_alias / "submissions"))
+
+            fetch.assert_not_called()
+
     def test_script_repository_is_protected_when_index_root_is_elsewhere(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             directory = Path(tmp)
@@ -111,11 +130,107 @@ class ReadPeerOutputBoundaryTests(unittest.TestCase):
             fetch.assert_not_called()
             self.assertFalse((own_package / "alice" / "sample").exists())
 
+    def test_loose_script_still_rejects_a_submissions_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            loose_script_root = directory / "loose-script"
+            index_root = directory / "index-cache"
+            index_root.mkdir()
+            repository = directory / "checkout"
+            existing = repository / "submissions" / "alice" / "sample" / "proposal.md"
+            existing.parent.mkdir(parents=True)
+            existing.write_text("original proposal\n", encoding="utf-8")
+
+            with mock.patch(
+                "read_peer_proposals.SCRIPT_REPO_ROOT", loose_script_root
+            ), mock.patch(
+                "read_peer_proposals.fetch_bytes", return_value=b"peer content\n"
+            ) as fetch:
+                with self.assertRaisesRegex(
+                    PeerReaderError, "peer download cache must stay outside"
+                ):
+                    download_bundle(ITEM, args(index_root, repository / "submissions"))
+
+            fetch.assert_not_called()
+            self.assertEqual(existing.read_text(encoding="utf-8"), "original proposal\n")
+
+    def test_second_checkout_submissions_output_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            first_repository = directory / "checkout-a"
+            first_repository.mkdir()
+            second_repository = directory / "checkout-b"
+            existing = second_repository / "submissions" / "alice" / "sample" / "proposal.md"
+            existing.parent.mkdir(parents=True)
+            existing.write_text("original proposal\n", encoding="utf-8")
+
+            with mock.patch(
+                "read_peer_proposals.SCRIPT_REPO_ROOT", first_repository
+            ), mock.patch(
+                "read_peer_proposals.fetch_bytes", return_value=b"peer content\n"
+            ) as fetch:
+                with self.assertRaisesRegex(
+                    PeerReaderError, "peer download cache must stay outside"
+                ):
+                    download_bundle(
+                        ITEM, args(first_repository, second_repository / "submissions")
+                    )
+
+            fetch.assert_not_called()
+            self.assertEqual(existing.read_text(encoding="utf-8"), "original proposal\n")
+
+    def test_existing_file_symlink_is_rejected_without_touching_victim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            root = directory / "repo"
+            victim = root / "submissions" / "victim" / "proposal.md"
+            victim.parent.mkdir(parents=True)
+            victim.write_text("original proposal\n", encoding="utf-8")
+            cache = directory / "peer-cache"
+            target = cache / "alice" / "sample" / "proposal.md"
+            target.parent.mkdir(parents=True)
+            target.symlink_to(victim)
+
+            with mock.patch(
+                "read_peer_proposals.fetch_bytes", return_value=b"peer content\n"
+            ) as fetch:
+                with self.assertRaisesRegex(PeerReaderError, "must not be a symlink"):
+                    download_bundle(ITEM, args(root, cache))
+
+            fetch.assert_not_called()
+            self.assertTrue(target.is_symlink())
+            self.assertEqual(victim.read_text(encoding="utf-8"), "original proposal\n")
+
+    def test_existing_hardlink_is_rejected_without_touching_victim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            root = directory / "repo"
+            victim = root / "submissions" / "victim" / "proposal.md"
+            victim.parent.mkdir(parents=True)
+            victim.write_text("original proposal\n", encoding="utf-8")
+            cache = directory / "peer-cache"
+            target = cache / "alice" / "sample" / "proposal.md"
+            target.parent.mkdir(parents=True)
+            os.link(victim, target)
+
+            with mock.patch(
+                "read_peer_proposals.fetch_bytes", return_value=b"peer content\n"
+            ) as fetch:
+                with self.assertRaisesRegex(PeerReaderError, "multiple hard links"):
+                    download_bundle(ITEM, args(root, cache))
+
+            fetch.assert_not_called()
+            self.assertEqual(target.stat().st_ino, victim.stat().st_ino)
+            self.assertEqual(victim.read_text(encoding="utf-8"), "original proposal\n")
+
     def test_distinct_cache_directory_remains_supported(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "repo"
             root.mkdir()
-            cache = root / ".peer-proposals"
+            cache = root / "submissions-cache"
+            existing = cache / "alice" / "sample" / "proposal.md"
+            existing.parent.mkdir(parents=True)
+            existing.write_text("stale cache\n", encoding="utf-8")
 
             with mock.patch(
                 "read_peer_proposals.fetch_bytes", return_value=b"peer content\n"


### PR DESCRIPTION
## Summary

- reject peer download bundles whose resolved path contains an exact `submissions` component, including a copied standalone script and a second checkout
- retain repository-root containment checks for symlinked `submissions/` aliases
- preflight every downloaded file and `peer-metadata.json`, rejecting existing symbolic links and multiply linked files before any network request
- repeat target validation immediately before each write while preserving ordinary external caches and names such as `submissions-cache`

## Reproduction

Running `read_peer_proposals.py --proposal alice/sample --output-dir submissions` can otherwise download a merged peer bundle into `submissions/alice/sample` and overwrite an existing participant package. The same destructive write was reproduced through:

- a directory or ancestor symlink into `submissions/`
- a standalone copied script with an unrelated `--repo-root`
- script/index checkout A with `--output-dir` in checkout B's `submissions/`
- an existing cache target file symlinked or hardlinked to a participant file

The command documents this output as a git-ignored peer cache, so the cache must remain separate from participant source packages and must not follow linked target files.

## Validation

Rebased onto main `233853bfdfdd7309f1f6e8de616a94c052f89235`.

- `python3 -m unittest tests.test_read_peer_output_boundary tests.test_lightweight_participant_flow tests.test_site_package_contract` (31 passed, 1 dependency-based skip)
- actual copied-script/two-checkout matrix: direct, directory symlink, ancestor symlink, file symlink, file hardlink, loose script, and second checkout all rejected; both victim files remained unchanged
- `python3 -m py_compile scripts/read_peer_proposals.py tests/test_read_peer_output_boundary.py`
- `git diff --check origin/main...HEAD`