### PR TITLE
fix: contain bilingual artifact discovery

### DIFF
--- a/scripts/backfill_bilingual_artifacts.py
+++ b/scripts/backfill_bilingual_artifacts.py
@@ -59,6 +59,7 @@ import argparse
 import hashlib
 import html
 import json
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -113,17 +114,34 @@ def is_symlink_free_contained_path(path: Path, root: Path) -> bool:
     return path.resolve().is_relative_to(root.resolve())
 
 
+def package_is_symlink_free(directory: Path) -> bool:
+    def raise_walk_error(error: OSError) -> None:
+        raise error
+
+    try:
+        for current, names, files in os.walk(
+            directory, followlinks=False, onerror=raise_walk_error
+        ):
+            if any((Path(current) / name).is_symlink() for name in [*names, *files]):
+                return False
+    except OSError:
+        return False
+    return True
+
+
 def resolve_only_selection(found: list[Path], only: list[str], repo_root: Path) -> list[Path]:
     if not only:
         return found
     selected: list[Path] = []
+    resolved = {path: path.resolve() for path in found}
     for raw in only:
         candidate = Path(raw)
         if candidate.is_absolute():
-            matches = [path for path in found if path == candidate.resolve()]
+            target = candidate.resolve()
+            matches = [path for path in found if resolved[path] == target]
         elif "/" in raw or "\\" in raw:
             target = (repo_root / candidate).resolve()
-            matches = [path for path in found if path == target]
+            matches = [path for path in found if resolved[path] == target]
         else:
             matches = [path for path in found if path.name == raw]
             if len(matches) > 1:
@@ -144,6 +162,7 @@ def submission_dirs(repo_root: Path, only: list[str]) -> list[Path]:
         path.parent
         for path in submissions_root.glob("*/*/proposal.md")
         if is_symlink_free_contained_path(path, submissions_root)
+        and package_is_symlink_free(path.parent)
     )
     return resolve_only_selection(dirs, only, repo_root)
 

--- a/scripts/backfill_bilingual_artifacts.py
+++ b/scripts/backfill_bilingual_artifacts.py
@@ -113,6 +113,29 @@ def is_symlink_free_contained_path(path: Path, root: Path) -> bool:
     return path.resolve().is_relative_to(root.resolve())
 
 
+def resolve_only_selection(found: list[Path], only: list[str], repo_root: Path) -> list[Path]:
+    if not only:
+        return found
+    selected: list[Path] = []
+    for raw in only:
+        candidate = Path(raw)
+        if candidate.is_absolute():
+            matches = [path for path in found if path == candidate.resolve()]
+        elif "/" in raw or "\\" in raw:
+            target = (repo_root / candidate).resolve()
+            matches = [path for path in found if path == target]
+        else:
+            matches = [path for path in found if path.name == raw]
+            if len(matches) > 1:
+                choices = ", ".join(path.relative_to(repo_root).as_posix() for path in matches)
+                raise ValueError(f"--only `{raw}` is ambiguous; use an exact path: {choices}")
+        if not matches:
+            raise ValueError(f"--only `{raw}` did not match a discovered submission")
+        if matches[0] not in selected:
+            selected.append(matches[0])
+    return sorted(selected)
+
+
 def submission_dirs(repo_root: Path, only: list[str]) -> list[Path]:
     submissions_root = repo_root / "submissions"
     if submissions_root.is_symlink():
@@ -122,10 +145,7 @@ def submission_dirs(repo_root: Path, only: list[str]) -> list[Path]:
         for path in submissions_root.glob("*/*/proposal.md")
         if is_symlink_free_contained_path(path, submissions_root)
     )
-    if not only:
-        return dirs
-    wanted = set(only)
-    return [directory for directory in dirs if directory.name in wanted or directory.as_posix() in wanted]
+    return resolve_only_selection(dirs, only, repo_root)
 
 
 def languages(submission_dir: Path) -> tuple[str, str]:

--- a/scripts/backfill_bilingual_artifacts.py
+++ b/scripts/backfill_bilingual_artifacts.py
@@ -100,8 +100,28 @@ def display_path(path: Path) -> str:
         return path.as_posix()
 
 
+def is_symlink_free_contained_path(path: Path, root: Path) -> bool:
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        return False
+    current = root
+    for part in relative.parts:
+        current /= part
+        if current.is_symlink():
+            return False
+    return path.resolve().is_relative_to(root.resolve())
+
+
 def submission_dirs(repo_root: Path, only: list[str]) -> list[Path]:
-    dirs = sorted(path.parent for path in (repo_root / "submissions").glob("*/*/proposal.md"))
+    submissions_root = repo_root / "submissions"
+    if submissions_root.is_symlink():
+        raise ValueError(f"submissions root must not be a symbolic link: {submissions_root}")
+    dirs = sorted(
+        path.parent
+        for path in submissions_root.glob("*/*/proposal.md")
+        if is_symlink_free_contained_path(path, submissions_root)
+    )
     if not only:
         return dirs
     wanted = set(only)
@@ -596,7 +616,10 @@ def main() -> int:
     parser.add_argument("--force", action="store_true")
     args = parser.parse_args()
     repo_root = args.repo_root.resolve()
-    dirs = submission_dirs(repo_root, args.only)
+    try:
+        dirs = submission_dirs(repo_root, args.only)
+    except ValueError as exc:
+        parser.error(str(exc))
     changed = 0
     if args.mode in {"figures", "all"}:
         zh_to_en, en_to_zh = load_glossary(repo_root / "docs" / "terminology-glossary.md")

--- a/tests/test_bilingual_backfill.py
+++ b/tests/test_bilingual_backfill.py
@@ -76,6 +76,25 @@ class BilingualBackfillTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "submissions root must not be a symbolic link"):
                 submission_dirs(root, [])
 
