### PR TITLE
Port strict JSON metric validation onto current main

### DIFF
--- a/scripts/metric_types.py
+++ b/scripts/metric_types.py
@@ -1,0 +1,10 @@
+"""Shared JSON metric type predicates used by the review gates."""
+
+from __future__ import annotations
+
+
+def is_json_number(value: object) -> bool:
+    """Return true only for JSON numbers, never for Python booleans."""
+
+    # Python makes bool a subclass of int, but JSON booleans are not numbers.
+    return isinstance(value, (int, float)) and not isinstance(value, bool)

--- a/scripts/metric_types.py
+++ b/scripts/metric_types.py
@@ -9,8 +9,11 @@ def is_json_number(value: object) -> bool:
     """Return true only for JSON numbers, never for Python booleans."""
 
     # Python makes bool a subclass of int, but JSON booleans are not numbers.
-    return (
-        isinstance(value, (int, float))
-        and not isinstance(value, bool)
-        and math.isfinite(value)
-    )
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    if isinstance(value, int):
+        try:
+            value = float(value)
+        except OverflowError:
+            return False
+    return math.isfinite(value)

--- a/scripts/metric_types.py
+++ b/scripts/metric_types.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import math
+
 
 def is_json_number(value: object) -> bool:
     """Return true only for JSON numbers, never for Python booleans."""
 
     # Python makes bool a subclass of int, but JSON booleans are not numbers.
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )

--- a/scripts/spatial_review.py
+++ b/scripts/spatial_review.py
@@ -58,6 +58,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from metric_types import is_json_number
+
 
 try:
     from pyproj import Transformer
@@ -215,7 +217,18 @@ def load_feature_geometries(
                 )
             )
         declared = props.get("area_sqm_declared")
-        if isinstance(declared, (int, float)) and geom.geom_type in {"Polygon", "MultiPolygon"}:
+        if isinstance(declared, bool):
+            report.add(
+                SpatialIssue(
+                    "DECLARED_AREA_TYPE",
+                    "major",
+                    str(path),
+                    "Declared area must be a JSON number, not a boolean.",
+                    feature_id,
+                    actual=declared,
+                )
+            )
+        elif is_json_number(declared) and geom.geom_type in {"Polygon", "MultiPolygon"}:
             delta = abs(float(declared) - float(geom.area))
             allowed_delta = max(AREA_TOLERANCE_SQM, abs(float(geom.area)) * RELATIVE_AREA_TOLERANCE)
             if delta > allowed_delta:
@@ -388,9 +401,20 @@ def check_key_areas(report: SpatialReport, site: Any, key_items: list[tuple[str,
                 )
             )
         expected_area = props.get("official_area_sqm")
-        if not isinstance(expected_area, (int, float)) and is_official:
+        if isinstance(expected_area, bool):
+            report.add(
+                SpatialIssue(
+                    "KEY_AREA_AREA_TYPE",
+                    "major",
+                    "geometry/key_areas.geojson",
+                    "Official key-area area must be a JSON number, not a boolean.",
+                    feature_id,
+                    actual=expected_area,
+                )
+            )
+        elif not is_json_number(expected_area) and is_official:
             expected_area = OFFICIAL_KEY_AREA_AREAS.get(area_id)
-        if isinstance(expected_area, (int, float)) and is_official:
+        if is_json_number(expected_area) and is_official:
             delta = abs(float(expected_area) - float(geom.area))
             allowed = max(AREA_TOLERANCE_SQM, float(expected_area) * KEY_AREA_RELATIVE_TOLERANCE)
             if delta > allowed:
@@ -437,7 +461,7 @@ def metric_value(metrics: dict, name: str) -> float | None:
     if not isinstance(metric, dict):
         return None
     value = metric.get("value")
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
+    if is_json_number(value):
         return float(value)
     return None
 
@@ -564,6 +588,17 @@ def review_submission(submission_dir: Path, repo_root: Path, stage: str) -> Spat
     }
 
     metrics = load_metrics(submission_dir)
+    for name, metric in metrics.items():
+        if isinstance(metric, dict) and isinstance(metric.get("value"), bool):
+            report.add(
+                SpatialIssue(
+                    "METRIC_VALUE_TYPE",
+                    "major",
+                    "metrics.json",
+                    f"{name} must use a JSON number, not a boolean.",
+                    actual=metric["value"],
+                )
+            )
     check_metric_close(report, metrics, "site_area_sqm", site_area, "sqm")
     check_metric_close(report, metrics, "green_space_area_sqm", green_area, "sqm")
     check_metric_close(report, metrics, "public_space_area_sqm", public_area, "sqm")
