### PR TITLE
fix: protect source registry generator input

### DIFF
--- a/scripts/generate_source_registry_data.py
+++ b/scripts/generate_source_registry_data.py
@@ -50,7 +50,11 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from source_registry_utils import load_source_registry, summarize_source_registry
+from source_registry_utils import (
+    DEFAULT_SOURCE_REGISTRY_PATH,
+    load_source_registry,
+    summarize_source_registry,
+)
 
 
 DEFAULT_OUTPUT = "source-registry-data.js"
@@ -106,6 +110,9 @@ def main() -> int:
     out_path = Path(args.out)
     if not out_path.is_absolute():
         out_path = repo_root / out_path
+    registry_path = repo_root / DEFAULT_SOURCE_REGISTRY_PATH
+    if out_path.resolve() == registry_path.resolve():
+        parser.error(f"output must not overwrite the source registry input: {registry_path}")
     content = render_js(build_frontend_data(repo_root))
     if args.check:
         if not out_path.exists():

--- a/scripts/generate_source_registry_data.py
+++ b/scripts/generate_source_registry_data.py
@@ -46,7 +46,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import stat
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -82,6 +85,30 @@ def render_js(data: dict[str, Any]) -> str:
         + json.dumps(data, ensure_ascii=False, indent=2)
         + ";\n"
     )
+
+
+def write_text_atomically(path: Path, content: str) -> None:
+    mode = stat.S_IMODE(path.stat().st_mode) if path.exists() else 0o644
+    temporary: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=path.parent,
+            prefix=f".{path.name}-",
+            suffix=".tmp",
+            delete=False,
+            mode="w",
+            encoding="utf-8",
+        ) as handle:
+            temporary = handle.name
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    except BaseException:
+        if temporary:
+            Path(temporary).unlink(missing_ok=True)
+        raise
 
 
 def main() -> int:
@@ -129,7 +156,7 @@ def main() -> int:
             print(f"{out_path}: generated data is stale; run scripts/generate_source_registry_data.py", file=sys.stderr)
             return 1
         return 0
-    out_path.write_text(content, encoding="utf-8")
+    write_text_atomically(out_path, content)
     print(out_path.relative_to(repo_root) if out_path.is_relative_to(repo_root) else out_path)
     return 0
 

--- a/scripts/generate_source_registry_data.py
+++ b/scripts/generate_source_registry_data.py
@@ -111,8 +111,14 @@ def main() -> int:
     if not out_path.is_absolute():
         out_path = repo_root / out_path
     registry_path = repo_root / DEFAULT_SOURCE_REGISTRY_PATH
-    if out_path.resolve() == registry_path.resolve():
-        parser.error(f"output must not overwrite the source registry input: {registry_path}")
+    resolved_out = out_path.resolve()
+    aliases_registry = resolved_out == registry_path.resolve() or (
+        out_path.exists()
+        and registry_path.exists()
+        and out_path.samefile(registry_path)
+    )
+    if aliases_registry or resolved_out.parts[-2:] == Path(DEFAULT_SOURCE_REGISTRY_PATH).parts:
+        parser.error(f"output must not overwrite a source registry input: {resolved_out}")
     content = render_js(build_frontend_data(repo_root))
     if args.check:
         if not out_path.exists():

