### PR TITLE
fix(validation): support verified GitHub rename aliases

### DIFF
--- a/data/participant_owner_aliases.json
+++ b/data/participant_owner_aliases.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "0.1.0",
+  "aliases": [
+    {
+      "github_user_id": 51290995,
+      "current_login": "zyaoii",
+      "legacy_login": "zymk8353",
+      "legacy_submission_dirs": [
+        "submissions/zymk8353/jingzhang-safe-return-line",
+        "submissions/zymk8353/jingzhang-safe-charge-line",
+        "submissions/zymk8353/jingzhang-ready-aed-line",
+        "submissions/zymk8353/jingzhang-level-access-line"
+      ]
+    }
+  ]
+}

--- a/docs/participant-owner-aliases.md
+++ b/docs/participant-owner-aliases.md
@@ -11,4 +11,6 @@ Each exception binds all of the following trusted values:
 
 The exception permits the current account to maintain only those listed historical packages. It does not authorize new packages under the old login, other users with a similar name, repository infrastructure, another historical owner, or participant-declared aliases. Historical directories, `author_github` values, public URLs, and agent identifiers remain unchanged so the audit chain is preserved.
 
+GitHub may release an old login for re-registration. Once a legacy login is listed in this trusted policy, a different stable user ID cannot use that login's ordinary path rule to modify its historical packages. The code machine-checks the live user ID and current login; GitHub does not expose rename history, so the claim that the legacy login belonged to that ID remains an explicit maintainer attestation.
+
 Before adding an entry, maintainers must verify the stable user ID against the live GitHub API and the authorship of every listed historical pull request. Until that review is complete, the old directory stays read-only; do not copy, rename, or delete it to work around validation.

