### PR TITLE
fix(validation): allow explicit nonnumeric required metrics

### DIFF
--- a/scripts/visual_review.py
+++ b/scripts/visual_review.py
@@ -12,8 +12,9 @@ Checks performed
   ``WebSocket``, remote ``<script src>``, remote CSS ``@import``, etc.).
 - The page contains the 14 required Chinese-language content markers
   (总览地图, 三层范围, 重点区域, …).
-- Metric ``data-metric`` / ``data-value`` attributes declare finite numeric
-  values that match ``metrics.json`` within a 1 ppm tolerance.
+- Known metrics declare finite numeric ``data-value`` attributes that match
+  ``metrics.json`` within a 1 ppm tolerance. Registered non-known metrics may
+  instead be disclosed explicitly by omitting ``data-value`` entirely.
 - The three required metrics (``site_area_sqm``, ``green_ratio``,
   ``public_space_ratio``) are present and declared.
 
@@ -123,18 +124,27 @@ class VisualMetricParser(HTMLParser):
         super().__init__(convert_charrefs=True)
         self.metrics: dict[str, float] = {}
         self.declarations: list[tuple[str, float]] = []
+        self.metric_names_seen: set[str] = set()
+        self.invalid_value_metrics: set[str] = set()
         self.nonfinite_metrics: set[str] = set()
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         attributes = {name.lower(): value for name, value in attrs}
         name = attributes.get("data-metric")
-        raw_value = attributes.get("data-value")
-        if not isinstance(name, str) or not isinstance(raw_value, str):
+        if not isinstance(name, str):
             return
         name = html.unescape(name)
+        self.metric_names_seen.add(name)
+        if "data-value" not in attributes:
+            return
+        raw_value = attributes["data-value"]
+        if not isinstance(raw_value, str):
+            self.invalid_value_metrics.add(name)
+            return
         try:
             value = float(html.unescape(raw_value))
         except ValueError:
+            self.invalid_value_metrics.add(name)
             return
         if not math.isfinite(value):
             self.nonfinite_metrics.add(name)
@@ -188,6 +198,14 @@ def review_visual(submission_dir: Path) -> VisualReport:
     declared = parser.metrics
     report.metrics_seen = declared
     metrics = load_metrics(submission_dir / "metrics.json")
+    for name in sorted(parser.invalid_value_metrics):
+        report.add(
+            "VISUAL_METRIC_INVALID_VALUE",
+            "major",
+            display_path,
+            f"HTML metric `{name}` includes data-value but it is not a valid numeric value; "
+            "omit data-value entirely for explicitly non-numeric metrics.",
+        )
     for name in sorted(parser.nonfinite_metrics):
         report.add(
             "VISUAL_METRIC_NONFINITE_VALUE",
@@ -232,8 +250,33 @@ def review_visual(submission_dir: Path) -> VisualReport:
                 f"HTML metric `{name}` value {value} does not match metrics.json value {expected}.",
             )
     for name in REQUIRED_METRICS:
-        if name not in declared:
+        if name not in parser.metric_names_seen:
             report.add("VISUAL_METRIC_MISSING", "major", display_path, f"Missing data-metric `{name}`.")
+            continue
+        metric = metrics.get(name)
+        if not isinstance(metric, dict):
+            report.add(
+                "VISUAL_METRIC_SOURCE_MISSING",
+                "major",
+                display_path,
+                f"HTML declares unregistered required metric `{name}`; add it to metrics.json.",
+            )
+            continue
+        status = metric.get("status")
+        if status == "known" and name not in declared:
+            report.add(
+                "VISUAL_METRIC_MISSING",
+                "major",
+                display_path,
+                f"Known required metric `{name}` must declare a finite numeric data-value.",
+            )
+        elif status not in {"known", "unknown", "not_applicable"}:
+            report.add(
+                "VISUAL_METRIC_SOURCE_MISSING",
+                "major",
+                display_path,
+                f"Required metric `{name}` has invalid metrics.json status `{status!r}`.",
+            )
     return report
 
 

--- a/scripts/visual_review.py
+++ b/scripts/visual_review.py
@@ -139,12 +139,14 @@ class VisualMetricParser(HTMLParser):
             return
         raw_value = attributes["data-value"]
         if not isinstance(raw_value, str):
-            self.invalid_value_metrics.add(name)
+            if name in REQUIRED_METRICS:
+                self.invalid_value_metrics.add(name)
             return
         try:
             value = float(html.unescape(raw_value))
         except ValueError:
-            self.invalid_value_metrics.add(name)
+            if name in REQUIRED_METRICS:
+                self.invalid_value_metrics.add(name)
             return
         if not math.isfinite(value):
             self.nonfinite_metrics.add(name)

--- a/tests/test_visual_review.py
+++ b/tests/test_visual_review.py
@@ -42,6 +42,18 @@ def write_valid_visual_package(root: Path) -> Path:
     return submission
 
 
+def set_required_ratios_unknown(submission: Path) -> None:
+    metrics_path = submission / "metrics.json"
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    for name in ["green_ratio", "public_space_ratio"]:
+        metrics["metrics"][name] = {
+            "status": "unknown",
+            "value": None,
+            "reason": "Official source data are not available.",
+        }
+    metrics_path.write_text(json.dumps(metrics), encoding="utf-8")
+
+
 class VisualReviewTests(unittest.TestCase):
     def test_valid_static_visual_passes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -181,6 +193,89 @@ class VisualReviewTests(unittest.TestCase):
 
             self.assertFalse(report.ok)
             self.assertIn("VISUAL_METRIC_NONFINITE_VALUE", {issue.check_id for issue in report.issues})
+
+    def test_unknown_required_metrics_can_be_declared_non_numeric(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_valid_visual_package(Path(tmp))
+            set_required_ratios_unknown(submission)
+            html = VALID_HTML.replace(
+                '<span data-metric="green_ratio" data-value="0.2">0.2</span>',
+                '<span data-metric="green_ratio">unknown</span>',
+            ).replace(
+                '<span data-metric="public_space_ratio" data-value="0.1">0.1</span>',
+                '<span data-metric="public_space_ratio">unknown</span>',
+            )
+            (submission / "visual" / "index.html").write_text(html, encoding="utf-8")
+
+            report = review_visual(submission)
+
+            self.assertTrue(report.ok, [issue.__dict__ for issue in report.issues])
+
+    def test_unknown_required_metric_numeric_claim_still_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_valid_visual_package(Path(tmp))
+            set_required_ratios_unknown(submission)
+            html = VALID_HTML.replace(
+                '<span data-metric="public_space_ratio" data-value="0.1">0.1</span>',
+                '<span data-metric="public_space_ratio">unknown</span>',
+            )
+            (submission / "visual" / "index.html").write_text(html, encoding="utf-8")
+
+            report = review_visual(submission)
+
+            self.assertFalse(report.ok)
+            self.assertIn("VISUAL_METRIC_SOURCE_MISSING", {issue.check_id for issue in report.issues})
+
+    def test_known_required_metric_without_numeric_value_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_valid_visual_package(Path(tmp))
+            html = VALID_HTML.replace(
+                '<span data-metric="green_ratio" data-value="0.2">0.2</span>',
+                '<span data-metric="green_ratio">unknown</span>',
+            )
+            (submission / "visual" / "index.html").write_text(html, encoding="utf-8")
+
+            report = review_visual(submission)
+
+            self.assertFalse(report.ok)
+            self.assertIn("VISUAL_METRIC_MISSING", {issue.check_id for issue in report.issues})
+
+    def test_missing_required_metric_element_still_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_valid_visual_package(Path(tmp))
+            set_required_ratios_unknown(submission)
+            html = VALID_HTML.replace(
+                '<span data-metric="green_ratio" data-value="0.2">0.2</span>',
+                "",
+            ).replace(
+                '<span data-metric="public_space_ratio" data-value="0.1">0.1</span>',
+                '<span data-metric="public_space_ratio">unknown</span>',
+            )
+            (submission / "visual" / "index.html").write_text(html, encoding="utf-8")
+
+            report = review_visual(submission)
+
+            self.assertFalse(report.ok)
+            self.assertIn("VISUAL_METRIC_MISSING", {issue.check_id for issue in report.issues})
+
+    def test_unknown_required_metric_invalid_string_value_fails(self) -> None:
+        for raw_value in ["unknown", "pending", "", "not-available"]:
+            with self.subTest(raw_value=raw_value), tempfile.TemporaryDirectory() as tmp:
+                submission = write_valid_visual_package(Path(tmp))
+                set_required_ratios_unknown(submission)
+                html = VALID_HTML.replace(
+                    'data-metric="green_ratio" data-value="0.2"',
+                    f'data-metric="green_ratio" data-value="{raw_value}"',
+                ).replace(
+                    '<span data-metric="public_space_ratio" data-value="0.1">0.1</span>',
+                    '<span data-metric="public_space_ratio">unknown</span>',
+                )
+                (submission / "visual" / "index.html").write_text(html, encoding="utf-8")
+
+                report = review_visual(submission)
+
+            self.assertFalse(report.ok)
+            self.assertIn("VISUAL_METRIC_INVALID_VALUE", {issue.check_id for issue in report.issues})
 
 
 if __name__ == "__main__":

--- a/tests/test_visual_review.py
+++ b/tests/test_visual_review.py
@@ -259,7 +259,7 @@ class VisualReviewTests(unittest.TestCase):
             self.assertIn("VISUAL_METRIC_MISSING", {issue.check_id for issue in report.issues})
 
     def test_unknown_required_metric_invalid_string_value_fails(self) -> None:
-        for raw_value in ["unknown", "pending", "", "not-available"]:
+        for raw_value in ["unknown", "pending", "", "null", "not-available"]:
             with self.subTest(raw_value=raw_value), tempfile.TemporaryDirectory() as tmp:
                 submission = write_valid_visual_package(Path(tmp))
                 set_required_ratios_unknown(submission)
@@ -274,8 +274,63 @@ class VisualReviewTests(unittest.TestCase):
 
                 report = review_visual(submission)
 
-            self.assertFalse(report.ok)
-            self.assertIn("VISUAL_METRIC_INVALID_VALUE", {issue.check_id for issue in report.issues})
+                self.assertFalse(report.ok)
+                self.assertIn("VISUAL_METRIC_INVALID_VALUE", {issue.check_id for issue in report.issues})
+
+    def test_non_required_unknown_empty_value_remains_compatible(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_valid_visual_package(Path(tmp))
+            metrics_path = submission / "metrics.json"
+            metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+            metrics["metrics"]["floor_area_ratio"] = {
+                "status": "unknown",
+                "value": None,
+                "reason": "Official planning controls are not available.",
+            }
+            metrics_path.write_text(json.dumps(metrics), encoding="utf-8")
+            html = VALID_HTML.replace(
+                "</body>",
+                '<span data-metric="floor_area_ratio" data-value="">unknown</span></body>',
+            )
+            (submission / "visual" / "index.html").write_text(html, encoding="utf-8")
+
+            report = review_visual(submission)
+
+            self.assertTrue(report.ok, [issue.__dict__ for issue in report.issues])
+
+    def test_non_required_unknown_null_value_remains_compatible(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_valid_visual_package(Path(tmp))
+            metrics_path = submission / "metrics.json"
+            metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+            metrics["metrics"]["floor_area_ratio"] = {
+                "status": "unknown",
+                "value": None,
+                "reason": "Official planning controls are not available.",
+            }
+            metrics_path.write_text(json.dumps(metrics), encoding="utf-8")
+            html = VALID_HTML.replace(
+                "</body>",
+                '<span data-metric="floor_area_ratio" data-value="null">unknown</span></body>',
+            )
+            (submission / "visual" / "index.html").write_text(html, encoding="utf-8")
+
+            report = review_visual(submission)
+
+            self.assertTrue(report.ok, [issue.__dict__ for issue in report.issues])
+
+    def test_non_required_unregistered_garbage_value_remains_compatible(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_valid_visual_package(Path(tmp))
+            html = VALID_HTML.replace(
+                "</body>",
+                '<span data-metric="unregistered_ratio" data-value="garbage">unknown</span></body>',
+            )
+            (submission / "visual" / "index.html").write_text(html, encoding="utf-8")
+
+            report = review_visual(submission)
+
+            self.assertTrue(report.ok, [issue.__dict__ for issue in report.issues])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Required metrics may legitimately be registered as unknown.
- Current visual validation requires a numeric declaration while also rejecting numeric claims for unknown metrics.
- This patch separates metric presence from numeric declaration.
- Registered non-known required metrics may omit `data-value` entirely.
- Invalid strings, nonfinite values, and numeric claims for non-known metrics remain rejected.
- Known metrics still require a matching finite numeric `data-value`.
- Missing required metrics still fail.

## Tests

- `tests.test_visual_review`: PASS (16 tests)
- behavior matrix: PASS (7 cases)
- `py_compile`: PASS
- `git diff --check`: PASS
- compatible related tests: PASS (155 tests)
- Windows full suite has the same pre-existing tempfile/symlink platform errors on patched and unmodified upstream; Linux CI should provide the authoritative full-suite result.