--- a/tests/test_source_registry_output_boundary.py
+++ b/tests/test_source_registry_output_boundary.py
@@ -1,0 +1,90 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "generate_source_registry_data.py"
+
+
+class SourceRegistryOutputBoundaryTests(unittest.TestCase):
+    def make_registry(self, root: Path) -> Path:
+        registry = root / "data" / "source_registry.json"
+        registry.parent.mkdir(parents=True)
+        registry.write_text(
+            json.dumps(
+                {
+                    "updated_date": "2026-08-12",
+                    "sources": [
+                        {
+                            "source_id": "SOURCE-1",
+                            "review_status": "approved",
+                            "usable_for_formal": "yes",
+                        }
+                    ],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return registry
+
+    def run_generator(self, root: Path, output: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--repo-root",
+                str(root),
+                "--out",
+                str(output),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_output_cannot_overwrite_source_registry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            registry = self.make_registry(root)
+            original = registry.read_bytes()
+
+            result = self.run_generator(root, registry)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("output must not overwrite the source registry input", result.stderr)
+            self.assertEqual(registry.read_bytes(), original)
+
+    def test_symlink_alias_to_source_registry_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            registry = self.make_registry(root)
+            alias = root / "registry-output.js"
+            alias.symlink_to(registry)
+            original = registry.read_bytes()
+
+            result = self.run_generator(root, alias)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("output must not overwrite the source registry input", result.stderr)
+            self.assertEqual(registry.read_bytes(), original)
+
+    def test_distinct_output_is_written(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.make_registry(root)
+            output = root / "source-registry-data.js"
+
+            result = self.run_generator(root, output)
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("window.HAIDIAN_SOURCE_REGISTRY", output.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_source_registry_output_boundary.py
+++ b/tests/test_source_registry_output_boundary.py
@@ -57,7 +57,7 @@ class SourceRegistryOutputBoundaryTests(unittest.TestCase):
             result = self.run_generator(root, registry)
 
             self.assertNotEqual(result.returncode, 0)
-            self.assertIn("output must not overwrite the source registry input", result.stderr)
+            self.assertIn("output must not overwrite a source registry input", result.stderr)
             self.assertEqual(registry.read_bytes(), original)
 
     def test_symlink_alias_to_source_registry_is_rejected(self) -> None:
@@ -71,8 +71,37 @@ class SourceRegistryOutputBoundaryTests(unittest.TestCase):
             result = self.run_generator(root, alias)
 
             self.assertNotEqual(result.returncode, 0)
-            self.assertIn("output must not overwrite the source registry input", result.stderr)
+            self.assertIn("output must not overwrite a source registry input", result.stderr)
             self.assertEqual(registry.read_bytes(), original)
+
+    def test_hardlink_alias_to_source_registry_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            registry = self.make_registry(root)
+            alias = root / "registry-output.js"
+            alias.hardlink_to(registry)
+            original = registry.read_bytes()
+
+            result = self.run_generator(root, alias)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("output must not overwrite a source registry input", result.stderr)
+            self.assertEqual(registry.read_bytes(), original)
+
+    def test_cross_root_canonical_registry_output_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            source_root = directory / "source"
+            victim_root = directory / "victim"
+            self.make_registry(source_root)
+            victim = self.make_registry(victim_root)
+            original = victim.read_bytes()
+
+            result = self.run_generator(source_root, victim)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("output must not overwrite a source registry input", result.stderr)
+            self.assertEqual(victim.read_bytes(), original)
 
     def test_distinct_output_is_written(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_source_registry_output_boundary.py
+++ b/tests/test_source_registry_output_boundary.py
@@ -103,6 +103,31 @@ class SourceRegistryOutputBoundaryTests(unittest.TestCase):
             self.assertIn("output must not overwrite a source registry input", result.stderr)
             self.assertEqual(victim.read_bytes(), original)
 
+    def test_cross_root_hardlink_alias_is_detached_before_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            source_root = directory / "source"
+            victim_root = directory / "victim"
+            self.make_registry(source_root)
+            victim = self.make_registry(victim_root)
+            output = source_root / "registry-output.js"
+            output.hardlink_to(victim)
+            original = victim.read_bytes()
+            self.assertTrue(output.samefile(victim))
+
+            result = self.run_generator(source_root, output)
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(victim.read_bytes(), original)
+            self.assertTrue(output.is_file())
+            self.assertFalse(output.is_symlink())
+            self.assertFalse(output.samefile(victim))
+            self.assertIn(
+                "window.HAIDIAN_SOURCE_REGISTRY",
+                output.read_text(encoding="utf-8"),
+            )
+            self.assertEqual([], list(output.parent.glob(f".{output.name}-*.tmp")))
+
     def test_distinct_output_is_written(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary

- reject frontend generator outputs that resolve to the canonical source registry input
- detect direct, symlink, same-root hardlink, and canonical cross-root aliases before building or writing generated JavaScript
- write accepted outputs through a flushed and fsynced same-directory temporary file followed by `os.replace`
- detach arbitrary-name cross-root hardlink aliases instead of writing through them to another registry
- preserve normal custom output, file mode, and `--check` behavior

## Reproduction

With a valid `data/source_registry.json`, the previous generator could overwrite registry input through several output aliases:

- `--out data/source_registry.json` directly replaced the input JSON with JavaScript;
- symlink aliases and same-root hardlink aliases wrote through to the same input;
- canonical or symlinked `data/source_registry.json` paths in another repository root were also writable;
- an arbitrary-name hardlink to another root's registry bypassed path and same-file comparisons, then `Path.write_text()` truncated the shared inode.

## Change

- compare the resolved output against the source registry input;
- use `samefile()` for an existing same-root hardlink alias;
- reject resolved outputs whose path ends in the canonical `data/source_registry.json` suffix across repository roots;
- atomically replace accepted output directory entries using `NamedTemporaryFile`, `flush()`, `os.fsync()`, mode preservation, and `os.replace()`;
- clean up temporary files when generation fails.

Atomic replacement closes the remaining cross-root hardlink window: the victim inode remains unchanged while the requested output path becomes an independent generated file.

## Relationship to #2057

#2057 preserves existing generated output when the registry is missing, malformed, or empty. This change handles valid-input/output overlap and prevents accepted outputs from writing through hardlinks. The patches modify separate control-flow points and can be merged independently.

## Review follow-up

This revision addresses the remaining cross-root hardlink finding from the review of `d18a54f7e` and retains all previously added direct, symlink, hardlink, and cross-root guards.

The regression verifies that the victim registry remains byte-for-byte unchanged, the output is detached into an independent regular file containing generated JavaScript, and no temporary file remains.

## Validation

- `python3 -m unittest tests.test_source_registry_output_boundary tests.test_source_registry_frontend -v` (9 passed)
- real repository `python3 scripts/generate_source_registry_data.py --check` passed
- `python3 -m py_compile scripts/generate_source_registry_data.py tests/test_source_registry_output_boundary.py`
- `git diff --check upstream/main...HEAD`
- atomic mode/content/temp-cleanup probe passed

Rebased onto canonical main `233853bfdfdd7309f1f6e8de616a94c052f89235`. Current exact head: `e9b3e648a2d5f3c24d9ce863a374cabbe6c10cea`.
