### PR TITLE
Fix review queue discovery across label index lag

### DIFF
--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -93,6 +93,29 @@ def gh_json(repo: str, args: list[str], *, cwd: Path) -> Any:
         raise WorkerError(f"invalid JSON from gh {' '.join(args)}") from exc
 
 
+def queued_prs(repo: str, label: str, cwd: Path) -> list[dict[str, Any]]:
+    """Return queued PRs from object labels, without GitHub search indexing."""
+    open_prs = gh_json(
+        repo,
+        [
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            "1000",
+            "--json",
+            "number,author,headRefOid,state,isDraft,mergeable,statusCheckRollup,labels",
+        ],
+        cwd=cwd,
+    )
+    return [
+        item
+        for item in open_prs
+        if any(str(entry.get("name") or "") == label for entry in item.get("labels", []))
+    ]
+
+
 def pr_file_paths(repo: str, number: int, cwd: Path) -> list[str]:
     completed = run(
         ["gh", "api", "--paginate", "--slurp", f"repos/{repo}/pulls/{number}/files"],
@@ -437,22 +460,7 @@ def main() -> int:
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
     except BlockingIOError as exc:
         raise WorkerError("another auto-review worker is already running") from exc
-    candidates = gh_json(
-        args.repo,
-        [
-            "pr",
-            "list",
-            "--state",
-            "open",
-            "--label",
-            args.label,
-            "--limit",
-            "1000",
-            "--json",
-            "number,author,headRefOid,state,isDraft,mergeable,statusCheckRollup,labels",
-        ],
-        cwd=repo_root,
-    )
+    candidates = queued_prs(args.repo, args.label, repo_root)
     selected = []
     results = []
     for candidate in sorted(candidates, key=lambda item: int(item["number"])):

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -16,6 +16,7 @@ from auto_review_queue import (  # noqa: E402
     load_cached_review,
     parse_args,
     pr_file_paths,
+    queued_prs,
     submission_dir_from_files,
 )
 from generate_submissions_data import package_sha256  # noqa: E402
@@ -100,6 +101,19 @@ class AutoReviewQueueTests(unittest.TestCase):
             ],
             cwd=ROOT,
         )
+
+    def test_queued_prs_filter_object_labels_without_search(self) -> None:
+        open_prs = [
+            {"number": 101, "labels": [{"name": "review/queued"}]},
+            {"number": 102, "labels": [{"name": "review/ci-failed"}]},
+            {"number": 103, "labels": []},
+        ]
+        with patch("auto_review_queue.gh_json", return_value=open_prs) as mocked_gh_json:
+            self.assertEqual([open_prs[0]], queued_prs("open-city-ai/haidian", "review/queued", ROOT))
+
+        args = mocked_gh_json.call_args.args[1]
+        self.assertNotIn("--label", args)
+        self.assertIn("labels", args[-1])
 
     def test_ci_state(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
## Summary

- list open PR objects without a label search qualifier
- filter the returned `labels` objects locally for `review/queued`
- preserve the existing oldest-first limit and live per-PR state recheck
- add a regression test proving discovery does not pass `--label`

Closes #2410.

## Verification

- `python3 -m unittest tests.test_auto_review_queue` (11 tests, PASS)
- `python3 -m compileall -q scripts/auto_review_queue.py tests/test_auto_review_queue.py`
- `git diff --check upstream/main...HEAD`
- live read-only comparison after the reported backlog cleared: object labels and search labels both currently returned `[2402, 2390]`; the fix removes reliance on their continued agreement