### PR TITLE
test: add deterministic review load fixture generator

### DIFF
--- a/docs/review-load-fixtures.md
+++ b/docs/review-load-fixtures.md
@@ -1,0 +1,21 @@
+# Review-load fixtures
+
+Use `tools/generate_commit_review_fixture.sh` to exercise automated review
+systems with a deterministic linear history. The default creates 2,000 commits
+in an isolated repository; it does not modify the Haidian checkout.
+
+```bash
+tools/generate_commit_review_fixture.sh 2000 ./review-fixture review/load-test
+```
+
+To model a pull request, provide a clean local repository as the fourth
+argument. Its tracked files become one synthetic base commit, followed by the
+requested commit range:
+
+```bash
+tools/generate_commit_review_fixture.sh 2000 ./review-fixture review/load-test /path/to/base-repository
+```
+
+The generated `summary.txt` records the base and head SHAs. `commits.tsv` is an
+oldest-first inventory, and `review-fixture.bundle` can be imported without a
+network connection using the `clone_command` from the summary.

--- a/docs/review-load-fixtures.md
+++ b/docs/review-load-fixtures.md
@@ -2,10 +2,11 @@
 
 Use `tools/generate_commit_review_fixture.sh` to exercise automated review
 systems with a deterministic linear history. The default creates 2,000 commits
-in an isolated repository; it does not modify the Haidian checkout.
+in an isolated repository. Place the output outside the Haidian checkout to
+keep generated files out of `git status`:
 
 ```bash
-tools/generate_commit_review_fixture.sh 2000 ./review-fixture review/load-test
+tools/generate_commit_review_fixture.sh 2000 /tmp/haidian-review-fixture review/load-test
 ```
 
 To model a pull request, provide a clean local repository as the fourth
@@ -13,9 +14,11 @@ argument. Its tracked files become one synthetic base commit, followed by the
 requested commit range:
 
 ```bash
-tools/generate_commit_review_fixture.sh 2000 ./review-fixture review/load-test /path/to/base-repository
+tools/generate_commit_review_fixture.sh 2000 /tmp/haidian-review-pr-fixture review/load-test /path/to/base-repository
 ```
 
-The generated `summary.txt` records the base and head SHAs. `commits.tsv` is an
+The generated `summary.txt` records the head SHA and, in pull-request mode, the
+base SHA. Standalone fixtures use `base=standalone`. `commits.tsv` is an
 oldest-first inventory, and `review-fixture.bundle` can be imported without a
-network connection using the `clone_command` from the summary.
+network connection using the `clone_command` from the summary. Failed runs
+remove their partial output directory so the same command can be retried.

--- a/tests/test_generate_commit_review_fixture.py
+++ b/tests/test_generate_commit_review_fixture.py
@@ -19,11 +19,29 @@ def git(repo: Path, *args: str, env: dict[str, str] | None = None) -> subprocess
     return run(["git", "-C", str(repo), *args], env=env)
 
 
-def init_repo(path: Path) -> None:
+def controlled_git_env(root: Path) -> dict[str, str]:
+    global_config = root / "global.gitconfig"
+    global_config.write_text("", encoding="utf-8")
+    return {**os.environ, "GIT_CONFIG_GLOBAL": str(global_config), "GIT_CONFIG_NOSYSTEM": "1"}
+
+
+def install_failing_hook(root: Path, env: dict[str, str]) -> None:
+    hooks = root / "hooks"
+    hooks.mkdir()
+    pre_commit = hooks / "pre-commit"
+    pre_commit.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    pre_commit.chmod(0o755)
+    subprocess.run(
+        ["git", "config", "--file", env["GIT_CONFIG_GLOBAL"], "core.hooksPath", str(hooks)],
+        check=True,
+    )
+
+
+def init_repo(path: Path, *, env: dict[str, str]) -> None:
     path.mkdir()
-    subprocess.run(["git", "-C", str(path), "init", "--quiet", "--initial-branch=main"], check=True)
-    subprocess.run(["git", "-C", str(path), "config", "user.name", "Fixture Base"], check=True)
-    subprocess.run(["git", "-C", str(path), "config", "user.email", "base@example.invalid"], check=True)
+    subprocess.run(["git", "-C", str(path), "init", "--quiet", "--initial-branch=main"], check=True, env=env)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "Fixture Base"], check=True, env=env)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "base@example.invalid"], check=True, env=env)
 
 
 def read_summary(path: Path) -> dict[str, str]:
@@ -33,8 +51,11 @@ def read_summary(path: Path) -> dict[str, str]:
 class CommitReviewFixtureTests(unittest.TestCase):
     def test_standalone_history_and_bundle_are_self_contained(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            output = Path(tmp) / "fixture"
-            completed = run([str(SCRIPT), "3", str(output), "review/test"])
+            root = Path(tmp)
+            env = controlled_git_env(root)
+            install_failing_hook(root, env)
+            output = root / "fixture"
+            completed = run([str(SCRIPT), "3", str(output), "review/test"], env=env)
             self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
             summary = read_summary(output / "summary.txt")
             self.assertEqual(summary["base"], "standalone")
@@ -51,21 +72,22 @@ class CommitReviewFixtureTests(unittest.TestCase):
     def test_base_snapshot_uses_head_tree_with_sparse_and_ignored_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
+            env = controlled_git_env(root)
             base = root / "base"
-            init_repo(base)
+            init_repo(base, env=env)
             (base / "keep").mkdir()
             (base / "drop").mkdir()
             (base / "keep" / "k.txt").write_text("keep\n", encoding="utf-8")
             (base / "drop" / "d.txt").write_text("drop\n", encoding="utf-8")
             (base / "tracked.log").write_text("tracked\n", encoding="utf-8")
-            (base / ".gitignore").write_text("*.log\n", encoding="utf-8")
-            subprocess.run(["git", "-C", str(base), "add", "--all", "--force"], check=True)
-            subprocess.run(["git", "-C", str(base), "commit", "--quiet", "-m", "base"], check=True)
-            subprocess.run(["git", "-C", str(base), "sparse-checkout", "set", "keep"], check=True)
+            (base / ".gitignore").write_text("*.log\n*.jsonl\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(base), "add", "--all", "--force"], check=True, env=env)
+            subprocess.run(["git", "-C", str(base), "commit", "--quiet", "-m", "base"], check=True, env=env)
+            subprocess.run(["git", "-C", str(base), "sparse-checkout", "set", "keep"], check=True, env=env)
 
-            global_config = root / "global.gitconfig"
+            global_config = Path(env["GIT_CONFIG_GLOBAL"])
             global_config.write_text("[commit]\n\tgpgSign = true\n[gpg]\n\tprogram = false\n", encoding="utf-8")
-            env = {**os.environ, "GIT_CONFIG_GLOBAL": str(global_config)}
+            install_failing_hook(root, env)
             output = root / "fixture"
             completed = run([str(SCRIPT), "3", str(output), "review/test", str(base)], env=env)
             self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
@@ -77,11 +99,14 @@ class CommitReviewFixtureTests(unittest.TestCase):
             self.assertIn("drop/d.txt", actual)
             self.assertIn("tracked.log", actual)
             self.assertEqual(git(output / "repo", "rev-list", "--count", f'{summary["base"]}..HEAD').stdout.strip(), "3")
+            self.assertEqual((output / "repo" / ".review-load-fixture" / "audit-events.jsonl").read_text().count("\n"), 3)
 
     def test_empty_count_is_rejected_without_creating_output(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            output = Path(tmp) / "fixture"
-            completed = run([str(SCRIPT), "", str(output)])
+            root = Path(tmp)
+            env = controlled_git_env(root)
+            output = root / "fixture"
+            completed = run([str(SCRIPT), "", str(output)], env=env)
             self.assertEqual(completed.returncode, 2)
             self.assertIn("COUNT must be a positive integer", completed.stderr)
             self.assertFalse(output.exists())
@@ -89,18 +114,19 @@ class CommitReviewFixtureTests(unittest.TestCase):
     def test_copy_failure_removes_partial_output(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
+            env = controlled_git_env(root)
             base = root / "base"
-            init_repo(base)
+            init_repo(base, env=env)
             (base / "tracked.txt").write_text("tracked\n", encoding="utf-8")
-            subprocess.run(["git", "-C", str(base), "add", "tracked.txt"], check=True)
-            subprocess.run(["git", "-C", str(base), "commit", "--quiet", "-m", "base"], check=True)
+            subprocess.run(["git", "-C", str(base), "add", "tracked.txt"], check=True, env=env)
+            subprocess.run(["git", "-C", str(base), "commit", "--quiet", "-m", "base"], check=True, env=env)
 
             fake_bin = root / "bin"
             fake_bin.mkdir()
             fake_tar = fake_bin / "tar"
             fake_tar.write_text("#!/bin/sh\nexit 44\n", encoding="utf-8")
             fake_tar.chmod(0o755)
-            env = {**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"}
+            env = {**env, "PATH": f"{fake_bin}:{os.environ['PATH']}"}
             output = root / "fixture"
             completed = run([str(SCRIPT), "3", str(output), "review/test", str(base)], env=env)
             self.assertNotEqual(completed.returncode, 0)

--- a/tests/test_generate_commit_review_fixture.py
+++ b/tests/test_generate_commit_review_fixture.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "tools" / "generate_commit_review_fixture.sh"
+
+
+def run(command: list[str], *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, text=True, capture_output=True, check=False, env=env)
+
+
+def git(repo: Path, *args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return run(["git", "-C", str(repo), *args], env=env)
+
+
+def init_repo(path: Path) -> None:
+    path.mkdir()
+    subprocess.run(["git", "-C", str(path), "init", "--quiet", "--initial-branch=main"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "Fixture Base"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "base@example.invalid"], check=True)
+
+
+def read_summary(path: Path) -> dict[str, str]:
+    return dict(line.split("=", 1) for line in path.read_text(encoding="utf-8").splitlines())
+
+
+class CommitReviewFixtureTests(unittest.TestCase):
+    def test_standalone_history_and_bundle_are_self_contained(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "fixture"
+            completed = run([str(SCRIPT), "3", str(output), "review/test"])
+            self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+            summary = read_summary(output / "summary.txt")
+            self.assertEqual(summary["base"], "standalone")
+            self.assertEqual(summary["commits"], "3")
+            self.assertEqual(summary["merges"], "0")
+            self.assertTrue(summary["clone_command"].endswith(" review-fixture-clone"))
+            self.assertEqual(len((output / "commits.tsv").read_text().splitlines()), 3)
+
+            clone = Path(tmp) / "clone"
+            cloned = run(["git", "clone", "--quiet", "-b", "review/test", str(output / "review-fixture.bundle"), str(clone)])
+            self.assertEqual(cloned.returncode, 0, cloned.stdout + cloned.stderr)
+            self.assertEqual(git(clone, "rev-list", "--count", "HEAD").stdout.strip(), "3")
+
+    def test_base_snapshot_uses_head_tree_with_sparse_and_ignored_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / "base"
+            init_repo(base)
+            (base / "keep").mkdir()
+            (base / "drop").mkdir()
+            (base / "keep" / "k.txt").write_text("keep\n", encoding="utf-8")
+            (base / "drop" / "d.txt").write_text("drop\n", encoding="utf-8")
+            (base / "tracked.log").write_text("tracked\n", encoding="utf-8")
+            (base / ".gitignore").write_text("*.log\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(base), "add", "--all", "--force"], check=True)
+            subprocess.run(["git", "-C", str(base), "commit", "--quiet", "-m", "base"], check=True)
+            subprocess.run(["git", "-C", str(base), "sparse-checkout", "set", "keep"], check=True)
+
+            global_config = root / "global.gitconfig"
+            global_config.write_text("[commit]\n\tgpgSign = true\n[gpg]\n\tprogram = false\n", encoding="utf-8")
+            env = {**os.environ, "GIT_CONFIG_GLOBAL": str(global_config)}
+            output = root / "fixture"
+            completed = run([str(SCRIPT), "3", str(output), "review/test", str(base)], env=env)
+            self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+
+            summary = read_summary(output / "summary.txt")
+            expected = git(base, "ls-tree", "-r", "--name-only", "HEAD").stdout.splitlines()
+            actual = git(output / "repo", "ls-tree", "-r", "--name-only", summary["base"]).stdout.splitlines()
+            self.assertEqual(actual, expected)
+            self.assertIn("drop/d.txt", actual)
+            self.assertIn("tracked.log", actual)
+            self.assertEqual(git(output / "repo", "rev-list", "--count", f'{summary["base"]}..HEAD').stdout.strip(), "3")
+
+    def test_empty_count_is_rejected_without_creating_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "fixture"
+            completed = run([str(SCRIPT), "", str(output)])
+            self.assertEqual(completed.returncode, 2)
+            self.assertIn("COUNT must be a positive integer", completed.stderr)
+            self.assertFalse(output.exists())
+
+    def test_copy_failure_removes_partial_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / "base"
+            init_repo(base)
+            (base / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(base), "add", "tracked.txt"], check=True)
+            subprocess.run(["git", "-C", str(base), "commit", "--quiet", "-m", "base"], check=True)
+
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            fake_tar = fake_bin / "tar"
+            fake_tar.write_text("#!/bin/sh\nexit 44\n", encoding="utf-8")
+            fake_tar.chmod(0o755)
+            env = {**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"}
+            output = root / "fixture"
+            completed = run([str(SCRIPT), "3", str(output), "review/test", str(base)], env=env)
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertFalse(output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/generate_commit_review_fixture.sh
+++ b/tools/generate_commit_review_fixture.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: generate_commit_review_fixture.sh [COUNT] [OUTPUT_DIR] [BRANCH] [BASE_REPO]
+
+Generate a self-contained Git history for automated review load tests.
+COUNT defaults to 2000. BASE_REPO, when supplied, is copied as one synthetic
+base commit and COUNT commits are added on top, matching a pull-request range.
+The output contains repo/, commits.tsv, review-fixture.bundle, and summary.txt.
+EOF
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then usage; exit 0; fi
+count=${1:-2000}
+output_dir=${2:-commit-review-fixture}
+branch=${3:-review-load-test}
+base_repo=${4:-}
+
+[[ $count =~ ^[1-9][0-9]*$ ]] || { printf 'error: COUNT must be a positive integer\n' >&2; exit 2; }
+[[ ! -e $output_dir ]] || { printf 'error: output path already exists: %s\n' "$output_dir" >&2; exit 2; }
+git check-ref-format --branch "$branch" >/dev/null 2>&1 || { printf 'error: invalid branch name: %s\n' "$branch" >&2; exit 2; }
+
+mkdir -p "$output_dir"
+output_dir=$(cd "$output_dir" && pwd)
+if [[ -n $base_repo ]]; then
+  git -C "$base_repo" rev-parse --verify HEAD >/dev/null
+  [[ -z $(git -C "$base_repo" status --porcelain) ]] || { printf 'error: BASE_REPO worktree must be clean\n' >&2; exit 2; }
+  mkdir "$output_dir/repo"
+  repo="$output_dir/repo"
+  git -C "$repo" init --quiet --initial-branch=fixture-base
+  (
+    cd "$base_repo"
+    git ls-files -z | tar --null -T - -cf -
+  ) | tar -xf - -C "$repo"
+  git -C "$repo" config user.name "Review Load Fixture"
+  git -C "$repo" config user.email "fixture@example.invalid"
+  git -C "$repo" add --all
+  GIT_AUTHOR_DATE='@1704067199 +0000' GIT_COMMITTER_DATE='@1704067199 +0000' \
+    git -C "$repo" commit --quiet -m 'fixture: record review base'
+  base_sha=$(git -C "$repo" rev-parse HEAD)
+  git -C "$repo" switch --quiet -c "$branch"
+else
+  mkdir "$output_dir/repo"
+  repo="$output_dir/repo"
+  git -C "$repo" init --quiet --initial-branch="$branch"
+  base_sha=
+fi
+git -C "$repo" config user.name "Review Load Fixture"
+git -C "$repo" config user.email "fixture@example.invalid"
+git -C "$repo" config commit.gpgSign false
+git -C "$repo" config gc.auto 0
+
+fixture_dir="$repo/.review-load-fixture"
+mkdir "$fixture_dir"
+printf '# Commit Review Fixture\n\nSynthetic review-load history.\n' > "$fixture_dir/README.md"
+events="$fixture_dir/audit-events.jsonl"
+width=${#count}
+for ((index = 1; index <= count; index++)); do
+  printf -v sequence "%0${width}d" "$index"
+  printf '{"sequence":%d,"fixture":"review-load-test","record":"%s"}\n' "$index" "$sequence" >> "$events"
+  git -C "$repo" add .review-load-fixture
+  timestamp=$((1704067200 + index))
+  GIT_AUTHOR_DATE="@$timestamp +0000" GIT_COMMITTER_DATE="@$timestamp +0000" \
+    git -C "$repo" commit --quiet -m "fixture: add audit event $sequence of $count"
+done
+
+if [[ -n $base_sha ]]; then range="$base_sha..HEAD"; expected_roots=0; else range=HEAD; expected_roots=1; fi
+actual=$(git -C "$repo" rev-list --count "$range")
+roots=$(git -C "$repo" rev-list --max-parents=0 --count "$range")
+merges=$(git -C "$repo" rev-list --min-parents=2 --count "$range")
+[[ $actual -eq $count && $roots -eq $expected_roots && $merges -eq 0 && -z $(git -C "$repo" status --porcelain) ]] || exit 1
+
+git -C "$repo" log --reverse --format='%H%x09%aI%x09%s' "$range" > "$output_dir/commits.tsv"
+git -C "$repo" bundle create "$output_dir/review-fixture.bundle" "$branch" >/dev/null
+git -C "$repo" bundle verify "$output_dir/review-fixture.bundle" >/dev/null
+head=$(git -C "$repo" rev-parse HEAD)
+cat > "$output_dir/summary.txt" <<EOF
+repository=$repo
+branch=$branch
+base=${base_sha:-standalone}
+commits=$actual
+roots=$roots
+merges=$merges
+working_tree=clean
+head=$head
+bundle=$output_dir/review-fixture.bundle
+inventory=$output_dir/commits.tsv
+clone_command=git clone -b $branch $output_dir/review-fixture.bundle review-fixture
+EOF
+printf 'Generated %d commits in %s\nBundle: %s\nInventory: %s\n' "$actual" "$repo" "$output_dir/review-fixture.bundle" "$output_dir/commits.tsv"

--- a/tools/generate_commit_review_fixture.sh
+++ b/tools/generate_commit_review_fixture.sh
@@ -43,6 +43,7 @@ if [[ -n $base_repo ]]; then
   git -C "$repo" config user.name "Review Load Fixture"
   git -C "$repo" config user.email "fixture@example.invalid"
   git -C "$repo" config commit.gpgSign false
+  git -C "$repo" config core.hooksPath "$repo/.git/disabled-hooks"
   git -C "$repo" config gc.auto 0
   git -C "$base_repo" archive --format=tar HEAD | tar -xf - -C "$repo"
   git -C "$repo" add --all --force
@@ -59,6 +60,7 @@ fi
 git -C "$repo" config user.name "Review Load Fixture"
 git -C "$repo" config user.email "fixture@example.invalid"
 git -C "$repo" config commit.gpgSign false
+git -C "$repo" config core.hooksPath "$repo/.git/disabled-hooks"
 git -C "$repo" config gc.auto 0
 
 fixture_dir="$repo/.review-load-fixture"
@@ -69,7 +71,7 @@ width=${#count}
 for ((index = 1; index <= count; index++)); do
   printf -v sequence "%0${width}d" "$index"
   printf '{"sequence":%d,"fixture":"review-load-test","record":"%s"}\n' "$index" "$sequence" >> "$events"
-  git -C "$repo" add .review-load-fixture
+  git -C "$repo" add --force .review-load-fixture
   timestamp=$((1704067200 + index))
   GIT_AUTHOR_DATE="@$timestamp +0000" GIT_COMMITTER_DATE="@$timestamp +0000" \
     git -C "$repo" commit --quiet --no-gpg-sign -m "fixture: add audit event $sequence of $count"

--- a/tools/generate_commit_review_fixture.sh
+++ b/tools/generate_commit_review_fixture.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 
 usage() {
   cat <<'EOF'
@@ -13,7 +13,7 @@ EOF
 }
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then usage; exit 0; fi
-count=${1:-2000}
+count=${1-2000}
 output_dir=${2:-commit-review-fixture}
 branch=${3:-review-load-test}
 base_repo=${4:-}
@@ -21,24 +21,33 @@ base_repo=${4:-}
 [[ $count =~ ^[1-9][0-9]*$ ]] || { printf 'error: COUNT must be a positive integer\n' >&2; exit 2; }
 [[ ! -e $output_dir ]] || { printf 'error: output path already exists: %s\n' "$output_dir" >&2; exit 2; }
 git check-ref-format --branch "$branch" >/dev/null 2>&1 || { printf 'error: invalid branch name: %s\n' "$branch" >&2; exit 2; }
-
-mkdir -p "$output_dir"
-output_dir=$(cd "$output_dir" && pwd)
 if [[ -n $base_repo ]]; then
   git -C "$base_repo" rev-parse --verify HEAD >/dev/null
   [[ -z $(git -C "$base_repo" status --porcelain) ]] || { printf 'error: BASE_REPO worktree must be clean\n' >&2; exit 2; }
+fi
+
+mkdir -p "$output_dir"
+output_dir=$(cd "$output_dir" && pwd)
+cleanup_output() {
+  status=${1:-$?}
+  trap - ERR
+  rm -rf -- "$output_dir"
+  exit "$status"
+}
+trap cleanup_output ERR
+
+if [[ -n $base_repo ]]; then
   mkdir "$output_dir/repo"
   repo="$output_dir/repo"
   git -C "$repo" init --quiet --initial-branch=fixture-base
-  (
-    cd "$base_repo"
-    git ls-files -z | tar --null -T - -cf -
-  ) | tar -xf - -C "$repo"
   git -C "$repo" config user.name "Review Load Fixture"
   git -C "$repo" config user.email "fixture@example.invalid"
-  git -C "$repo" add --all
+  git -C "$repo" config commit.gpgSign false
+  git -C "$repo" config gc.auto 0
+  git -C "$base_repo" archive --format=tar HEAD | tar -xf - -C "$repo"
+  git -C "$repo" add --all --force
   GIT_AUTHOR_DATE='@1704067199 +0000' GIT_COMMITTER_DATE='@1704067199 +0000' \
-    git -C "$repo" commit --quiet -m 'fixture: record review base'
+    git -C "$repo" commit --quiet --no-gpg-sign -m 'fixture: record review base'
   base_sha=$(git -C "$repo" rev-parse HEAD)
   git -C "$repo" switch --quiet -c "$branch"
 else
@@ -63,14 +72,17 @@ for ((index = 1; index <= count; index++)); do
   git -C "$repo" add .review-load-fixture
   timestamp=$((1704067200 + index))
   GIT_AUTHOR_DATE="@$timestamp +0000" GIT_COMMITTER_DATE="@$timestamp +0000" \
-    git -C "$repo" commit --quiet -m "fixture: add audit event $sequence of $count"
+    git -C "$repo" commit --quiet --no-gpg-sign -m "fixture: add audit event $sequence of $count"
 done
 
 if [[ -n $base_sha ]]; then range="$base_sha..HEAD"; expected_roots=0; else range=HEAD; expected_roots=1; fi
 actual=$(git -C "$repo" rev-list --count "$range")
 roots=$(git -C "$repo" rev-list --max-parents=0 --count "$range")
 merges=$(git -C "$repo" rev-list --min-parents=2 --count "$range")
-[[ $actual -eq $count && $roots -eq $expected_roots && $merges -eq 0 && -z $(git -C "$repo" status --porcelain) ]] || exit 1
+if [[ $actual -ne $count || $roots -ne $expected_roots || $merges -ne 0 || -n $(git -C "$repo" status --porcelain) ]]; then
+  printf 'error: generated repository failed verification\n' >&2
+  cleanup_output 1
+fi
 
 git -C "$repo" log --reverse --format='%H%x09%aI%x09%s' "$range" > "$output_dir/commits.tsv"
 git -C "$repo" bundle create "$output_dir/review-fixture.bundle" "$branch" >/dev/null
@@ -87,6 +99,7 @@ working_tree=clean
 head=$head
 bundle=$output_dir/review-fixture.bundle
 inventory=$output_dir/commits.tsv
-clone_command=git clone -b $branch $output_dir/review-fixture.bundle review-fixture
+clone_command=git clone -b $branch $output_dir/review-fixture.bundle review-fixture-clone
 EOF
+trap - ERR
 printf 'Generated %d commits in %s\nBundle: %s\nInventory: %s\n' "$actual" "$repo" "$output_dir/review-fixture.bundle" "$output_dir/commits.tsv"


### PR DESCRIPTION
## Summary

Add a deterministic, isolated Git fixture generator for automated review-system load testing.

The tool:

- defaults to exactly 2,000 linear commits;
- supports a clean local base repository to model a `base..head` pull-request range;
- emits an oldest-first `commits.tsv` inventory and a self-contained Git bundle;
- verifies commit count, merge count, root count, clean worktree, and bundle integrity;
- leaves the Haidian checkout and project history untouched.

The generated synthetic commits are test data and are not included in this PR.

## Verification

- `bash -n tools/generate_commit_review_fixture.sh`
- standalone 3-commit fixture: passed
- base-plus-3-commit PR-range fixture: passed
- bundle clone and range count: passed
- invalid count exits with status 2
- `git diff --check`: passed
