### PR TITLE
v7.4 fix: mask phone number in narrative.md appendix (personal-data red line closure)

### DIFF
--- a/submissions/adjustshot/jingzhang-ai-belt/manifest.json
+++ b/submissions/adjustshot/jingzhang-ai-belt/manifest.json
@@ -56,7 +56,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "4d024c119f6a2a1dde1cbf770222745e8641325aa4cffceddeaf7084051b0d0f"
+      "sha256": "f7c2059706d7e4d35e4941ce69431f0f5e85d541e311eb8568aafb0d752cf6b9"
     },
     {
       "path": "compliance_matrix.json",
@@ -87,7 +87,7 @@
       "path": "report/narrative.md",
       "role": "narrative",
       "required": false,
-      "sha256": "8ce6aa753669fbf57cf4b1aec64babbe6948d85de184d882c3b7057774da9627"
+      "sha256": "74433e864466d8a3581c1fb6ecf8a2d6e0d0d46512222ba8741055fa138fedf2"
     },
     {
       "path": "report/copyright_statement.md",

--- a/submissions/adjustshot/jingzhang-ai-belt/report/narrative.md
+++ b/submissions/adjustshot/jingzhang-ai-belt/report/narrative.md
@@ -261,14 +261,14 @@ This narrative is derived from the structured AI package. Geometry, metrics, com
 
 > Date: 2026-08-14
 > Scope: every deliverable in the submission package and the workspace.
-> Trigger: AI reviewer flagged A3 中文 cover page as publishing a complete mobile phone number (15858138235), which is "identifiable personal data" under reviewer interpretation — mandatory reject.
+> Trigger: AI reviewer flagged A3 中文 cover page as publishing a complete mobile phone number (158****8235), which is "identifiable personal data" under reviewer interpretation — mandatory reject.
 
 ## 1. Files cleaned (source files)
 
 | File | Action |
 |---|---|
-| `a3_booklet_v6.json` | cover subtitle stripped of `｜ 联系电话：15858138235` |
-| `a3_booklet_v6_en.json` | cover subtitle stripped of ` | Contact: 15858138235` |
+| `a3_booklet_v6.json` | cover subtitle stripped of `｜ 联系电话：158****8235` |
+| `a3_booklet_v6_en.json` | cover subtitle stripped of ` | Contact: 158****8235` |
 | `make_a3_en_json.py` | cover subtitle stripped of phone |
 | `make_ppt_postprocess_v6.py` | cover `add_text` stripped of phone; indicator-page "1880 万㎡（1200+680）" replaced with "未验证情景（待官方数据）" |
 | `make_ppt_postprocess_v6_en.py` | cover `add_text` stripped of phone; cover title resized from 56pt to 44pt to remove overlap with subtitle; indicator-page "18.80M m² (12.0M+6.8M)" replaced with "Unverified scenario (awaiting official data)" |
@@ -286,7 +286,7 @@ This narrative is derived from the structured AI package. Geometry, metrics, com
 ## 3. Other source-code search
 
 ```
-$ grep -rn "15858138235" --include="*.py" --include="*.json" --include="*.md" --include="*.html" .
+$ grep -rn "158****8235" --include="*.py" --include="*.json" --include="*.md" --include="*.html" .
 (a3_booklet_v6.json | make_a3_en_json.py | make_ppt_postprocess_v6.py | make_ppt_postprocess_v6_en.py | .workbuddy/memory/2026-08-13.md)
 ```
 
@@ -295,7 +295,7 @@ All occurrences identified in §1 have been edited; the memory file entry is bei
 ## 4. PDF text-layer & image-OCR scan
 
 ```
-pymupdf get_text() per page → no match for "15858138235" in:
+pymupdf get_text() per page → no match for "158****8235" in:
   - a3-booklet.pdf        (24 pages)
   - a3-booklet.en.pdf     (24 pages)
   - a0-boards.en.pdf      (7 pages)
@@ -314,7 +314,7 @@ Reviewed — none of the generated HTML files or PDFs embed the phone number in:
 
 ## 6. Outcome
 
-- The phone number `15858138235` has been **permanently removed** from all deliverable artefacts (source + generated).
+- The phone number `158****8235` has been **permanently removed** from all deliverable artefacts (source + generated).
 - Local self-check: `can_enter_formal_review = True / formal-review-ready`
 - Mandatory-reject item cleared; ready for next AI-reviewer cycle.
 
@@ -324,14 +324,14 @@ Reviewed — none of the generated HTML files or PDFs embed the phone number in:
 
 > Date: 2026-08-14
 > Scope: every deliverable in the submission package and the workspace.
-> Trigger: AI reviewer flagged A3 中文 cover page as publishing a complete mobile phone number (15858138235), which is "identifiable personal data" under reviewer interpretation — mandatory reject.
+> Trigger: AI reviewer flagged A3 中文 cover page as publishing a complete mobile phone number (158****8235), which is "identifiable personal data" under reviewer interpretation — mandatory reject.
 
 ## 1. Files cleaned (source files)
 
 | File | Action |
 |---|---|
-| `a3_booklet_v6.json` | cover subtitle stripped of `｜ 联系电话：15858138235` |
-| `a3_booklet_v6_en.json` | cover subtitle stripped of ` | Contact: 15858138235` |
+| `a3_booklet_v6.json` | cover subtitle stripped of `｜ 联系电话：158****8235` |
+| `a3_booklet_v6_en.json` | cover subtitle stripped of ` | Contact: 158****8235` |
 | `make_a3_en_json.py` | cover subtitle stripped of phone |
 | `make_ppt_postprocess_v6.py` | cover `add_text` stripped of phone; indicator-page "1880 万㎡（1200+680）" replaced with "未验证情景（待官方数据）" |
 | `make_ppt_postprocess_v6_en.py` | cover `add_text` stripped of phone; cover title resized from 56pt to 44pt to remove overlap with subtitle; indicator-page "18.80M m² (12.0M+6.8M)" replaced with "Unverified scenario (awaiting official data)" |
@@ -349,7 +349,7 @@ Reviewed — none of the generated HTML files or PDFs embed the phone number in:
 ## 3. Other source-code search
 
 ```
-$ grep -rn "15858138235" --include="*.py" --include="*.json" --include="*.md" --include="*.html" .
+$ grep -rn "158****8235" --include="*.py" --include="*.json" --include="*.md" --include="*.html" .
 (a3_booklet_v6.json | make_a3_en_json.py | make_ppt_postprocess_v6.py | make_ppt_postprocess_v6_en.py | .workbuddy/memory/2026-08-13.md)
 ```
 
@@ -358,7 +358,7 @@ All occurrences identified in §1 have been edited; the memory file entry is bei
 ## 4. PDF text-layer & image-OCR scan
 
 ```
-pymupdf get_text() per page → no match for "15858138235" in:
+pymupdf get_text() per page → no match for "158****8235" in:
   - a3-booklet.pdf        (24 pages)
   - a3-booklet.en.pdf     (24 pages)
   - a0-boards.en.pdf      (7 pages)
@@ -377,6 +377,6 @@ Reviewed — none of the generated HTML files or PDFs embed the phone number in:
 
 ## 6. Outcome
 
-- The phone number `15858138235` has been **permanently removed** from all deliverable artefacts (source + generated).
+- The phone number `158****8235` has been **permanently removed** from all deliverable artefacts (source + generated).
 - Local self-check: `can_enter_formal_review = True / formal-review-ready`
 - Mandatory-reject item cleared; ready for next AI-reviewer cycle.

--- a/submissions/adjustshot/jingzhang-ai-belt/self_check.json
+++ b/submissions/adjustshot/jingzhang-ai-belt/self_check.json
@@ -74,7 +74,7 @@
       "ai_package_stages": {
         "submissions/adjustshot/jingzhang-ai-belt": "formal"
       },
-      "total_bytes": 41562460,
+      "total_bytes": 41562845,
       "maintainer_bypass": false
     },
     "stderr": ""


### PR DESCRIPTION
## v7.4 修复：narrative.md 附录 B 完整手机号打码

**背景**：PR #2323 已合并（v7.3）。合并后复查发现  附录 B（个人数据清理清单）中记录了完整手机号  的上文（描述被清理对象时写入了完整号码 ）。

**本 PR 修改**（唯一变更）：
- ：完整手机号 → 打码 （附录 B 清理清单描述用），确保 main 上任何文件均不含可识别个人数据
- 其余文件与 main 一致，无其他变更

**自检**：can_enter_formal_review = True / formal-review-ready
**扫描**：源文件 + PDF 文本层 + HTML 全包 0 残留完整手机号

说明：官方 v7.3 APPROVED 时已通过强制拒绝项核查（A3 PDF 无手机号）；本 PR 是进一步消除 narrative 源文件中的号码残留，属于个人数据红线闭合。