--- a/docs/participant-owner-aliases.md
+++ b/docs/participant-owner-aliases.md
@@ -1,0 +1,14 @@
+# GitHub rename aliases for historical submissions
+
+Participant directories normally match the pull-request author's current GitHub login exactly. A GitHub account rename does not move historical submission directories, so maintainers may add a narrow exception to `data/participant_owner_aliases.json`.
+
+Each exception binds all of the following trusted values:
+
+- the stable numeric GitHub user ID from the `pull_request_target` event;
+- the account's current login;
+- one historical login;
+- an explicit list of already merged, three-component proposal directories owned by that historical login.
+
+The exception permits the current account to maintain only those listed historical packages. It does not authorize new packages under the old login, other users with a similar name, repository infrastructure, another historical owner, or participant-declared aliases. Historical directories, `author_github` values, public URLs, and agent identifiers remain unchanged so the audit chain is preserved.
+
+Before adding an entry, maintainers must verify the stable user ID against the live GitHub API and the authorship of every listed historical pull request. Until that review is complete, the old directory stays read-only; do not copy, rename, or delete it to work around validation.

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -403,7 +403,14 @@ def authorized_legacy_submission_dirs(
     if not isinstance(aliases, list):
         return set()
     for item in aliases:
-        if not isinstance(item, dict) or item.get("github_user_id") != github_user_id:
+        if not isinstance(item, dict):
+            continue
+        configured_user_id = item.get("github_user_id")
+        if (
+            not isinstance(configured_user_id, int)
+            or isinstance(configured_user_id, bool)
+            or configured_user_id != github_user_id
+        ):
             continue
         configured_login = item.get("current_login")
         if not isinstance(configured_login, str) or configured_login.casefold() != current_login.casefold():
@@ -429,6 +436,32 @@ def authorized_legacy_submission_dirs(
             result.add(PurePosixPath(value).as_posix())
         return result
     return set()
+
+
+def reserved_legacy_login_user_id(repo_root: Path, login: str) -> int | None:
+    """Return the trusted user ID that owns a released historical login."""
+    try:
+        policy = json.loads(
+            (repo_root / PARTICIPANT_OWNER_ALIASES_PATH).read_text(encoding="utf-8")
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    aliases = policy.get("aliases") if isinstance(policy, dict) else None
+    if not isinstance(aliases, list):
+        return None
+    for item in aliases:
+        if not isinstance(item, dict):
+            continue
+        legacy_login = item.get("legacy_login")
+        user_id = item.get("github_user_id")
+        if (
+            isinstance(legacy_login, str)
+            and legacy_login.casefold() == login.casefold()
+            and isinstance(user_id, int)
+            and not isinstance(user_id, bool)
+        ):
+            return user_id
+    return None
 
 
 def is_review_queue_candidate(
@@ -660,6 +693,12 @@ def main() -> int:
     authorized_legacy_dirs = authorized_legacy_submission_dirs(
         trusted_repo_root, pr_user_id, pr_author
     )
+    reserved_legacy_user_id = reserved_legacy_login_user_id(trusted_repo_root, pr_author)
+    blocked_submission_owners = (
+        {pr_author}
+        if reserved_legacy_user_id is not None and reserved_legacy_user_id != pr_user_id
+        else set()
+    )
     validation_files = validation_paths_for(files, maintainer_bypass)
     queue_candidate = is_review_queue_candidate(changed_files, pr_author, authorized_legacy_dirs)
 
@@ -748,6 +787,7 @@ def main() -> int:
                 strict_manifest_paths=strict_manifest_paths_for(files),
                 required_readiness_contract_dirs=required_readiness_contract_dirs,
                 authorized_legacy_submission_dirs=authorized_legacy_dirs,
+                blocked_submission_owners=blocked_submission_owners,
             )
             if validation_files and not base_sha:
                 validation.add_error(

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -45,6 +45,7 @@ RETRYABLE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 # with the path and head-specific download error after the retry budget.
 RETRYABLE_STATUS_CODES = frozenset({404, 429, 500, 502, 503, 504})
 TRUSTED_REVIEW_GATE_TIMEOUT_SECONDS = 180
+PARTICIPANT_OWNER_ALIASES_PATH = "data/participant_owner_aliases.json"
 
 
 def _http_error_message(error: urllib.error.HTTPError) -> str:
@@ -387,14 +388,67 @@ def strict_manifest_paths_for(files: list[dict]) -> list[str]:
     return sorted(paths)
 
 
-def is_review_queue_candidate(changed_files: list[str], pr_author: str) -> bool:
+def authorized_legacy_submission_dirs(
+    repo_root: Path, github_user_id: object, current_login: str
+) -> set[str]:
+    """Resolve maintainer-controlled rename aliases from trusted GitHub identity."""
+    if not isinstance(github_user_id, int) or isinstance(github_user_id, bool):
+        return set()
+    policy_path = repo_root / PARTICIPANT_OWNER_ALIASES_PATH
+    try:
+        policy = json.loads(policy_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return set()
+    aliases = policy.get("aliases") if isinstance(policy, dict) else None
+    if not isinstance(aliases, list):
+        return set()
+    for item in aliases:
+        if not isinstance(item, dict) or item.get("github_user_id") != github_user_id:
+            continue
+        configured_login = item.get("current_login")
+        if not isinstance(configured_login, str) or configured_login.casefold() != current_login.casefold():
+            continue
+        legacy_login = item.get("legacy_login")
+        if not isinstance(legacy_login, str) or not legacy_login:
+            return set()
+        legacy_dirs = item.get("legacy_submission_dirs")
+        if not isinstance(legacy_dirs, list):
+            return set()
+        result: set[str] = set()
+        for value in legacy_dirs:
+            if not isinstance(value, str):
+                return set()
+            parts = PurePosixPath(value).parts
+            if (
+                len(parts) != 3
+                or parts[0] != "submissions"
+                or parts[1] != legacy_login
+                or ".." in parts
+            ):
+                return set()
+            result.add(PurePosixPath(value).as_posix())
+        return result
+    return set()
+
+
+def is_review_queue_candidate(
+    changed_files: list[str],
+    pr_author: str,
+    authorized_legacy_dirs: set[str] | None = None,
+) -> bool:
     """Return true only for a single participant-owned submission directory."""
+    authorized_legacy_dirs = authorized_legacy_dirs or set()
     roots: set[str] = set()
     for filename in changed_files:
         parts = filename.split("/")
-        if len(parts) < 4 or parts[0] != "submissions" or parts[1].casefold() != pr_author.casefold():
+        proposal_dir = "/".join(parts[:3])
+        if (
+            len(parts) < 4
+            or parts[0] != "submissions"
+            or (parts[1].casefold() != pr_author.casefold() and proposal_dir not in authorized_legacy_dirs)
+        ):
             return False
-        roots.add("/".join(parts[:3]))
+        roots.add(proposal_dir)
     return bool(changed_files) and len(roots) == 1
 
 
@@ -573,6 +627,7 @@ def main() -> int:
 
     pr_number = int(pull_request["number"])
     pr_author = pull_request["user"]["login"]
+    pr_user_id = pull_request["user"].get("id")
     head_repo = pull_request["head"]["repo"]["full_name"]
     head_sha = pull_request["head"]["sha"]
     base = pull_request.get("base") or {}
@@ -601,8 +656,12 @@ def main() -> int:
         if item.strip()
     ]
     maintainer_bypass = pr_author.lower() in {item.lower() for item in bypass}
+    trusted_repo_root = Path(__file__).resolve().parent.parent
+    authorized_legacy_dirs = authorized_legacy_submission_dirs(
+        trusted_repo_root, pr_user_id, pr_author
+    )
     validation_files = validation_paths_for(files, maintainer_bypass)
-    queue_candidate = is_review_queue_candidate(changed_files, pr_author)
+    queue_candidate = is_review_queue_candidate(changed_files, pr_author, authorized_legacy_dirs)
 
     # Code/docs/test PRs do not need participant-package hydration.  Decide
     # this immediately after the file listing so a non-submission change
@@ -688,12 +747,12 @@ def main() -> int:
                 bypass,
                 strict_manifest_paths=strict_manifest_paths_for(files),
                 required_readiness_contract_dirs=required_readiness_contract_dirs,
+                authorized_legacy_submission_dirs=authorized_legacy_dirs,
             )
             if validation_files and not base_sha:
                 validation.add_error(
                     "pull_request.base.sha is required to establish the trusted readiness migration boundary"
                 )
-            trusted_repo_root = Path(__file__).resolve().parent.parent
             for proposal_path in sorted(proposal_paths):
                 run_trusted_review_gates(
                     validation,

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -182,6 +182,7 @@ ALLOWED_VISUAL_ASSET_EXTENSIONS = {".css", ".js", ".json", ".svg", ".png", ".jpg
 PARTICIPANT_PROTECTED_GLOBAL_FILES = {
     "submissions-data.js",
     "gallery-publication.json",
+    "data/participant_owner_aliases.json",
 }
 MAINTAINER_CONTROLLED_SUBMISSIONS_ROOT_FILES = {
     "submissions/README.md",
@@ -2801,6 +2802,7 @@ def validate_submission(
     required_readiness_contract_dirs: Iterable[str] = (),
     strict_manifest_paths: Iterable[str] = (),
     authorized_legacy_submission_dirs: Iterable[str] = (),
+    blocked_submission_owners: Iterable[str] = (),
 ) -> ValidationReport:
     report = ValidationReport()
     repo_root = repo_root.resolve()
@@ -2818,6 +2820,11 @@ def validate_submission(
     authorized_legacy_dirs = {
         normalize_changed_path(path).rstrip("/")
         for path in authorized_legacy_submission_dirs
+    }
+    blocked_owners = {
+        str(owner).strip().casefold()
+        for owner in blocked_submission_owners
+        if str(owner).strip()
     }
 
     if not pr_author or not GITHUB_LOGIN_RE.match(pr_author):
@@ -2869,7 +2876,7 @@ def validate_submission(
         if not report.maintainer_bypass:
             if path in PARTICIPANT_PROTECTED_GLOBAL_FILES:
                 report.add_error(
-                    f"{path}: participants must not edit maintainer-controlled gallery publication data"
+                    f"{path}: participants must not edit maintainer-controlled gallery publication data or global policy"
                 )
                 continue
             if parts[0] != "submissions" or len(parts) < 2:
@@ -2878,6 +2885,12 @@ def validate_submission(
                 )
                 continue
             proposal_dir = "/".join(parts[:3]) if len(parts) >= 3 else ""
+            if parts[1].casefold() in blocked_owners:
+                report.add_error(
+                    f"{path}: submission owner `{parts[1]}` is a reserved historical login "
+                    "bound to a different stable GitHub user ID"
+                )
+                continue
             if parts[1] != pr_author and proposal_dir not in authorized_legacy_dirs:
                 report.add_error(
                     f"{path}: submission directory `{parts[1]}` must exactly match "

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -2472,6 +2472,7 @@ def validate_proposal_file(
     proposal_path: str,
     pr_author: str,
     path_author: str,
+    legacy_owner_authorized: bool = False,
 ) -> None:
     full_path = repo_root / proposal_path
     try:
@@ -2491,7 +2492,12 @@ def validate_proposal_file(
             report.add_error(f"{proposal_path}: missing front matter field `{key}`")
 
     author = metadata.get("author_github", "")
-    if author and author.lower() != pr_author.lower() and not report.maintainer_bypass:
+    if (
+        author
+        and author.lower() != pr_author.lower()
+        and not report.maintainer_bypass
+        and not legacy_owner_authorized
+    ):
         report.add_error(
             f"{proposal_path}: author_github `{author}` must match PR author `{pr_author}`"
         )
@@ -2794,6 +2800,7 @@ def validate_submission(
     allow_pending_self_check: bool = False,
     required_readiness_contract_dirs: Iterable[str] = (),
     strict_manifest_paths: Iterable[str] = (),
+    authorized_legacy_submission_dirs: Iterable[str] = (),
 ) -> ValidationReport:
     report = ValidationReport()
     repo_root = repo_root.resolve()
@@ -2807,6 +2814,10 @@ def validate_submission(
     }
     report.strict_manifest_paths = {
         normalize_changed_path(path) for path in strict_manifest_paths
+    }
+    authorized_legacy_dirs = {
+        normalize_changed_path(path).rstrip("/")
+        for path in authorized_legacy_submission_dirs
     }
 
     if not pr_author or not GITHUB_LOGIN_RE.match(pr_author):
@@ -2866,7 +2877,8 @@ def validate_submission(
                     f"{path}: participant PRs may only change submissions/{pr_author}/"
                 )
                 continue
-            if parts[1] != pr_author:
+            proposal_dir = "/".join(parts[:3]) if len(parts) >= 3 else ""
+            if parts[1] != pr_author and proposal_dir not in authorized_legacy_dirs:
                 report.add_error(
                     f"{path}: submission directory `{parts[1]}` must exactly match "
                     f"GitHub PR author `{pr_author}`, including letter case"
@@ -3050,7 +3062,15 @@ def validate_submission(
         if not (repo_root / proposal_path).exists():
             continue
         path_author = proposal_path.split("/")[1]
-        validate_proposal_file(report, repo_root, proposal_path, pr_author, path_author)
+        proposal_dir = str(PurePosixPath(proposal_path).parent)
+        validate_proposal_file(
+            report,
+            repo_root,
+            proposal_path,
+            pr_author,
+            path_author,
+            proposal_dir in authorized_legacy_dirs,
+        )
 
     for proposal_dir in sorted(ai_package_dirs):
         if proposal_dir in unsafe_submission_dirs:

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -41,6 +41,7 @@ from github_pr_validation import (  # noqa: E402
     is_current_pull_request_head,
     is_non_submission_pr,
     is_review_queue_candidate,
+    reserved_legacy_login_user_id,
     main,
     readiness_contract_dirs_from_base,
     run_trusted_review_gates,
@@ -979,6 +980,8 @@ class ManifestHydrationTests(unittest.TestCase):
         self.assertEqual(
             set(), authorized_legacy_submission_dirs(REPO_ROOT, 51290995, "attacker")
         )
+        self.assertEqual(51290995, reserved_legacy_login_user_id(REPO_ROOT, "zymk8353"))
+        self.assertIsNone(reserved_legacy_login_user_id(REPO_ROOT, "unrelated"))
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             policy = root / "data" / "participant_owner_aliases.json"
@@ -1892,8 +1895,35 @@ class SubmissionWorkflowTests(unittest.TestCase):
             )
             denied = validate_submission(root, "current", changed)
 
-        self.assertNotIn("must exactly match", "\n".join(allowed.errors))
+        self.assertTrue(allowed.ok, allowed.errors)
+        self.assertFalse(denied.ok)
         self.assertIn("must exactly match", "\n".join(denied.errors))
+
+    def test_re_registered_legacy_login_cannot_take_over_historical_package(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/legacy/known-package"
+            changed = self.write_minimal_ai_package(root, base)
+            report = validate_submission(
+                root,
+                "legacy",
+                changed,
+                blocked_submission_owners={"legacy"},
+            )
+
+        self.assertFalse(report.ok)
+        self.assertIn("reserved historical login", "\n".join(report.errors))
+
+    def test_alias_policy_is_participant_protected(self) -> None:
+        path = "data/participant_owner_aliases.json"
+        self.assertFalse(is_non_submission_pr([path]))
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "data").mkdir()
+            (root / path).write_text('{"aliases": []}\n', encoding="utf-8")
+            report = validate_submission(root, "alice", [path])
+        self.assertFalse(report.ok)
+        self.assertIn("global policy", "\n".join(report.errors))
 
     def test_submission_owner_casing_must_match_github_login(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -32,6 +32,7 @@ from validate_submission import (  # noqa: E402
     validate_submission,
 )
 from github_pr_validation import (  # noqa: E402
+    authorized_legacy_submission_dirs,
     base_requires_persisted_readiness,
     COMMENT_MARKER,
     GitHubClient,
@@ -948,6 +949,58 @@ class ManifestHydrationTests(unittest.TestCase):
                 "alice",
             )
         )
+        self.assertTrue(
+            is_review_queue_candidate(
+                ["submissions/legacy/design/proposal.md"],
+                "current",
+                {"submissions/legacy/design"},
+            )
+        )
+        self.assertFalse(
+            is_review_queue_candidate(
+                ["submissions/legacy/other/proposal.md"],
+                "current",
+                {"submissions/legacy/design"},
+            )
+        )
+
+    def test_owner_alias_requires_stable_user_id_current_login_and_exact_package(self) -> None:
+        expected = {
+            "submissions/zymk8353/jingzhang-safe-return-line",
+            "submissions/zymk8353/jingzhang-safe-charge-line",
+            "submissions/zymk8353/jingzhang-ready-aed-line",
+            "submissions/zymk8353/jingzhang-level-access-line",
+        }
+        self.assertEqual(
+            expected,
+            authorized_legacy_submission_dirs(REPO_ROOT, 51290995, "zyaoii"),
+        )
+        self.assertEqual(set(), authorized_legacy_submission_dirs(REPO_ROOT, 7, "zyaoii"))
+        self.assertEqual(
+            set(), authorized_legacy_submission_dirs(REPO_ROOT, 51290995, "attacker")
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            policy = root / "data" / "participant_owner_aliases.json"
+            policy.parent.mkdir()
+            policy.write_text(
+                json.dumps(
+                    {
+                        "aliases": [
+                            {
+                                "github_user_id": 51290995,
+                                "current_login": "zyaoii",
+                                "legacy_login": "legacy",
+                                "legacy_submission_dirs": ["submissions/other/package"],
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                set(), authorized_legacy_submission_dirs(root, 51290995, "zyaoii")
+            )
         self.assertFalse(
             is_review_queue_candidate(
                 [
@@ -1818,6 +1871,29 @@ class SubmissionWorkflowTests(unittest.TestCase):
             report = validate_submission(root, "alice", [rel])
             self.assertFalse(report.ok)
             self.assertIn("must exactly match", "\n".join(report.errors))
+
+    def test_verified_rename_alias_can_only_maintain_listed_legacy_package(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/legacy/known-package"
+            changed = self.write_minimal_ai_package(root, base)
+            proposal = root / base / "proposal.md"
+            proposal.write_text(
+                proposal.read_text(encoding="utf-8").replace(
+                    'author_github: "alice"', 'author_github: "legacy"'
+                ),
+                encoding="utf-8",
+            )
+            allowed = validate_submission(
+                root,
+                "current",
+                changed,
+                authorized_legacy_submission_dirs={base},
+            )
+            denied = validate_submission(root, "current", changed)
+
+        self.assertNotIn("must exactly match", "\n".join(allowed.errors))
+        self.assertIn("must exactly match", "\n".join(denied.errors))
 
     def test_submission_owner_casing_must_match_github_login(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- add a maintainer-controlled participant owner alias policy keyed by stable GitHub user ID
- verify the live `pull_request_target` user ID and current login before granting any legacy ownership
- authorize only four explicit, already merged historical packages; new packages and other legacy paths remain denied
- preserve historical directories, `author_github`, agent IDs, public URLs, and audit history
- document the verification and read-only migration procedure

## Security boundary

Aliases cannot be supplied by participants. A matching login without the stable user ID, a matching user ID with the wrong current login, a legacy directory owned by a different historical login, and an unlisted package all fail closed. Maintainer bypass, participant scope, and trusted-base execution remain unchanged.

## Validation

- `.venv/bin/python -m unittest -q tests.test_submission_workflow` — 140 passed
- `.venv/bin/python -m py_compile scripts/github_pr_validation.py scripts/validate_submission.py tests/test_submission_workflow.py`
- `.venv/bin/python -m json.tool data/participant_owner_aliases.json`
- `git diff --check`

Fixes #2210
