### PR TITLE
fix(validation): reject non-finite GeoJSON ordinates

### DIFF
--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import os
 import re
 import sys
@@ -1003,7 +1004,12 @@ def load_required_standard_ids(repo_root: Path) -> set[str]:
 def coordinate_pair_is_valid(value: object) -> bool:
     if not isinstance(value, list) or len(value) < 2:
         return False
-    if any(isinstance(item, bool) or not isinstance(item, (int, float)) for item in value):
+    if any(
+        isinstance(item, bool)
+        or not isinstance(item, (int, float))
+        or (isinstance(item, float) and not math.isfinite(item))
+        for item in value
+    ):
         return False
     lon, lat = value[0], value[1]
     return -180 <= lon <= 180 and -90 <= lat <= 90

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -3423,6 +3423,39 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertFalse(report.ok)
             self.assertIn("invalid or unclosed geometry", "\n".join(report.errors))
 
+    def test_nonfinite_ai_package_third_ordinate_fails_validation(self) -> None:
+        for nonfinite in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(nonfinite=nonfinite), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                base = "submissions/alice/ai-urban-loop"
+                changed = self.write_minimal_ai_package(root, base)
+                site_path = root / base / "geometry/site_boundary.geojson"
+                site = json.loads(site_path.read_text(encoding="utf-8"))
+                ring = site["features"][0]["geometry"]["coordinates"][0]
+                ring[0].append(nonfinite)
+                ring[-1].append(nonfinite)
+                site_path.write_text(json.dumps(site), encoding="utf-8")
+                report = validate_submission(root, "alice", changed)
+                self.assertFalse(report.ok)
+                self.assertIn("invalid or unclosed geometry", "\n".join(report.errors))
+
+    def test_large_integer_ai_package_third_ordinate_does_not_crash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            site_path = root / base / "geometry/site_boundary.geojson"
+            site = json.loads(site_path.read_text(encoding="utf-8"))
+            ring = site["features"][0]["geometry"]["coordinates"][0]
+            large_integer = 10**1000
+            ring[0].append(large_integer)
+            ring[-1].append(large_integer)
+            site_path.write_text(json.dumps(site), encoding="utf-8")
+
+            report = validate_submission(root, "alice", changed)
+
+            self.assertTrue(report.ok, report.errors)
+
     def test_local_submission_wrapper_validates_directory(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- reject `NaN`, `Infinity`, and `-Infinity` in every GeoJSON position ordinate
- preserve valid 2D/3D numeric coordinates, including arbitrary-precision integer ordinates
- add full-package regression coverage for non-finite third ordinates and the large-integer no-crash case

## Reproduction
On exact main before the fix, the Python JSON parser accepts `[116.3, 39.9, NaN]`, `coordinate_pair_is_valid()` returns true for a non-finite third ordinate, and the complete `validate_submission()` path passes the package.

During exact-head review, applying `math.isfinite()` indiscriminately also reproduced `OverflowError: int too large to convert to float` for a 1000-digit JSON integer. The amended predicate checks finiteness only for floats, so non-finite JSON constants fail cleanly without crashing on Python arbitrary-precision integers.

## Validation
- rebased onto `upstream/main` at `ba0d5c5a0`
- `python3 -m unittest tests.test_submission_workflow`: 142/142 PASS
- focused non-finite, boolean, large-integer, and local-wrapper tests: 4/4 PASS
- `python3 -m py_compile scripts/validate_submission.py tests/test_submission_workflow.py`: PASS
- `git diff --check upstream/main...HEAD`: PASS
- scoped changed-lines secret scan: 0 findings