### PR TITLE
fix: contain proposal renderer outputs

### DIFF
--- a/scripts/render_proposal_html.py
+++ b/scripts/render_proposal_html.py
@@ -47,6 +47,8 @@ import argparse
 import html
 import os
 import re
+import stat
+import tempfile
 from pathlib import Path, PurePosixPath
 
 
@@ -108,6 +110,77 @@ def normalize_image_src(submission_dir: Path, raw_src: str) -> str:
     if not image_path.exists():
         raise ValueError(f"image source is missing: {raw_src}")
     return "../" + pure.as_posix()
+
+
+def contained_output_path(submission_dir: Path, raw_path: str) -> Path:
+    if "\\" in raw_path:
+        raise ValueError(f"output must be a relative path inside the submission: {raw_path}")
+    pure = PurePosixPath(raw_path)
+    if (
+        not raw_path
+        or pure.is_absolute()
+        or not pure.parts
+        or ".." in pure.parts
+        or pure.as_posix() != raw_path
+        or pure.suffix.lower() != ".html"
+    ):
+        raise ValueError(f"output must be a relative path inside the submission: {raw_path}")
+    path = submission_dir.joinpath(*pure.parts)
+    current = submission_dir
+    for part in pure.parts:
+        current /= part
+        if current.is_symlink():
+            raise ValueError(f"output path must not use symbolic links: {raw_path}")
+    if not path.resolve().is_relative_to(submission_dir):
+        raise ValueError(f"output must stay inside the submission: {raw_path}")
+    return path
+
+
+def render_inputs(submission_dir: Path, proposal_paths: list[Path]) -> list[Path]:
+    inputs = list(proposal_paths)
+    for proposal_path in proposal_paths:
+        text = proposal_path.read_text(encoding="utf-8")
+        for match in IMAGE_RE.finditer(text):
+            raw_src = match.group(2).strip()
+            clean = raw_src.split("#", 1)[0].split("?", 1)[0]
+            pure = PurePosixPath(clean)
+            if pure.is_absolute() or ".." in pure.parts:
+                continue
+            candidate = submission_dir.joinpath(*pure.parts)
+            if candidate.is_file():
+                inputs.append(candidate)
+    return inputs
+
+
+def aliases_path(path: Path, other: Path) -> bool:
+    return path.resolve() == other.resolve() or (
+        path.exists() and other.exists() and path.samefile(other)
+    )
+
+
+def write_text_atomically(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    mode = stat.S_IMODE(path.stat().st_mode) if path.exists() else 0o644
+    temporary: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=path.parent,
+            prefix=f".{path.name}-",
+            suffix=".tmp",
+            delete=False,
+            mode="w",
+            encoding="utf-8",
+        ) as handle:
+            temporary = handle.name
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    except OSError:
+        if temporary:
+            Path(temporary).unlink(missing_ok=True)
+        raise
 
 
 def render_inline(text: str, language: str = "zh") -> str:
@@ -552,17 +625,44 @@ def main() -> int:
     args = parser.parse_args()
 
     submission_dir = Path(args.submission_dir).resolve()
-    out_path = submission_dir / args.out
+    try:
+        out_path = contained_output_path(submission_dir, args.out)
+    except ValueError as exc:
+        parser.error(str(exc))
     if not (submission_dir / "proposal.md").exists():
         raise SystemExit(f"{submission_dir}/proposal.md is missing")
     primary_path = submission_dir / "proposal.md"
+    if primary_path.is_symlink():
+        parser.error(f"proposal input must not be a symbolic link: {primary_path}")
     metadata, _ = parse_front_matter(primary_path.read_text(encoding="utf-8"))
     translation_name = metadata.get("translation_file", "")
     translation_path = submission_dir / translation_name if translation_name else None
     translation_output = None
-    if translation_path and translation_path.is_file() and translation_name in {"proposal.zh.md", "proposal.en.md"}:
+    if (
+        translation_path
+        and translation_name in {"proposal.zh.md", "proposal.en.md"}
+        and translation_path.is_file()
+    ):
+        if translation_path.is_symlink():
+            parser.error(f"proposal input must not be a symbolic link: {translation_path}")
         language = "zh" if translation_name == "proposal.zh.md" else "en"
