### PR TITLE
fix(validation): reject boolean GeoJSON coordinates

### DIFF
--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1004,7 +1004,12 @@ def coordinate_pair_is_valid(value: object) -> bool:
     if not isinstance(value, list) or len(value) < 2:
         return False
     lon, lat = value[0], value[1]
-    if not isinstance(lon, (int, float)) or not isinstance(lat, (int, float)):
+    if (
+        isinstance(lon, bool)
+        or isinstance(lat, bool)
+        or not isinstance(lon, (int, float))
+        or not isinstance(lat, (int, float))
+    ):
         return False
     return -180 <= lon <= 180 and -90 <= lat <= 90
 

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1003,14 +1003,9 @@ def load_required_standard_ids(repo_root: Path) -> set[str]:
 def coordinate_pair_is_valid(value: object) -> bool:
     if not isinstance(value, list) or len(value) < 2:
         return False
-    lon, lat = value[0], value[1]
-    if (
-        isinstance(lon, bool)
-        or isinstance(lat, bool)
-        or not isinstance(lon, (int, float))
-        or not isinstance(lat, (int, float))
-    ):
+    if any(isinstance(item, bool) or not isinstance(item, (int, float)) for item in value):
         return False
+    lon, lat = value[0], value[1]
     return -180 <= lon <= 180 and -90 <= lat <= 90
 
 

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -3393,6 +3393,21 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertFalse(report.ok)
             self.assertIn("invalid or unclosed geometry", "\n".join(report.errors))
 
+    def test_boolean_ai_package_coordinate_fails_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            site_path = root / base / "geometry/site_boundary.geojson"
+            site = json.loads(site_path.read_text(encoding="utf-8"))
+            ring = site["features"][0]["geometry"]["coordinates"][0]
+            ring[0] = [True, False]
+            ring[-1] = [True, False]
+            site_path.write_text(json.dumps(site), encoding="utf-8")
+            report = validate_submission(root, "alice", changed)
+            self.assertFalse(report.ok)
+            self.assertIn("invalid or unclosed geometry", "\n".join(report.errors))
+
     def test_local_submission_wrapper_validates_directory(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -3408,6 +3408,21 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertFalse(report.ok)
             self.assertIn("invalid or unclosed geometry", "\n".join(report.errors))
 
+    def test_boolean_ai_package_third_ordinate_fails_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            site_path = root / base / "geometry/site_boundary.geojson"
+            site = json.loads(site_path.read_text(encoding="utf-8"))
+            ring = site["features"][0]["geometry"]["coordinates"][0]
+            ring[0].append(True)
+            ring[-1].append(True)
+            site_path.write_text(json.dumps(site), encoding="utf-8")
+            report = validate_submission(root, "alice", changed)
+            self.assertFalse(report.ok)
+            self.assertIn("invalid or unclosed geometry", "\n".join(report.errors))
+
     def test_local_submission_wrapper_validates_directory(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- reject JSON booleans in GeoJSON coordinate pairs instead of accepting them as Python integers
- preserve valid integer/float coordinates
- add an end-to-end formal-package regression

## Reproduction
On exact main before this patch, a closed site polygon whose first/last coordinate is `[true, false]` passes `validate_submission()` with no geometry error.

## Validation
- direct valid/invalid coordinate checks: PASS
- `tests.test_submission_workflow`: 139/139 PASS
- `py_compile`: PASS
- `git diff --check`: PASS
- secret scan: 0 findings