@@ -575,7 +610,7 @@ def review_submission(submission_dir: Path, repo_root: Path, stage: str) -> Spat
     for name, metric in metrics.items():
         if isinstance(metric, dict) and metric.get("unit") == "ratio":
             value = metric.get("value")
-            if isinstance(value, (int, float)) and not 0 <= float(value) <= 1:
+            if is_json_number(value) and not 0 <= float(value) <= 1:
                 report.add(
                     SpatialIssue(
                         "METRIC_RATIO_RANGE",

--- a/scripts/spatial_review.py
+++ b/scripts/spatial_review.py
@@ -589,14 +589,18 @@ def review_submission(submission_dir: Path, repo_root: Path, stage: str) -> Spat
 
     metrics = load_metrics(submission_dir)
     for name, metric in metrics.items():
-        if isinstance(metric, dict) and isinstance(metric.get("value"), bool):
+        if (
+            isinstance(metric, dict)
+            and metric.get("status") == "known"
+            and not is_json_number(metric.get("value"))
+        ):
             report.add(
                 SpatialIssue(
                     "METRIC_VALUE_TYPE",
                     "major",
                     "metrics.json",
-                    f"{name} must use a JSON number, not a boolean.",
-                    actual=metric["value"],
+                    f"{name} must use a finite JSON number.",
+                    actual=metric.get("value"),
                 )
             )
     check_metric_close(report, metrics, "site_area_sqm", site_area, "sqm")

--- a/scripts/spatial_review.py
+++ b/scripts/spatial_review.py
@@ -401,7 +401,7 @@ def check_key_areas(report: SpatialReport, site: Any, key_items: list[tuple[str,
                 )
             )
         expected_area = props.get("official_area_sqm")
-        if isinstance(expected_area, bool):
+        if is_official and isinstance(expected_area, bool):
             report.add(
                 SpatialIssue(
                     "KEY_AREA_AREA_TYPE",

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -20,6 +20,7 @@ from typing import Iterable
 
 from front_matter import parse_front_matter
 from git_blob_hashes import git_blob_sha256
+from metric_types import is_json_number
 
 
 POLICY_ROOT = Path(__file__).resolve().parents[1]
@@ -1296,9 +1297,9 @@ def validate_metrics_file(report: ValidationReport, path: Path, display_path: st
                 report.add_error(f"{label}: unknown metric value must be null")
             if not metric.get("reason"):
                 report.add_error(f"{label}: unknown metric needs reason")
-        if status == "known" and not isinstance(metric.get("value"), (int, float)):
+        if status == "known" and not is_json_number(metric.get("value")):
             report.add_error(f"{label}: known metric needs numeric value")
-        if metric.get("unit") == "ratio" and isinstance(metric.get("value"), (int, float)):
+        if metric.get("unit") == "ratio" and is_json_number(metric.get("value")):
             value = metric["value"]
             if value < 0 or value > 1:
                 report.add_error(f"{label}: ratio value must be between 0 and 1")

--- a/scripts/visual_review.py
+++ b/scripts/visual_review.py
@@ -43,6 +43,8 @@ from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any
 
+from metric_types import is_json_number
+
 
 REQUIRED_TEXT_MARKERS = [
     "总览地图",
@@ -215,7 +217,7 @@ def review_visual(submission_dir: Path) -> VisualReport:
             )
             continue
         expected = metric.get("value")
-        if not isinstance(expected, (int, float)):
+        if not is_json_number(expected):
             report.add(
                 "VISUAL_METRIC_SOURCE_MISSING",
                 "major",

--- a/tests/test_metric_types.py
+++ b/tests/test_metric_types.py
@@ -24,6 +24,33 @@ class MetricTypeTests(unittest.TestCase):
             with self.subTest(value=value):
                 self.assertFalse(is_json_number(value))
 
+    def test_huge_integers_are_not_json_numbers(self) -> None:
+        for value in (10**1000, -(10**1000)):
+            with self.subTest(sign=value > 0):
+                self.assertFalse(is_json_number(value))
+
+    def test_huge_integer_known_metric_fails_deterministic_validation(self) -> None:
+        for value in (10**1000, -(10**1000)):
+            with self.subTest(sign=value > 0), tempfile.TemporaryDirectory() as tmp:
+                path = Path(tmp) / "metrics.json"
+                path.write_text(
+                    json.dumps(
+                        {
+                            "schema_version": "0.1.0",
+                            "units": {"length": "m", "area": "sqm"},
+                            "metrics": {
+                                "green_ratio": {"status": "known", "value": value, "unit": "ratio"}
+                            },
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                report = ValidationReport()
+                validate_metrics_file(report, path, "metrics.json")
+
+            self.assertFalse(report.ok)
+            self.assertTrue(any("known metric needs numeric value" in error for error in report.errors))
+
     def test_boolean_known_metric_fails_deterministic_validation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "metrics.json"

--- a/tests/test_metric_types.py
+++ b/tests/test_metric_types.py
@@ -1,0 +1,74 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from validate_submission import ValidationReport, validate_metrics_file  # noqa: E402
+from metric_types import is_json_number  # noqa: E402
+
+
+class MetricTypeTests(unittest.TestCase):
+    def test_booleans_are_not_json_numbers(self) -> None:
+        self.assertTrue(is_json_number(0))
+        self.assertTrue(is_json_number(1.0))
+        self.assertFalse(is_json_number(True))
+        self.assertFalse(is_json_number(False))
+
+    def test_boolean_known_metric_fails_deterministic_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "metrics.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "0.1.0",
+                        "units": {"length": "m", "area": "sqm"},
+                        "metrics": {
+                            "green_ratio": {
+                                "status": "known",
+                                "value": True,
+                                "unit": "ratio",
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            report = ValidationReport()
+            validate_metrics_file(report, path, "metrics.json")
+
+        self.assertFalse(report.ok)
+        self.assertTrue(any("known metric needs numeric value" in error for error in report.errors))
+
+    def test_numeric_zero_and_one_remain_valid_ratio_values(self) -> None:
+        for value in (0, 1):
+            with self.subTest(value=value), tempfile.TemporaryDirectory() as tmp:
+                path = Path(tmp) / "metrics.json"
+                path.write_text(
+                    json.dumps(
+                        {
+                            "schema_version": "0.1.0",
+                            "units": {"length": "m", "area": "sqm"},
+                            "metrics": {
+                                "green_ratio": {
+                                    "status": "known",
+                                    "value": value,
+                                    "unit": "ratio",
+                                }
+                            },
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                report = ValidationReport()
+                validate_metrics_file(report, path, "metrics.json")
+
+            self.assertTrue(report.ok, report.errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_metric_types.py
+++ b/tests/test_metric_types.py
@@ -19,6 +19,11 @@ class MetricTypeTests(unittest.TestCase):
         self.assertFalse(is_json_number(True))
         self.assertFalse(is_json_number(False))
 
+    def test_non_finite_values_are_not_json_numbers(self) -> None:
+        for value in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(value=value):
+                self.assertFalse(is_json_number(value))
+
     def test_boolean_known_metric_fails_deterministic_validation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "metrics.json"

--- a/tests/test_spatial_review.py
+++ b/tests/test_spatial_review.py
@@ -141,6 +141,29 @@ class SpatialReviewTests(unittest.TestCase):
         self.assertFalse(report.ok)
         self.assertIn("METRIC_VALUE_TYPE", {issue.check_id for issue in report.issues})
 
+    def test_huge_integer_metric_value_is_rejected_before_spatial_recalculation(self) -> None:
+        for value in (10**1000, -(10**1000)):
+            with self.subTest(sign=value > 0), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                base = "submissions/alice/spatial-huge-integer-metric"
+                write_valid_spatial_package(root, base)
+                write_json(
+                    root,
+                    f"{base}/metrics.json",
+                    {
+                        "schema_version": "0.1.0",
+                        "units": {"length": "m", "area": "sqm"},
+                        "metrics": {
+                            "green_ratio": {"status": "known", "value": value, "unit": "ratio"},
+                        },
+                    },
+                )
+
+                report = review_submission(root / base, REPO_ROOT, "formal")
+
+            self.assertFalse(report.ok)
+            self.assertIn("METRIC_VALUE_TYPE", {issue.check_id for issue in report.issues})
+
     def test_nonfinite_metric_value_is_rejected_before_spatial_recalculation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_spatial_review.py
+++ b/tests/test_spatial_review.py
@@ -119,6 +119,28 @@ class SpatialReviewTests(unittest.TestCase):
             report = review_submission(root / base, REPO_ROOT, "formal")
             self.assertTrue(report.ok, [issue.__dict__ for issue in report.issues])
 
+    def test_boolean_metric_value_is_rejected_before_spatial_recalculation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/spatial-boolean-metric"
+            write_valid_spatial_package(root, base)
+            write_json(
+                root,
+                f"{base}/metrics.json",
+                {
+                    "schema_version": "0.1.0",
+                    "units": {"length": "m", "area": "sqm"},
+                    "metrics": {
+                        "green_ratio": {"status": "known", "value": True, "unit": "ratio"},
+                    },
+                },
+            )
+
+            report = review_submission(root / base, REPO_ROOT, "formal")
+
+        self.assertFalse(report.ok)
+        self.assertIn("METRIC_VALUE_TYPE", {issue.check_id for issue in report.issues})
+
     def test_land_use_gap_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_spatial_review.py
+++ b/tests/test_spatial_review.py
@@ -141,6 +141,32 @@ class SpatialReviewTests(unittest.TestCase):
         self.assertFalse(report.ok)
         self.assertIn("METRIC_VALUE_TYPE", {issue.check_id for issue in report.issues})
 
+    def test_nonfinite_metric_value_is_rejected_before_spatial_recalculation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/spatial-nonfinite-metric"
+            write_valid_spatial_package(root, base)
+            write_json(
+                root,
+                f"{base}/metrics.json",
+                {
+                    "schema_version": "0.1.0",
+                    "units": {"length": "m", "area": "sqm"},
+                    "metrics": {
+                        "green_ratio": {
+                            "status": "known",
+                            "value": float("nan"),
+                            "unit": "ratio",
+                        },
+                    },
+                },
+            )
+
+            report = review_submission(root / base, REPO_ROOT, "formal")
+
+        self.assertFalse(report.ok)
+        self.assertIn("METRIC_VALUE_TYPE", {issue.check_id for issue in report.issues})
+
     def test_land_use_gap_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_spatial_review.py
+++ b/tests/test_spatial_review.py
@@ -249,6 +249,29 @@ class SpatialReviewTests(unittest.TestCase):
             self.assertFalse(report.ok)
             self.assertIn("KEY_AREA_AREA_MISMATCH", {issue.check_id for issue in report.issues})
 
+    def test_provisional_key_area_ignores_non_authoritative_area_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/spatial-provisional-key-area"
+            write_valid_spatial_package(root, base)
+            path = root / base / "geometry/key_areas.geojson"
+            data = json.loads(path.read_text(encoding="utf-8"))
+            props = data["features"][0]["properties"]
+            props.update(
+                source_type="agent_generated_design",
+                confidence="medium",
+                geometry_role="design_proposal",
+                official_boundary=False,
+                official_area_sqm=True,
+            )
+            write_json(root, f"{base}/geometry/key_areas.geojson", data)
+
+            report = review_submission(root / base, REPO_ROOT, "formal")
+
+        check_ids = {issue.check_id for issue in report.issues}
+        self.assertNotIn("KEY_AREA_AREA_TYPE", check_ids)
+        self.assertIn("KEY_AREA_NOT_OFFICIAL", check_ids)
+
     def test_absolute_metric_drift_is_reported_without_blocking_legacy_package(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_visual_review.py
+++ b/tests/test_visual_review.py
@@ -95,6 +95,19 @@ class VisualReviewTests(unittest.TestCase):
             self.assertFalse(report.ok)
             self.assertIn("VISUAL_METRIC_MISMATCH", {issue.check_id for issue in report.issues})
 
+    def test_boolean_metric_value_is_not_coerced_to_one(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_valid_visual_package(Path(tmp))
+            metrics_path = submission / "metrics.json"
+            metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+            metrics["metrics"]["green_ratio"]["value"] = True
+            metrics_path.write_text(json.dumps(metrics), encoding="utf-8")
+
+            report = review_visual(submission)
+
+        self.assertFalse(report.ok)
+        self.assertIn("VISUAL_METRIC_SOURCE_MISSING", {issue.check_id for issue in report.issues})
+
     def test_metric_attribute_order_does_not_change_validation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             submission = write_valid_visual_package(Path(tmp))


### PR DESCRIPTION
## Summary
- replay the reviewed fix from #2229 onto current `main`, where the original PR is now conflicting
- preserve original commit authorship and the `Co-authored-by: 147228` attribution from the underlying #2080 work
- reject JSON booleans and non-finite numeric values consistently across deterministic, visual, and spatial metric validation
- retain current-main manifest Git-blob hashing and all newer validator behavior

Supersedes #2229 without modifying its branch. Closes #2071.

## Reproduction and compatibility
#2071 documents the exact boolean-as-number bypass. The #2229 review also reproduced the non-finite visual bypass and backtested the change against the merged corpus. This PR changes no policy or valid numeric metric semantics; integer and floating-point `0`/`1` remain accepted.

The only replay conflict was the import block in `scripts/validate_submission.py`: current main added `git_blob_sha256`, while the fix adds `is_json_number`; this port retains both.

## Validation
- `PYTHONPATH=scripts:. python3 -m unittest tests.test_metric_types tests.test_spatial_review tests.test_visual_review tests.test_submission_workflow -v` — 170 passed
- `python3 -m py_compile scripts/metric_types.py scripts/spatial_review.py scripts/validate_submission.py scripts/visual_review.py` — passed
- `git diff --check upstream/main...HEAD` — passed
- added-diff secret-pattern scan — no matches

Base verified immediately before push: `upstream/main` is an ancestor of this head with divergence `0 2`.

This is a contributor port, not a maintainer action; normal CODEOWNER review remains required.