+    def test_artifact_only_rejects_ambiguous_slug_and_empty_selection(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            first = root / "submissions" / "alice" / "same-slug"
+            second = root / "submissions" / "bob" / "same-slug"
+            for package in (first, second):
+                package.mkdir(parents=True)
+                (package / "proposal.md").write_text(
+                    '---\nlanguage: "en"\n---\n# Proposal\n', encoding="utf-8"
+                )
+
+            with self.assertRaisesRegex(ValueError, "ambiguous"):
+                submission_dirs(root, ["same-slug"])
+            self.assertEqual(
+                [first], submission_dirs(root, ["submissions/alice/same-slug"])
+            )
+            with self.assertRaisesRegex(ValueError, "did not match"):
+                submission_dirs(root, ["missing"])
+
     def test_front_matter_parser_accepts_utf8_bom(self) -> None:
         front, body = parse_front_matter("\ufeff---\nlanguage: zh\n---\n正文\n")
         self.assertEqual(["language: zh"], front)

--- a/tests/test_bilingual_backfill.py
+++ b/tests/test_bilingual_backfill.py
@@ -14,6 +14,7 @@ from backfill_bilingual_artifacts import (  # noqa: E402
     backfill_manifests,
     create_localized_figure,
     localize_translation_image_paths,
+    submission_dirs,
 )
 from backfill_bilingual_submissions import (  # noqa: E402
     LocalTranslator,
@@ -26,6 +27,55 @@ from backfill_bilingual_submissions import (  # noqa: E402
 
 
 class BilingualBackfillTests(unittest.TestCase):
+    def test_artifact_discovery_rejects_symlinked_packages_and_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            submissions = root / "submissions"
+            regular = submissions / "alice" / "regular"
+            regular.mkdir(parents=True)
+            (regular / "proposal.md").write_text("regular", encoding="utf-8")
+
+            outside_package = Path(tmp) / "outside-package"
+            outside_package.mkdir()
+            (outside_package / "proposal.md").write_text("outside", encoding="utf-8")
+            outside_manifest = outside_package / "manifest.json"
+            outside_manifest.write_text('{"files": []}\n', encoding="utf-8")
+            (submissions / "alice" / "linked-package").symlink_to(
+                outside_package,
+                target_is_directory=True,
+            )
+
+            linked_file = submissions / "alice" / "linked-file"
+            linked_file.mkdir()
+            (linked_file / "proposal.md").symlink_to(outside_package / "proposal.md")
+
+            outside_owner = Path(tmp) / "outside-owner"
+            owner_package = outside_owner / "linked-owner-package"
+            owner_package.mkdir(parents=True)
+            (owner_package / "proposal.md").write_text("outside owner", encoding="utf-8")
+            (submissions / "linked-owner").symlink_to(
+                outside_owner,
+                target_is_directory=True,
+            )
+
+            found = submission_dirs(root, [])
+            self.assertEqual([regular], found)
+            backfill_manifests(found)
+            self.assertEqual('{"files": []}\n', outside_manifest.read_text(encoding="utf-8"))
+
+    def test_artifact_discovery_reports_symlinked_submissions_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            outside = Path(tmp) / "outside-submissions"
+            package = outside / "alice" / "sample"
+            package.mkdir(parents=True)
+            (package / "proposal.md").write_text("outside", encoding="utf-8")
+            (root / "submissions").symlink_to(outside, target_is_directory=True)
+
+            with self.assertRaisesRegex(ValueError, "submissions root must not be a symbolic link"):
+                submission_dirs(root, [])
+
     def test_front_matter_parser_accepts_utf8_bom(self) -> None:
         front, body = parse_front_matter("\ufeff---\nlanguage: zh\n---\n正文\n")
         self.assertEqual(["language: zh"], front)

--- a/tests/test_bilingual_backfill.py
+++ b/tests/test_bilingual_backfill.py
@@ -11,6 +11,7 @@ import sys
 sys.path.insert(0, str(ROOT / "scripts"))
 
 from backfill_bilingual_artifacts import (  # noqa: E402
+    backfill_html,
     backfill_manifests,
     create_localized_figure,
     localize_translation_image_paths,
@@ -76,6 +77,52 @@ class BilingualBackfillTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "submissions root must not be a symbolic link"):
                 submission_dirs(root, [])
 
+    def test_artifact_discovery_rejects_internal_file_and_directory_symlinks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            root = workspace / "repo"
+
+            manifest_package = root / "submissions" / "alice" / "linked-manifest"
+            manifest_package.mkdir(parents=True)
+            (manifest_package / "proposal.md").write_text(
+                '---\nlanguage: "en"\n---\n# Proposal\n', encoding="utf-8"
+            )
+            outside_manifest = workspace / "outside-manifest.json"
+            original_manifest = b'{"files": []}\n'
+            outside_manifest.write_bytes(original_manifest)
+            try:
+                (manifest_package / "manifest.json").symlink_to(outside_manifest)
+            except OSError as exc:
+                self.skipTest(f"symlinks unavailable: {exc}")
+
+            output_package = root / "submissions" / "bob" / "linked-output"
+            output_package.mkdir(parents=True)
+            (output_package / "proposal.md").write_text(
+                '---\nlanguage: "en"\n---\n# Proposal\n', encoding="utf-8"
+            )
+            (output_package / "proposal.zh.md").write_text(
+                '---\nlanguage: "zh"\n---\n# 方案\n', encoding="utf-8"
+            )
+            outside_report = workspace / "outside-report"
+            outside_visual = workspace / "outside-visual"
+            outside_report.mkdir()
+            outside_visual.mkdir()
+            (output_package / "report").symlink_to(
+                outside_report, target_is_directory=True
+            )
+            (output_package / "visual").symlink_to(
+                outside_visual, target_is_directory=True
+            )
+
+            found = submission_dirs(root, [])
+
+            self.assertEqual([], found)
+            self.assertEqual(0, backfill_manifests(found))
+            self.assertEqual(0, backfill_html(found))
+            self.assertEqual(original_manifest, outside_manifest.read_bytes())
+            self.assertEqual([], list(outside_report.iterdir()))
+            self.assertEqual([], list(outside_visual.iterdir()))
+
     def test_artifact_only_rejects_ambiguous_slug_and_empty_selection(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "repo"
@@ -94,6 +141,29 @@ class BilingualBackfillTests(unittest.TestCase):
             )
             with self.assertRaisesRegex(ValueError, "did not match"):
                 submission_dirs(root, ["missing"])
+
+    def test_artifact_only_resolves_paths_below_symlinked_ancestor(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            real = workspace / "real"
+            alias = workspace / "alias"
+            real.mkdir()
+            try:
+                alias.symlink_to(real, target_is_directory=True)
+            except OSError as exc:
+                self.skipTest(f"symlinks unavailable: {exc}")
+            root = alias / "repo"
+            first = root / "submissions" / "alice" / "same-slug"
+            second = root / "submissions" / "bob" / "same-slug"
+            for package in (first, second):
+                package.mkdir(parents=True)
+                (package / "proposal.md").write_text("proposal", encoding="utf-8")
+
+            self.assertEqual(
+                [first], submission_dirs(root, ["submissions/alice/same-slug"])
+            )
+            self.assertEqual([first], submission_dirs(root, [str(first)]))
+            self.assertEqual([first], submission_dirs(root, [str(first.resolve())]))
 
     def test_front_matter_parser_accepts_utf8_bom(self) -> None:
         front, body = parse_front_matter("\ufeff---\nlanguage: zh\n---\n正文\n")


### PR DESCRIPTION
## Summary

- exclude symlinked owner directories, package directories, `proposal.md` paths, and packages containing any internal file or directory symlink from bilingual artifact backfill discovery
- fail explicitly when the `submissions/` root itself is a symbolic link
- make bare `--only` slugs fail when they identify multiple owners, while exact repository-relative and absolute paths select one package
- compare exact selections by resolved identity so callers below a symlinked ancestor still receive the original discovered path

## Reproduction

`backfill_bilingual_artifacts.py` discovers packages and then writes localized figures, HTML, PDFs, proposal image references, and manifest hashes below each selected package.

Before this change:

- a symlinked package under `submissions/` was discovered and maintainer writes followed it outside the repository;
- a normal package containing a symlinked `manifest.json`, `report/`, or `visual/` path could also redirect writes outside the repository;
- a bare slug shared by multiple owners selected every matching package;
- the documented repository-relative `--only submissions/<owner>/<slug>` form silently selected nothing;
- exact relative and absolute selections failed when the caller's repository path had a symlinked ancestor.

## Change

- require the discovery path from `submissions/` through `proposal.md` to be symlink-free and contained;
- walk each discovered package with `followlinks=False` and reject it if any file or directory entry is a symlink, failing closed on inspection errors;
- reject a symlinked `submissions/` root before discovery;
- resolve all discovered package identities once for exact relative/absolute matching while returning paths in the caller's original coordinate system;
- reject ambiguous bare slugs and empty selections before OCR or translation initialization.

The deterministic intake validator already rejects submission-package symlinks. This applies the same boundary before this maintainer-only artifact backfill performs writes.

## Review follow-up

This revision addresses both findings from the review on the previous exact head:

- internal package symlinks no longer allow manifest or output-directory write-through;
- relative and absolute `--only` paths now work below symlinked ancestors without changing returned path objects.

## Validation

- 5 focused discovery, write-through, ambiguity, and symlink-ancestor regressions passed
- `python3 -m unittest tests.test_bilingual_backfill -v`: 27 run, 26 passed; the existing Arial Unicode font fixture remains the only environment-dependent error tracked by #808
- `python3 -m py_compile scripts/backfill_bilingual_artifacts.py tests/test_bilingual_backfill.py`
- `git diff --check upstream/main...HEAD`

Rebased onto canonical main `f1a58798c1cf226036345bd4c42fda568e185b9c`. Current exact head: `ad8b86dfec0c8bd9a3429c847c3df6146a3b48c3`.

## Related work

- #2226 applies the same containment contract to the first-pass proposal translation script.
- #2221 changes manifest freshness and artifact roles in this sibling script; it does not change discovery.
- #2244 changes this script's documentation only.
