### PR TITLE
fix: protect gallery publication input

### DIFF
--- a/scripts/generate_submissions_data.py
+++ b/scripts/generate_submissions_data.py
@@ -42,8 +42,11 @@ import argparse
 from datetime import date
 import hashlib
 import json
+import os
 import re
+import stat
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
@@ -498,6 +501,30 @@ def render_js(items: list[dict[str, Any]]) -> str:
     )
 
 
+def write_text_atomically(path: Path, content: str) -> None:
+    mode = stat.S_IMODE(path.stat().st_mode) if path.exists() else 0o644
+    temporary: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=path.parent,
+            prefix=f".{path.name}-",
+            suffix=".tmp",
+            delete=False,
+            mode="w",
+            encoding="utf-8",
+        ) as handle:
+            temporary = handle.name
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    except BaseException:
+        if temporary:
+            Path(temporary).unlink(missing_ok=True)
+        raise
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo-root", default=".")
@@ -520,6 +547,15 @@ def main() -> int:
     out_path = Path(args.out)
     if not out_path.is_absolute():
         out_path = repo_root / out_path
+    publication_path = repo_root / PUBLICATION_FILE
+    resolved_out = out_path.resolve()
+    aliases_publication = resolved_out == publication_path.resolve() or (
+        out_path.exists()
+        and publication_path.exists()
+        and out_path.samefile(publication_path)
+    )
+    if aliases_publication or resolved_out.name == PUBLICATION_FILE:
+        parser.error(f"output must not overwrite a gallery publication input: {resolved_out}")
     generated = render_js(build_data(repo_root))
     if args.check:
         existing = out_path.read_text(encoding="utf-8") if out_path.exists() else ""
@@ -527,7 +563,7 @@ def main() -> int:
             print(f"{out_path.relative_to(repo_root)} is out of date; run scripts/generate_submissions_data.py", file=sys.stderr)
             return 1
         return 0
-    out_path.write_text(generated, encoding="utf-8")
+    write_text_atomically(out_path, generated)
     print(out_path.relative_to(repo_root))
     return 0
 