-        translation_output = submission_dir / f"report/proposal.{language}.html"
+        try:
+            translation_output = contained_output_path(
+                submission_dir, f"report/proposal.{language}.html"
+            )
+        except ValueError as exc:
+            parser.error(str(exc))
+
+    inputs = render_inputs(
+        submission_dir,
+        [primary_path, *([translation_path] if translation_output and translation_path else [])],
+    )
+    for output in [out_path, *([translation_output] if translation_output else [])]:
+        for input_path in inputs:
+            if aliases_path(output, input_path):
+                parser.error(f"output must not overwrite a rendering input: {input_path}")
+    if translation_output and aliases_path(out_path, translation_output):
+        parser.error("primary and translated reports must use distinct output paths")
 
     primary_translation_href = None
     if translation_output:
@@ -570,15 +670,20 @@ def main() -> int:
             os.path.relpath(translation_output, out_path.parent)
         ).as_posix()
     html_text = render_html(submission_dir, translation_href=primary_translation_href)
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(html_text, encoding="utf-8")
-    print(out_path)
+    translated_html = None
     if translation_output and translation_path:
-        translation_output.parent.mkdir(parents=True, exist_ok=True)
         primary_href = Path(os.path.relpath(out_path, translation_output.parent)).as_posix()
-        translation_output.write_text(
-            render_html(submission_dir, translation_name, translation_href=primary_href),
-            encoding="utf-8",
+        translated_html = render_html(
+            submission_dir,
+            translation_name,
+            translation_href=primary_href,
+        )
+    write_text_atomically(out_path, html_text)
+    print(out_path)
+    if translation_output and translated_html is not None:
+        write_text_atomically(
+            translation_output,
+            translated_html,
         )
         print(translation_output)
     return 0

--- a/tests/test_render_proposal_html.py
+++ b/tests/test_render_proposal_html.py
@@ -1,4 +1,4 @@
-import sys
+import os
 import tempfile
 import unittest
 import subprocess
@@ -300,6 +300,148 @@ English content [source:SITE-PACKAGE] [standard:STD-001] [depth:DEPTH-001]
             translated = (submission_dir / "report" / "proposal.en.html").read_text(encoding="utf-8")
             self.assertIn('href="../report/proposal.en.html"', primary)
             self.assertIn('href="../public/custom.html"', translated)
+
+    def test_cli_rejects_outputs_outside_submission_and_render_inputs(self) -> None:
+        for output_kind in ("parent", "proposal", "image", "manifest"):
+            with self.subTest(output_kind=output_kind), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                submission_dir = root / "submission"
+                figures = submission_dir / "assets" / "figures"
+                figures.mkdir(parents=True)
+                proposal = submission_dir / "proposal.md"
+                figure = figures / "overview.png"
+                figure.write_bytes(b"original image")
+                proposal.write_text(
+                    '---\ntitle: "Sample"\n---\n\n![Overview](assets/figures/overview.png)\n',
+                    encoding="utf-8",
+                )
+                output = {
+                    "parent": "../outside.html",
+                    "proposal": "proposal.md",
+                    "image": "assets/figures/overview.png",
+                    "manifest": "manifest.json",
+                }[output_kind]
+                originals = {proposal: proposal.read_bytes(), figure: figure.read_bytes()}
+
+                completed = subprocess.run(
+                    [
+                        sys.executable,
+                        str(REPO_ROOT / "scripts" / "render_proposal_html.py"),
+                        str(submission_dir),
+                        "--out",
+                        output,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+
+                self.assertNotEqual(0, completed.returncode)
+                self.assertFalse((root / "outside.html").exists())
+                for path, original in originals.items():
+                    self.assertEqual(original, path.read_bytes())
+
+    def test_cli_rejects_symlinked_output_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission_dir = root / "submission"
+            submission_dir.mkdir()
+            (submission_dir / "proposal.md").write_text("# Sample\n", encoding="utf-8")
+            outside = root / "outside"
+            outside.mkdir()
+            (submission_dir / "report").symlink_to(outside, target_is_directory=True)
+
+            completed = subprocess.run(
+                [sys.executable, str(REPO_ROOT / "scripts" / "render_proposal_html.py"), str(submission_dir)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn("output path must not use symbolic links", completed.stderr)
+            self.assertEqual([], list(outside.iterdir()))
+
+    def test_cli_replaces_hardlinked_output_without_changing_peer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission_dir = root / "submission"
+            report = submission_dir / "report"
+            report.mkdir(parents=True)
+            (submission_dir / "proposal.md").write_text("# Sample\n", encoding="utf-8")
+            peer = root / "peer.html"
+            peer.write_text("peer content\n", encoding="utf-8")
+            output = report / "proposal.html"
+            os.link(peer, output)
+
+            completed = subprocess.run(
+                [sys.executable, str(REPO_ROOT / "scripts" / "render_proposal_html.py"), str(submission_dir)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+            self.assertEqual("peer content\n", peer.read_text(encoding="utf-8"))
+            self.assertIn("<!doctype html>", output.read_text(encoding="utf-8"))
+
+    def test_cli_rejects_symlinked_proposal_input(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission_dir = root / "submission"
+            submission_dir.mkdir()
+            outside = root / "outside.md"
+            outside.write_text("# External\n", encoding="utf-8")
+            (submission_dir / "proposal.md").symlink_to(outside)
+
+            completed = subprocess.run(
+                [sys.executable, str(REPO_ROOT / "scripts" / "render_proposal_html.py"), str(submission_dir)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn("proposal input must not be a symbolic link", completed.stderr)
+            self.assertEqual("# External\n", outside.read_text(encoding="utf-8"))
+
+    def test_cli_can_regenerate_default_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission_dir = Path(tmp)
+            (submission_dir / "proposal.md").write_text("# Sample\n", encoding="utf-8")
+            command = [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "render_proposal_html.py"),
+                str(submission_dir),
+            ]
+
+            first = subprocess.run(command, capture_output=True, text=True, check=False)
+            second = subprocess.run(command, capture_output=True, text=True, check=False)
+
+            self.assertEqual(0, first.returncode, first.stdout + first.stderr)
+            self.assertEqual(0, second.returncode, second.stdout + second.stderr)
+            self.assertIn(
+                "<!doctype html>",
+                (submission_dir / "report" / "proposal.html").read_text(encoding="utf-8"),
+            )
+
+    def test_cli_ignores_missing_translation_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission_dir = Path(tmp)
+            (submission_dir / "proposal.md").write_text(
+                '---\ntitle: "Sample"\ntranslation_file: "missing.md"\n---\n# Sample\n',
+                encoding="utf-8",
+            )
+
+            completed = subprocess.run(
+                [sys.executable, str(REPO_ROOT / "scripts" / "render_proposal_html.py"), str(submission_dir)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+            self.assertTrue((submission_dir / "report" / "proposal.html").is_file())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- require `--out` to be a normalized relative `.html` path inside the submission
- reject output aliases to proposal Markdown, its validated translation, or locally referenced image inputs
- reject symbolic links in proposal inputs and output path components
- publish primary and translated reports through same-directory atomic replacement, preserving existing modes and avoiding hardlink write-through
- render both bilingual documents successfully before replacing either report

## Reproduction

On current main, `render_proposal_html.py SUBMISSION --out ../outside.html` writes outside the submission even though `--out` is documented as submission-relative. `--out proposal.md` replaces the source proposal with rendered HTML, and an output path naming a proposal figure replaces that image. A pre-existing symlink below `report/` redirects the default report write outside the package; a hardlinked report mutates its peer inode.

The new boundary checks run before rendering or directory creation. Normal `report/proposal.html`, nested custom HTML output, bilingual relative links, repeated generation, and missing optional translations remain supported.

## Validation

- `python3 -m unittest tests.test_render_proposal_html tests.test_agent_scaffold_and_self_check` (46 passed, 22 dependency skips)
- `python3 -m py_compile scripts/render_proposal_html.py tests/test_render_proposal_html.py`
- `git diff --check`

## Related work

- #1265 contains bilingual labels and image-source containment; it does not constrain report outputs.
- #2087 changes malformed text/image handling; it does not constrain report outputs.
- #2244 changes this script's documentation and CLI help only.
