### PR TITLE
Fix manifest refresh for missing declared hashes

### DIFF
--- a/scripts/finalize_submission.py
+++ b/scripts/finalize_submission.py
@@ -266,7 +266,11 @@ def main() -> int:
         and item.get("path") != "manifest.json"
         and (root / str(item["path"])).is_file()
     ]
-    hashes = manifest_digests(root, hash_paths)
+    try:
+        hashes = manifest_digests(root, hash_paths)
+    except RuntimeError as exc:
+        print(f"Submission cannot be finalized: {exc}")
+        return 1
     for item in manifest_files:
         if not isinstance(item, dict):
             continue

--- a/scripts/finalize_submission.py
+++ b/scripts/finalize_submission.py
@@ -41,8 +41,10 @@ from git_blob_hashes import git_blob_sha256
 from validate_submission import (
     DISPLAY_BASE_FILES,
     PERSISTED_READINESS_CONTRACT,
+    first_symbolic_link,
     is_empty_pdf,
     localized_path,
+    normalize_changed_path,
     parse_front_matter,
     primary_path_from_localized,
     requires_bilingual_contract,
@@ -75,7 +77,19 @@ def digest(path: Path) -> str:
 
 def manifest_digests(root: Path, relative_paths: list[str]) -> dict[str, str]:
     """Hash listed files using Git's pending blobs when available."""
-    files = {relative: root / relative for relative in relative_paths}
+    root = root.resolve()
+    files: dict[str, Path] = {}
+    for relative in relative_paths:
+        safe_path = normalize_changed_path(relative)
+        if safe_path != relative:
+            raise ValueError(f"manifest path must be normalized: {relative}")
+        linked_path = first_symbolic_link(root, safe_path)
+        if linked_path is not None:
+            raise ValueError(f"manifest path traverses symbolic link: {relative}")
+        path = (root / safe_path).resolve()
+        if not path.is_relative_to(root):
+            raise ValueError(f"manifest path escapes submission directory: {relative}")
+        files[relative] = path
     git_digests = git_blob_sha256(files.values(), cwd=root)
     if git_digests is None:
         return {relative: digest(path) for relative, path in files.items()}
@@ -100,13 +114,43 @@ def main() -> int:
     if manifest.get("package_state") != "scaffold":
         parser.error("package_state must be scaffold before finalization")
 
+    errors: list[str] = []
+    seen_manifest_paths: set[str] = set()
+    for index, item in enumerate(manifest.get("files", [])):
+        if not isinstance(item, dict) or not item.get("path"):
+            errors.append(f"manifest files[{index}] needs path")
+            continue
+        relative = str(item["path"])
+        try:
+            safe_path = normalize_changed_path(relative)
+        except ValueError as exc:
+            errors.append(f"manifest files[{index}] {exc}")
+            continue
+        if safe_path != relative:
+            errors.append(f"manifest files[{index}] path must be normalized: {relative}")
+            continue
+        if safe_path in seen_manifest_paths:
+            errors.append(f"manifest files[{index}] duplicate path: {safe_path}")
+            continue
+        seen_manifest_paths.add(safe_path)
+        linked_path = first_symbolic_link(root, safe_path)
+        if linked_path is not None:
+            errors.append(f"manifest files[{index}] path traverses symbolic link: {safe_path}")
+            continue
+        if not (root / safe_path).resolve().is_relative_to(root):
+            errors.append(f"manifest files[{index}] path escapes submission directory: {safe_path}")
+
+    if errors:
+        print("Submission is still a scaffold:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
     declared = {
         str(item.get("path")): str(item.get("sha256"))
         for item in manifest.get("files", [])
         if isinstance(item, dict) and item.get("path") and item.get("sha256")
     }
-    errors: list[str] = []
-
     proposal_text = (root / "proposal.md").read_text(encoding="utf-8")
     proposal_metadata, _ = parse_front_matter(proposal_text)
     if "SCAFFOLD-DRAFT" in proposal_text:

--- a/scripts/finalize_submission.py
+++ b/scripts/finalize_submission.py
@@ -12,7 +12,7 @@ Checks performed
 - ``proposal.md`` no longer contains the ``SCAFFOLD-DRAFT`` marker.
 - All five required figures have been replaced (SHA-256 differs from scaffold).
 - At least one participant-controlled geometry layer has been replaced.
-- Both PDF drawings have been replaced with non-empty PDFs.
+- Both PDF drawings exist and contain at least one page.
 - When ``bilingual_contract_version: "1"`` is declared, all required bilingual
   counterparts exist and carry correct ``language`` / ``translation_of``
   front-matter.
@@ -180,7 +180,7 @@ def main() -> int:
         errors.append("at least one participant-controlled design geometry layer must change")
     for rel in DRAWINGS:
         path = root / rel
-        if not changed(rel):
+        if not path.is_file():
             errors.append(f"{rel} is unchanged from the placeholder drawing")
         elif is_empty_pdf(path.read_bytes()):
             errors.append(f"{rel} has no pages")

--- a/scripts/finalize_submission.py
+++ b/scripts/finalize_submission.py
@@ -37,6 +37,7 @@ import hashlib
 import json
 from pathlib import Path
 
+from git_blob_hashes import git_blob_sha256
 from validate_submission import (
     DISPLAY_BASE_FILES,
     PERSISTED_READINESS_CONTRACT,
@@ -70,6 +71,15 @@ READABLE_OUTPUTS = ["proposal.md", "report/proposal.html", "visual/index.html"]
 def digest(path: Path) -> str:
     """Return the SHA-256 hex digest of *path*."""
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def manifest_digests(root: Path, relative_paths: list[str]) -> dict[str, str]:
+    """Hash listed files using Git's pending blobs when available."""
+    files = {relative: root / relative for relative in relative_paths}
+    git_digests = git_blob_sha256(files.values(), cwd=root)
+    if git_digests is None:
+        return {relative: digest(path) for relative, path in files.items()}
+    return {relative: git_digests[path.resolve()] for relative, path in files.items()}
 
 
 def main() -> int:
@@ -204,12 +214,21 @@ def main() -> int:
                 translated_item["language"] = translation_language
                 translated_item["translation_of"] = rel
                 translated_item["required"] = strict_bilingual
+    hash_paths = [
+        str(item["path"])
+        for item in manifest_files
+        if isinstance(item, dict)
+        and item.get("path")
+        and item.get("path") != "manifest.json"
+        and (root / str(item["path"])).is_file()
+    ]
+    hashes = manifest_digests(root, hash_paths)
     for item in manifest_files:
         if not isinstance(item, dict):
             continue
         rel = item.get("path")
-        if rel and rel != "manifest.json" and (root / rel).is_file():
-            item["sha256"] = digest(root / rel)
+        if rel and rel != "manifest.json" and str(rel) in hashes:
+            item["sha256"] = hashes[str(rel)]
     manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     print(f"Review-ready package: {root}")
     print(

--- a/scripts/git_blob_hashes.py
+++ b/scripts/git_blob_hashes.py
@@ -16,7 +16,7 @@ def git_blob_sha256(paths: Iterable[Path], *, cwd: Path) -> dict[Path, str] | No
     A contributor may have CRLF files in the worktree while Git stores their LF
     form. Manifests are checked against repository bytes in trusted CI, so use
     a temporary index to mirror the pending ``git add`` result. ``None`` means
-    that no usable Git repository/HEAD is available; callers can retain their
+    that no usable Git repository is available; callers can retain their
     file-byte fallback for standalone packages.
     """
     unique_paths = list(dict.fromkeys(Path(path).resolve() for path in paths))
@@ -46,19 +46,15 @@ def git_blob_sha256(paths: Iterable[Path], *, cwd: Path) -> dict[Path, str] | No
     environment = os.environ.copy()
     with tempfile.TemporaryDirectory(prefix="haidian-manifest-index-") as directory:
         environment["GIT_INDEX_FILE"] = str(Path(directory) / "index")
-        for command in (
-            ["git", "read-tree", "HEAD"],
+        staged = subprocess.run(
             ["git", "add", "--all", "--", *relative_paths.values()],
-        ):
-            staged = subprocess.run(
-                command,
-                cwd=repo_root,
-                capture_output=True,
-                env=environment,
-                check=False,
-            )
-            if staged.returncode:
-                return None
+            cwd=repo_root,
+            capture_output=True,
+            env=environment,
+            check=False,
+        )
+        if staged.returncode:
+            return None
 
         digests: dict[Path, str] = {}
         for path, relative_path in relative_paths.items():

--- a/scripts/git_blob_hashes.py
+++ b/scripts/git_blob_hashes.py
@@ -16,8 +16,9 @@ def git_blob_sha256(paths: Iterable[Path], *, cwd: Path) -> dict[Path, str] | No
     A contributor may have CRLF files in the worktree while Git stores their LF
     form. Manifests are checked against repository bytes in trusted CI, so use
     a temporary index to mirror the pending ``git add`` result. ``None`` means
-    that no usable Git repository is available; callers can retain their
-    file-byte fallback for standalone packages.
+    that no Git repository is available; callers can retain their file-byte
+    fallback for standalone packages. Once a repository is found, failures are
+    fatal so callers cannot silently hash bytes Git would refuse to stage.
     """
     unique_paths = list(dict.fromkeys(Path(path).resolve() for path in paths))
     if not unique_paths:
@@ -37,11 +38,11 @@ def git_blob_sha256(paths: Iterable[Path], *, cwd: Path) -> dict[Path, str] | No
     relative_paths: dict[Path, str] = {}
     for path in unique_paths:
         if not path.is_file():
-            return None
+            raise RuntimeError(f"Git blob path is not a regular file: {path}")
         try:
             relative_paths[path] = path.relative_to(repo_root).as_posix()
         except ValueError:
-            return None
+            raise RuntimeError(f"Git blob path is outside the repository: {path}") from None
 
     environment = os.environ.copy()
     with tempfile.TemporaryDirectory(prefix="haidian-manifest-index-") as directory:
@@ -54,7 +55,8 @@ def git_blob_sha256(paths: Iterable[Path], *, cwd: Path) -> dict[Path, str] | No
             check=False,
         )
         if staged.returncode:
-            return None
+            detail = staged.stderr.decode(errors="replace").strip()
+            raise RuntimeError(f"Git could not stage manifest paths: {detail or 'unknown error'}")
 
         digests: dict[Path, str] = {}
         for path, relative_path in relative_paths.items():
@@ -66,6 +68,10 @@ def git_blob_sha256(paths: Iterable[Path], *, cwd: Path) -> dict[Path, str] | No
                 check=False,
             )
             if blob.returncode:
-                return None
+                detail = blob.stderr.decode(errors="replace").strip()
+                raise RuntimeError(
+                    f"Git could not read the pending blob for {relative_path}: "
+                    f"{detail or 'path was not staged'}"
+                )
             digests[path] = hashlib.sha256(blob.stdout).hexdigest()
     return digests

--- a/scripts/git_blob_hashes.py
+++ b/scripts/git_blob_hashes.py
@@ -1,0 +1,75 @@
+"""Hash files as Git will store them after trusted clean filters run."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Iterable
+
+
+def git_blob_sha256(paths: Iterable[Path], *, cwd: Path) -> dict[Path, str] | None:
+    """Return SHA-256 digests of pending Git blobs without touching the real index.
+
+    A contributor may have CRLF files in the worktree while Git stores their LF
+    form. Manifests are checked against repository bytes in trusted CI, so use
+    a temporary index to mirror the pending ``git add`` result. ``None`` means
+    that no usable Git repository/HEAD is available; callers can retain their
+    file-byte fallback for standalone packages.
+    """
+    unique_paths = list(dict.fromkeys(Path(path).resolve() for path in paths))
+    if not unique_paths:
+        return {}
+
+    completed = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode:
+        return None
+    repo_root = Path(completed.stdout.strip()).resolve()
+
+    relative_paths: dict[Path, str] = {}
+    for path in unique_paths:
+        if not path.is_file():
+            return None
+        try:
+            relative_paths[path] = path.relative_to(repo_root).as_posix()
+        except ValueError:
+            return None
+
+    environment = os.environ.copy()
+    with tempfile.TemporaryDirectory(prefix="haidian-manifest-index-") as directory:
+        environment["GIT_INDEX_FILE"] = str(Path(directory) / "index")
+        for command in (
+            ["git", "read-tree", "HEAD"],
+            ["git", "add", "--all", "--", *relative_paths.values()],
+        ):
+            staged = subprocess.run(
+                command,
+                cwd=repo_root,
+                capture_output=True,
+                env=environment,
+                check=False,
+            )
+            if staged.returncode:
+                return None
+
+        digests: dict[Path, str] = {}
+        for path, relative_path in relative_paths.items():
+            blob = subprocess.run(
+                ["git", "show", f":{relative_path}"],
+                cwd=repo_root,
+                capture_output=True,
+                env=environment,
+                check=False,
+            )
+            if blob.returncode:
+                return None
+            digests[path] = hashlib.sha256(blob.stdout).hexdigest()
+    return digests

--- a/scripts/refresh_submission_manifest.py
+++ b/scripts/refresh_submission_manifest.py
@@ -38,17 +38,19 @@ def refresh_manifest(root: Path) -> tuple[bool, str, list[str]]:
     refreshed: list[str] = []
     seen: set[str] = set()
     for item in files:
-        if not isinstance(item, dict) or "sha256" not in item:
-            continue
+        if not isinstance(item, dict):
+            return False, "every manifest file entry must be an object", []
         rel = item.get("path")
         if not isinstance(rel, str) or not rel:
-            return False, "every hashed manifest entry must have a non-empty path", []
+            return False, "every manifest file entry must have a non-empty path", []
         pure = PurePosixPath(rel)
         if pure.is_absolute() or ".." in pure.parts or rel in seen:
             return False, f"unsafe or duplicate manifest path: {rel}", []
         seen.add(rel)
         if rel == "manifest.json":
-            return False, "manifest.json cannot declare a hash for itself", []
+            if "sha256" in item:
+                return False, "manifest.json cannot declare a hash for itself", []
+            continue
         target = (root / Path(*pure.parts)).resolve()
         if not target.is_relative_to(root) or not target.is_file():
             return False, f"listed file is missing or outside the submission: {rel}", []
@@ -56,7 +58,7 @@ def refresh_manifest(root: Path) -> tuple[bool, str, list[str]]:
         refreshed.append(rel)
 
     if not refreshed:
-        return False, "manifest.json has no declared file hashes to refresh", []
+        return False, "manifest.json has no declared files to refresh", []
     claim["self_checked"] = False
 
     encoded = (json.dumps(manifest, ensure_ascii=False, indent=2) + "\n").encode("utf-8")

--- a/scripts/refresh_submission_manifest.py
+++ b/scripts/refresh_submission_manifest.py
@@ -58,7 +58,7 @@ def refresh_manifest(root: Path) -> tuple[bool, str, list[str]]:
         return False, "manifest.json has no declared files to refresh", []
     try:
         hashes = manifest_digests(root, [rel for _item, rel in refresh_items])
-    except ValueError as exc:
+    except (ValueError, RuntimeError) as exc:
         return False, f"unsafe manifest path: {exc}", []
     for item, rel in refresh_items:
         item["sha256"] = hashes[rel]

--- a/scripts/refresh_submission_manifest.py
+++ b/scripts/refresh_submission_manifest.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import os
 import shlex
@@ -12,9 +11,7 @@ import tempfile
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-
-def digest(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
+from finalize_submission import manifest_digests
 
 
 def refresh_manifest(root: Path) -> tuple[bool, str, list[str]]:
@@ -36,6 +33,7 @@ def refresh_manifest(root: Path) -> tuple[bool, str, list[str]]:
         return False, "manifest.json is missing validation_claim", []
 
     refreshed: list[str] = []
+    refresh_items: list[tuple[dict[str, Any], str]] = []
     seen: set[str] = set()
     for item in files:
         if not isinstance(item, dict):
@@ -54,11 +52,17 @@ def refresh_manifest(root: Path) -> tuple[bool, str, list[str]]:
         target = (root / Path(*pure.parts)).resolve()
         if not target.is_relative_to(root) or not target.is_file():
             return False, f"listed file is missing or outside the submission: {rel}", []
-        item["sha256"] = digest(target)
-        refreshed.append(rel)
+        refresh_items.append((item, rel))
 
-    if not refreshed:
+    if not refresh_items:
         return False, "manifest.json has no declared files to refresh", []
+    try:
+        hashes = manifest_digests(root, [rel for _item, rel in refresh_items])
+    except ValueError as exc:
+        return False, f"unsafe manifest path: {exc}", []
+    for item, rel in refresh_items:
+        item["sha256"] = hashes[rel]
+        refreshed.append(rel)
     claim["self_checked"] = False
 
     encoded = (json.dumps(manifest, ensure_ascii=False, indent=2) + "\n").encode("utf-8")

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1604,12 +1604,32 @@ def validate_manifest_file(report: ValidationReport, repo_root: Path, proposal_d
                     f"{proposal_dir}/manifest.json: manifest.json must not declare sha256; remove the field"
                 )
             elif declared_digest:
-                actual_digest = hashlib.sha256(listed_file.read_bytes()).hexdigest()
+                raw = listed_file.read_bytes()
+                actual_digest = hashlib.sha256(raw).hexdigest()
                 if declared_digest != actual_digest:
                     message = (
                         f"{proposal_dir}/manifest.json: sha256 mismatch for `{safe_path}`; "
                         f"declared={declared_digest}, actual={actual_digest}"
                     )
+                    lf_raw = raw.replace(b"\r\n", b"\n")
+                    crlf_raw = lf_raw.replace(b"\n", b"\r\n")
+                    if (
+                        raw != crlf_raw
+                        and declared_digest == hashlib.sha256(crlf_raw).hexdigest()
+                    ):
+                        message += (
+                            "; declared digest matches the CRLF form, but Git is validating LF bytes. "
+                            "Regenerate manifest.json from the exact bytes committed to Git (for example, "
+                            "use an LF checkout or repository-local core.autocrlf=false before a fresh checkout)"
+                        )
+                    elif (
+                        raw != lf_raw
+                        and declared_digest == hashlib.sha256(lf_raw).hexdigest()
+                    ):
+                        message += (
+                            "; declared digest matches the LF form, but Git is validating CRLF bytes. "
+                            "Regenerate manifest.json from the exact bytes committed to Git"
+                        )
                     if translation_entry and not strict_bilingual:
                         report.add_warning(message + "; legacy bilingual metadata does not block review")
                     else:

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -19,6 +19,7 @@ from pathlib import Path, PurePosixPath
 from typing import Iterable
 
 from front_matter import parse_front_matter
+from git_blob_hashes import git_blob_sha256
 
 
 POLICY_ROOT = Path(__file__).resolve().parents[1]
@@ -1560,6 +1561,22 @@ def validate_manifest_file(report: ValidationReport, repo_root: Path, proposal_d
     strict_bilingual = requires_bilingual_display(repo_root, proposal_dir)
     files = data.get("files")
     listed_paths: set[str] = set()
+    git_digests: dict[Path, str] | None = None
+    if isinstance(files, list):
+        manifest_files: list[Path] = []
+        for item in files:
+            if not isinstance(item, dict) or not item.get("path"):
+                continue
+            try:
+                safe_path = normalize_changed_path(str(item["path"]))
+            except ValueError:
+                continue
+            if safe_path == "manifest.json":
+                continue
+            listed_file = repo_root / proposal_dir / safe_path
+            if listed_file.is_file():
+                manifest_files.append(listed_file)
+        git_digests = git_blob_sha256(manifest_files, cwd=repo_root)
     if not isinstance(files, list) or not files:
         report.add_error(f"{proposal_dir}/manifest.json: files must be a non-empty array")
     else:
@@ -1605,7 +1622,11 @@ def validate_manifest_file(report: ValidationReport, repo_root: Path, proposal_d
                 )
             elif declared_digest:
                 raw = listed_file.read_bytes()
-                actual_digest = hashlib.sha256(raw).hexdigest()
+                actual_digest = (
+                    git_digests.get(listed_file.resolve())
+                    if git_digests is not None
+                    else hashlib.sha256(raw).hexdigest()
+                )
                 if declared_digest != actual_digest:
                     message = (
                         f"{proposal_dir}/manifest.json: sha256 mismatch for `{safe_path}`; "
@@ -1614,7 +1635,8 @@ def validate_manifest_file(report: ValidationReport, repo_root: Path, proposal_d
                     lf_raw = raw.replace(b"\r\n", b"\n")
                     crlf_raw = lf_raw.replace(b"\n", b"\r\n")
                     if (
-                        raw != crlf_raw
+                        lf_raw != crlf_raw
+                        and actual_digest == hashlib.sha256(lf_raw).hexdigest()
                         and declared_digest == hashlib.sha256(crlf_raw).hexdigest()
                     ):
                         message += (
@@ -1623,7 +1645,8 @@ def validate_manifest_file(report: ValidationReport, repo_root: Path, proposal_d
                             "use an LF checkout or repository-local core.autocrlf=false before a fresh checkout)"
                         )
                     elif (
-                        raw != lf_raw
+                        lf_raw != crlf_raw
+                        and actual_digest == hashlib.sha256(crlf_raw).hexdigest()
                         and declared_digest == hashlib.sha256(lf_raw).hexdigest()
                     ):
                         message += (

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1576,7 +1576,11 @@ def validate_manifest_file(report: ValidationReport, repo_root: Path, proposal_d
             listed_file = repo_root / proposal_dir / safe_path
             if listed_file.is_file():
                 manifest_files.append(listed_file)
-        git_digests = git_blob_sha256(manifest_files, cwd=repo_root)
+        try:
+            git_digests = git_blob_sha256(manifest_files, cwd=repo_root)
+        except RuntimeError as exc:
+            report.add_error(f"{proposal_dir}/manifest.json: cannot hash pending Git blobs: {exc}")
+            git_digests = {}
     if not isinstance(files, list) or not files:
         report.add_error(f"{proposal_dir}/manifest.json: files must be a non-empty array")
     else:

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -859,6 +859,51 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
             self.assertNotEqual(checked.returncode, 0)
             self.assertIn("sha256 mismatch for `proposal.md`", checked.stdout)
 
+    def test_manifest_hash_mismatch_explains_crlf_normalization(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_official_site_package(root)
+            submission_dir = root / "submissions" / "alice" / "crlf-manifest"
+            scaffold = run_scaffold(submission_dir, cwd=root)
+            self.assertEqual(scaffold.returncode, 0, scaffold.stdout + scaffold.stderr)
+
+            proposal = submission_dir / "proposal.md"
+            lf_raw = proposal.read_bytes().replace(b"\r\n", b"\n")
+            proposal.write_bytes(lf_raw)
+            crlf_digest = hashlib.sha256(lf_raw.replace(b"\n", b"\r\n")).hexdigest()
+            manifest_path = submission_dir / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            next(item for item in manifest["files"] if item["path"] == "proposal.md")[
+                "sha256"
+            ] = crlf_digest
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            checked = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "validate_local_submission.py"),
+                    str(submission_dir),
+                    "--repo-root",
+                    str(root),
+                    "--pr-author",
+                    "alice",
+                    "--json",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(checked.returncode, 0)
+            self.assertIn("sha256 mismatch for `proposal.md`", checked.stdout)
+            self.assertIn("declared digest matches the CRLF form", checked.stdout)
+            self.assertIn(
+                "Regenerate manifest.json from the exact bytes committed to Git",
+                checked.stdout,
+            )
+
     def test_scaffold_includes_public_source_registry_reference(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -341,6 +341,43 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
                 result["next_command_note"],
             )
 
+    def test_ready_package_manifest_refresh_restores_missing_hashes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_official_site_package(root)
+            submission_dir = root / "submissions" / "alice" / "refresh-missing-hashes"
+            self.assertEqual(run_scaffold(submission_dir, cwd=root).returncode, 0)
+            self.assertEqual(complete_scaffold(submission_dir).returncode, 0)
+            self.assertEqual(mark_self_checked(submission_dir).returncode, 0)
+
+            manifest_path = submission_dir / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            for item in manifest["files"]:
+                item.pop("sha256", None)
+            manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "refresh_submission_manifest.py"),
+                    str(submission_dir),
+                    "--json",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+            refreshed = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertTrue(refreshed["files"])
+            self.assertTrue(
+                all(item.get("sha256") for item in refreshed["files"] if item.get("path") != "manifest.json")
+            )
+            self.assertFalse(refreshed["validation_claim"]["self_checked"])
+
+            checked = mark_self_checked(submission_dir)
+            self.assertEqual(checked.returncode, 0, checked.stdout + checked.stderr)
+
     def test_manifest_refresh_next_command_quotes_space_in_path(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             submission_dir = Path(tmp) / "workspace with spaces" / "submission"

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -134,7 +134,10 @@ def run_scaffold(output_dir: Path, stage: str = "formal", cwd: Path = REPO_ROOT)
     )
 
 
-def complete_scaffold(output_dir: Path) -> subprocess.CompletedProcess:
+def complete_scaffold(
+    output_dir: Path,
+    synchronized_paths: tuple[str, ...] = (),
+) -> subprocess.CompletedProcess:
     proposal = output_dir / "proposal.md"
     proposal.write_text(
         proposal.read_text(encoding="utf-8").replace("SCAFFOLD-DRAFT", "PARTICIPANT-DESIGN")
@@ -204,6 +207,15 @@ def complete_scaffold(output_dir: Path) -> subprocess.CompletedProcess:
         target = source.with_name(f"{source.stem}.en{source.suffix}")
         if not target.exists():
             target.write_bytes(source.read_bytes())
+    if synchronized_paths:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        items = {item["path"]: item for item in manifest["files"]}
+        for rel in synchronized_paths:
+            items[rel]["sha256"] = hashlib.sha256((output_dir / rel).read_bytes()).hexdigest()
+        manifest_path.write_text(
+            json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
     return subprocess.run(
         [sys.executable, str(REPO_ROOT / "scripts" / "finalize_submission.py"), str(output_dir)],
         capture_output=True,
@@ -487,6 +499,21 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
             )
             self.assertNotEqual(0, finalized.returncode)
             self.assertIn("required bilingual counterpart is missing", finalized.stdout)
+
+    def test_finalize_accepts_nonempty_drawing_with_synchronized_scaffold_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "submissions" / "alice" / "synchronized-drawing"
+            scaffold = run_scaffold(output_dir)
+            self.assertEqual(0, scaffold.returncode, scaffold.stdout + scaffold.stderr)
+
+            finalized = complete_scaffold(
+                output_dir,
+                synchronized_paths=("drawings/a0-boards.pdf",),
+            )
+
+            self.assertEqual(0, finalized.returncode, finalized.stdout + finalized.stderr)
+            manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual("ready_for_review", manifest["package_state"])
 
     def test_finalize_registers_existing_language_counterparts(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -681,6 +681,64 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
 
             self.assertFalse(has_blocking_self_check(submission_dir))
 
+    def test_finalize_rejects_manifest_path_outside_submission(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_official_site_package(root)
+            submission_dir = root / "submissions" / "alice" / "path-escape"
+            scaffold = run_scaffold(submission_dir, cwd=root)
+            self.assertEqual(scaffold.returncode, 0, scaffold.stdout + scaffold.stderr)
+            outside = root / "outside.txt"
+            outside.write_text("outside must not be hashed\n", encoding="utf-8")
+            manifest_path = submission_dir / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["files"].append(
+                {"path": str(outside), "role": "narrative", "required": False}
+            )
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            finalized = complete_scaffold(submission_dir)
+
+            self.assertNotEqual(finalized.returncode, 0)
+            self.assertIn("unsafe path", finalized.stdout)
+            persisted = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual("scaffold", persisted["package_state"])
+            self.assertEqual("outside must not be hashed\n", outside.read_text(encoding="utf-8"))
+
+    def test_finalize_rejects_manifest_path_through_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_official_site_package(root)
+            submission_dir = root / "submissions" / "alice" / "symlink-escape"
+            scaffold = run_scaffold(submission_dir, cwd=root)
+            self.assertEqual(scaffold.returncode, 0, scaffold.stdout + scaffold.stderr)
+            outside = root / "outside.txt"
+            outside.write_text("outside must not be hashed\n", encoding="utf-8")
+            link = submission_dir / "linked.txt"
+            try:
+                link.symlink_to(outside)
+            except OSError as exc:
+                self.skipTest(f"symlink not supported: {exc}")
+            manifest_path = submission_dir / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["files"].append(
+                {"path": "linked.txt", "role": "narrative", "required": False}
+            )
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            finalized = complete_scaffold(submission_dir)
+
+            self.assertNotEqual(finalized.returncode, 0)
+            self.assertIn("path traverses symbolic link", finalized.stdout)
+            persisted = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual("scaffold", persisted["package_state"])
+
     def test_scaffold_does_not_emit_contributor_exhibit(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -858,6 +916,7 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
             )
             self.assertNotEqual(checked.returncode, 0)
             self.assertIn("sha256 mismatch for `proposal.md`", checked.stdout)
+            self.assertNotIn("declared digest matches", checked.stdout)
 
     def test_manifest_hash_mismatch_explains_crlf_normalization(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_git_blob_hashes.py
+++ b/tests/test_git_blob_hashes.py
@@ -57,6 +57,17 @@ class GitBlobHashTests(unittest.TestCase):
             self.assertNotEqual(expected, hashlib.sha256(proposal.read_bytes()).hexdigest())
             self.assertEqual(0, self.git(root, "diff", "--cached", "--quiet").returncode)
 
+    def test_ignored_path_fails_closed_inside_git_repository(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.assertEqual(0, self.git(root, "init").returncode)
+            (root / ".gitignore").write_text("ignored.md\n", encoding="utf-8")
+            ignored = root / "ignored.md"
+            ignored.write_text("must not use raw bytes\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, "could not stage manifest paths"):
+                git_blob_sha256([ignored], cwd=root)
+
     def test_manifest_validation_uses_the_same_git_blob_bytes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_git_blob_hashes.py
+++ b/tests/test_git_blob_hashes.py
@@ -1,0 +1,95 @@
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from git_blob_hashes import git_blob_sha256  # noqa: E402
+from finalize_submission import manifest_digests  # noqa: E402
+from validate_submission import ValidationReport, validate_manifest_file  # noqa: E402
+
+
+class GitBlobHashTests(unittest.TestCase):
+    def git(self, root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args], cwd=root, capture_output=True, text=True, check=False
+        )
+
+    def make_autocrlf_package(self, root: Path) -> tuple[Path, Path, str]:
+        self.assertEqual(0, self.git(root, "init").returncode)
+        self.assertEqual(
+            0,
+            self.git(root, "config", "user.email", "test@example.com").returncode,
+        )
+        self.assertEqual(
+            0,
+            self.git(root, "config", "user.name", "Test User").returncode,
+        )
+        self.assertEqual(0, self.git(root, "config", "core.autocrlf", "true").returncode)
+        (root / ".gitattributes").write_text("*.md text\n", encoding="utf-8")
+        package = root / "submissions" / "alice" / "git-hashes"
+        package.mkdir(parents=True)
+        proposal = package / "proposal.md"
+        proposal.write_text("initial\n", encoding="utf-8")
+        self.assertEqual(0, self.git(root, "add", ".").returncode)
+        self.assertEqual(0, self.git(root, "commit", "-m", "initial package").returncode)
+
+        proposal.write_bytes(b"updated proposal\r\n")
+        expected = hashlib.sha256(b"updated proposal\n").hexdigest()
+        return package, proposal, expected
+
+    def test_hashes_pending_git_clean_blobs_without_mutating_real_index(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _package, proposal, expected = self.make_autocrlf_package(root)
+
+            hashes = git_blob_sha256([proposal], cwd=root)
+
+            self.assertIsNotNone(hashes)
+            self.assertEqual(expected, hashes[proposal.resolve()])
+            self.assertNotEqual(expected, hashlib.sha256(proposal.read_bytes()).hexdigest())
+            self.assertEqual(0, self.git(root, "diff", "--cached", "--quiet").returncode)
+
+    def test_manifest_validation_uses_the_same_git_blob_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package, _proposal, expected = self.make_autocrlf_package(root)
+            (package / "manifest.json").write_text(
+                json.dumps(
+                    {
+                        "submission_stage": "formal",
+                        "package_type": "professional_design_package",
+                        "package_state": "ready_for_review",
+                        "submission_type": "ai_agent",
+                        "project_id": "centennial-jingzhang-ai-belt",
+                        "files": [{"path": "proposal.md", "sha256": expected}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            report = ValidationReport()
+            validate_manifest_file(report, root, "submissions/alice/git-hashes")
+
+            self.assertFalse(
+                any("sha256 mismatch for `proposal.md`" in item for item in report.errors)
+            )
+
+    def test_finalizer_hashes_the_pending_git_blob(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package, _proposal, expected = self.make_autocrlf_package(root)
+
+            hashes = manifest_digests(package, ["proposal.md"])
+
+            self.assertEqual(expected, hashes["proposal.md"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_git_blob_hashes.py
+++ b/tests/test_git_blob_hashes.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from git_blob_hashes import git_blob_sha256  # noqa: E402
 from finalize_submission import manifest_digests  # noqa: E402
+from refresh_submission_manifest import refresh_manifest  # noqa: E402
 from validate_submission import ValidationReport, validate_manifest_file  # noqa: E402
 
 
@@ -89,6 +90,66 @@ class GitBlobHashTests(unittest.TestCase):
             hashes = manifest_digests(package, ["proposal.md"])
 
             self.assertEqual(expected, hashes["proposal.md"])
+
+    def test_refresh_restores_missing_hash_from_pending_git_blob(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package, proposal, expected = self.make_autocrlf_package(root)
+            (package / "manifest.json").write_text(
+                json.dumps(
+                    {
+                        "submission_stage": "formal",
+                        "package_type": "professional_design_package",
+                        "package_state": "ready_for_review",
+                        "submission_type": "ai_agent",
+                        "project_id": "centennial-jingzhang-ai-belt",
+                        "validation_claim": {"self_checked": True},
+                        "files": [{"path": "proposal.md"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            ok, error, refreshed = refresh_manifest(package)
+
+            self.assertTrue(ok, error)
+            self.assertEqual(["proposal.md"], refreshed)
+            manifest = json.loads((package / "manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(expected, manifest["files"][0]["sha256"])
+            self.assertNotEqual(expected, hashlib.sha256(proposal.read_bytes()).hexdigest())
+            report = ValidationReport()
+            validate_manifest_file(report, root, "submissions/alice/git-hashes")
+            self.assertFalse(
+                any("sha256 mismatch for `proposal.md`" in item for item in report.errors),
+                report.errors,
+            )
+
+    def test_refresh_rejects_symlink_before_hashing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package = root / "submissions" / "alice" / "symlink-refresh"
+            package.mkdir(parents=True)
+            target = package / "target.md"
+            target.write_text("safe bytes\n", encoding="utf-8")
+            (package / "proposal.md").symlink_to(target.name)
+            (package / "manifest.json").write_text(
+                json.dumps(
+                    {
+                        "package_state": "ready_for_review",
+                        "validation_claim": {"self_checked": True},
+                        "files": [{"path": "proposal.md"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            ok, error, refreshed = refresh_manifest(package)
+
+            self.assertFalse(ok)
+            self.assertIn("symbolic link", error)
+            self.assertEqual([], refreshed)
+            manifest = json.loads((package / "manifest.json").read_text(encoding="utf-8"))
+            self.assertNotIn("sha256", manifest["files"][0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- rebase the canonical safe Git-clean manifest hashing work from #1064 onto current `main`, preserving its original authorship
- make validator, finalizer, and ready-package refresh hash the same pending Git blob bytes that trusted CI will receive
- let refresh restore missing SHA-256 fields without following symlinks or weakening path/duplicate/containment checks
- preserve current-main readiness persistence and declared/actual mismatch diagnostics

## Reproduction / validation
Originally reproduced on PR #2141 exact head `8143c4c6f3384df170d37a6f17126bfa74f38f54`: CI required SHA-256 for every listed file, while refresh refused manifests with no hashes and finalizer refused an already-ready package.

The updated branch also reproduces `core.autocrlf=true`: a CRLF worktree file is refreshed to its LF pending-Git-blob digest, the immediate validator accepts that digest, and the real index remains unchanged. A separate regression proves an in-package symlink is rejected before hashing or manifest write.

Validation:
- 178 relevant scaffold/hash/submission-workflow tests: PASS
- `py_compile` for all four changed scripts: PASS
- `git diff --check upstream/main...HEAD`: PASS
- focused refresh → pending blob → validator and symlink regressions: PASS

Canonical commits from #1064 remain attributed to @CocoSgt.