--- a/tests/test_gallery_output_boundary.py
+++ b/tests/test_gallery_output_boundary.py
@@ -1,0 +1,155 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "generate_submissions_data.py"
+
+
+class GalleryOutputBoundaryTests(unittest.TestCase):
+    def make_publication(self, root: Path) -> Path:
+        root.mkdir(parents=True, exist_ok=True)
+        publication = root / "gallery-publication.json"
+        publication.write_text(
+            json.dumps({"version": 1, "entries": []}) + "\n",
+            encoding="utf-8",
+        )
+        return publication
+
+    def run_generator(self, root: Path, output: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--repo-root",
+                str(root),
+                "--out",
+                str(output),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def assert_rejected_without_change(self, root: Path, output: Path, victim: Path) -> None:
+        original = victim.read_bytes()
+        result = self.run_generator(root, output)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("output must not overwrite a gallery publication input", result.stderr)
+        self.assertEqual(victim.read_bytes(), original)
+
+    def assert_detached_without_changing_victim(self, root: Path, output: Path, victim: Path) -> None:
+        original = victim.read_bytes()
+        self.assertTrue(output.samefile(victim))
+
+        result = self.run_generator(root, output)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(victim.read_bytes(), original)
+        self.assertTrue(output.is_file())
+        self.assertFalse(output.is_symlink())
+        self.assertFalse(output.samefile(victim))
+        self.assertIn("window.HAIDIAN_SUBMISSIONS = []", output.read_text(encoding="utf-8"))
+        self.assertEqual([], list(output.parent.glob(f".{output.name}-*.tmp")))
+
+    def test_output_cannot_overwrite_gallery_publication(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            publication = self.make_publication(root)
+            self.assert_rejected_without_change(root, publication, publication)
+
+    def test_symlink_and_hardlink_aliases_are_rejected(self) -> None:
+        for kind in ("symlink", "hardlink"):
+            with self.subTest(kind=kind), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                publication = self.make_publication(root)
+                alias = root / "gallery-output.js"
+                if kind == "symlink":
+                    alias.symlink_to(publication)
+                else:
+                    alias.hardlink_to(publication)
+                self.assert_rejected_without_change(root, alias, publication)
+
+    def test_cross_root_canonical_publication_output_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            source_root = directory / "source"
+            victim_root = directory / "victim"
+            self.make_publication(source_root)
+            victim = self.make_publication(victim_root)
+            self.assert_rejected_without_change(source_root, victim, victim)
+
+    def test_cross_root_hardlink_alias_is_detached_before_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            source_root = directory / "source"
+            victim_root = directory / "victim"
+            self.make_publication(source_root)
+            victim = self.make_publication(victim_root)
+            output = source_root / "gallery-output.js"
+            output.hardlink_to(victim)
+
+            self.assert_detached_without_changing_victim(source_root, output, victim)
+
+    def test_output_symlink_alias_is_detached_before_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            source_root = directory / "source"
+            victim_root = directory / "victim"
+            self.make_publication(source_root)
+            victim = self.make_publication(victim_root)
+            victim_alias = victim_root / "publication-alias.js"
+            victim_alias.hardlink_to(victim)
+            output = source_root / "gallery-output.js"
+            output.symlink_to(victim_alias)
+
+            self.assert_detached_without_changing_victim(source_root, output, victim)
+
+    def test_output_through_symlinked_directory_is_detached_before_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            source_root = directory / "source"
+            victim_root = directory / "victim"
+            self.make_publication(source_root)
+            victim = self.make_publication(victim_root)
+            victim_alias = victim_root / "publication-alias.js"
+            victim_alias.hardlink_to(victim)
+            output_parent = source_root / "linked-output"
+            output_parent.symlink_to(victim_root, target_is_directory=True)
+            output = output_parent / victim_alias.name
+
+            self.assert_detached_without_changing_victim(source_root, output, victim)
+
+    def test_failed_replace_removes_temporary_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.make_publication(root)
+            output = root / "output-directory"
+            output.mkdir()
+
+            result = self.run_generator(root, output)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertTrue(output.is_dir())
+            self.assertEqual([], list(root.glob(f".{output.name}-*.tmp")))
+
+    def test_distinct_output_is_written(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.make_publication(root)
+            output = root / "submissions-data.js"
+
+            result = self.run_generator(root, output)
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("window.HAIDIAN_SUBMISSIONS = []", output.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject gallery generator outputs that directly alias `gallery-publication.json`
- write generated output through a same-directory temporary file, `flush`/`fsync`, and `os.replace`
- detach cross-root hardlink aliases and output/parent-directory symlink aliases without changing the publication input inode
- preserve normal `submissions-data.js`, existing output permissions, and `--package-sha` behavior

## Reproduction

Before this patch, running `generate_submissions_data.py --out gallery-publication.json` with a valid publication registry completes with exit code 0 and replaces the maintainer-controlled review/publication state with generated JavaScript.

The original guard closes direct, same-root symlink/hardlink, and cross-root canonical-name paths. Exact-head review also reproduced three alias combinations that bypassed a path-only guard: a cross-root hardlink under a different basename, an output symlink targeting a differently named hardlink to a publication input, and the same inode reached through a symlinked output directory. Atomic replacement now detaches those output directory entries while leaving the victim bytes unchanged.

This sibling defect was identified during the exact-head peer review of #2233 and reproduced on current main before this patch.

## Validation

- `python3 -m unittest tests.test_gallery_output_boundary tests.test_gallery_snapshot_maintenance_workflow -v` (14 tests passed: 8 output-boundary and 6 workflow tests)
- `python3 -m py_compile scripts/generate_submissions_data.py tests/test_gallery_output_boundary.py`
- `git diff --check origin/main...HEAD`
- current-main and patched generators render identical real-corpus output: 877 entries, SHA-256 `46aa39dc1562f95f7bfe7352d04e319c8e504789ccebb72360cd28953a746a9f`

The checked-in `submissions-data.js` on current main contains 872 entries and is already five submissions behind the generated 877-entry corpus. Therefore the real-corpus `--check` and five snapshot-dependent gallery/prelaunch assertions fail identically with the current-main generator; this PR does not change generated bytes.
