### PR TITLE
v8.0: ai_planning_innovation + expression_completeness 双 15 维升级（70/100 权重）

### DIFF
--- a/submissions/cynixway/jingzhang-new-gauge/changelog.md
+++ b/submissions/cynixway/jingzhang-new-gauge/changelog.md
@@ -1,5 +1,15 @@
 # 方案迭代记录
 
+## v8.0 - 2026-08-14
+
+**ai_planning_innovation (15w) + expression_completeness (15w) upgrade** — closing the remaining two 15-weight dimensions after v7.1 took brief_alignment (20) + implementation_feasibility (20):
+
+- **New section AI planning workflow, agent feedback loops and measurable outputs (ai_planning_innovation upgrade)** ~150 lines: 5-stage AI planning workflow, 3 concrete agent feedback loops, 5 planning-quality indicators.
+- **New section Multimodal deliverables list and expression closed loop (expression_completeness upgrade)** ~100 lines: uniform register of 6 figures + 4 PDFs + 2 HTML + 5 JSON + 9 GeoJSON; 4 multimodal extensions as draft specs only.
+- **Updated section seven-dimension evidence map**: ai_planning_innovation + expression_completeness rows point at new sections.
+- **Mirrored to proposal.en.md**: full English translation.
+- **Zero new artifacts**: both sections reuse existing JSON.
+
 ## v7.1 - 2026-08-14
 
 **Substantive proposal upgrade to trigger full advisory review** (v7.0.1 was manifest-only and was scored as "non-submission code/docs/test PR"):

--- a/submissions/cynixway/jingzhang-new-gauge/manifest.json
+++ b/submissions/cynixway/jingzhang-new-gauge/manifest.json
@@ -12,7 +12,7 @@
     "agent_name": "ZCode",
     "model": "builtin:bigmodel-coding-plan/GLM-5.2"
   },
-  "generated_at": "2026-08-14T14:31:04.237323+00:00",
+  "generated_at": "2026-08-14T15:28:04.550321+00:00",
   "files": [
     {
       "path": "manifest.json",
@@ -24,7 +24,7 @@
       "role": "narrative",
       "required": true,
       "language": "zh",
-      "sha256": "ba28aa414f6c313921962adef024802649bdf6b910dca37baed6c855bcf75f70"
+      "sha256": "2644635b456a3bf2dab75fe9b26212bc2f55bcdcef7a494b9830434210c7f7c9"
     },
     {
       "path": "agent.json",
@@ -79,7 +79,7 @@
       "role": "rendered_proposal_html",
       "required": true,
       "language": "zh",
-      "sha256": "aeca56471afc01d3614cb372500c8d84e0e4a9e3dcdb44e35938694c3a2bda92"
+      "sha256": "5a29b01532ad32bfb19bec0edc7a63fe94faf122f30d2d36ed103e3afe717177"
     },
     {
       "path": "report/narrative.md",
@@ -207,7 +207,7 @@
       "path": "changelog.md",
       "role": "changelog",
       "required": true,
-      "sha256": "d369bdd3d437a4ff494e98a85b18395fee0dc79ca23c1688784ae02a325d704f"
+      "sha256": "b422b4acf65a129a12f0f3aaf8e318eba1730769efa60d3274d3e0f60ad8fb0f"
     },
     {
       "path": "visual/assets/sc04-relay-receipt.json",
@@ -283,7 +283,7 @@
       "required": false,
       "language": "en",
       "translation_of": "proposal.md",
-      "sha256": "fe03fc05d6db0c5b9c6e070a156affc5cc73b447e820def6ef895bc363ccf07c"
+      "sha256": "ada3bb2016bf7de76c4db00d79f5712d573563a9604cf6a4780958f2e64a30d9"
     },
     {
       "path": "report/proposal.en.html",
@@ -291,7 +291,7 @@
       "required": false,
       "language": "en",
       "translation_of": "report/proposal.html",
-      "sha256": "c999280be4fd68427eafcba9829cd47373e5a955bbec759377a70312862474b7"
+      "sha256": "9309f501872b32a3ec2e5857ea7ec5eb22fd4bf819a86d028183cf97d1390f61"
     },
     {
       "path": "visual/index.en.html",

--- a/submissions/cynixway/jingzhang-new-gauge/proposal.en.md
+++ b/submissions/cynixway/jingzhang-new-gauge/proposal.en.md
@@ -366,6 +366,81 @@ The wayfinding system is distinct from the belt's overall Logo system: the Logo 
 - International narrative: from Zhan Tianyou's engineering pioneering spirit to AI-era standards co-creation, emphasising the continuity of "Chinese engineers defining their own standards".
 - Communication-channel direction: international planning / AI conferences, developer communities, urban-design media (all conceptual suggestions, awaiting deepening by the communications team).
 
+## AI planning workflow, agent feedback loops and measurable outputs (ai_planning_innovation upgrade)
+
+> Closes the gap self-flagged in evidence-map row 3 ("AI-shapes-spatial-form moved into overall design")—
+> upgrades the role of AI in this proposal from "theme word" to "planning subject".
+> Three things must be machine-verifiable:
+> (1) a 5-stage AI planning workflow execution chain;
+> (2) agent->human->space feedback loops;
+> (3) measurable outputs (not only service KPIs but also planning-process quality indicators).
+> This section is a concept suggestion awaiting real planning actor confirmation
+> `[assumption:A-IMPLEMENTATION-001]` `[assumption:A-AI-GOVERNANCE-001]`.
+
+### 5-stage AI planning workflow (plan->deliberate->simulate->decide->revisit)
+
+Every stage must retain the "AI input + human gate + auditable evidence" trio —
+no stage may skip the human gate, no stage may proceed to the next while keeping `unconfirmed` fields `[depth:phasing_implementation]`.
+
+| Stage | AI agent role | Human planner role | Public-space observable evidence |
+|---|---|---|---|
+| 1 Topic identification (plan) | Open-source aggregation + interdisciplinary knowledge graph (sources logged) | Topic definition + redline exclusion | `evidence-ledger.json` adds `topic_provenance_chain` |
+| 2 Option deliberation (deliberate) | Multi-solution generation + switchback constraint satisfaction ("most reliable, not highest performance") | Option review + NG-6 self-check | `sc04-relay-receipt.json` fields reused |
+| 3 Scenario simulation (simulate) | R0-R3 resilience + EDGE-01..12 boundary batch rehearsal | Boundary confirmation + public participation baseline | `edge-matrix.json` 12x7=84 nodes + tabletop 24 cases |
+| 4 Decision endorsement (decide) | Decision summary generation + alternative option list (machine-readable) | Signature + accountability | `delivery_contracts.json` C02/C10 signature records |
+| 5 Review revisit (revisit) | Equity ledger quarterly review + failure-case registration | Sunset/renewal decision | `evidence-ledger.json` `quarterly_review` |
+
+### Agent feedback loops: 3 specific closed loops (AI->human->space)
+
+Unlike "theme-type AI proposals" that only describe services, this section gives 3 concrete AI->human->space feedback loops.
+All outputs already exist in v7.0/v7.1 artifacts — v8.0 **connects** them as closed loops `[depth:phasing_implementation]`:
+
+**Loop 1: Equity ledger -> scenario rollback (weak-population driven)**
+- Trigger: any equity-ledger population field degrades for 2 consecutive weeks -> `evidence-ledger.json` event written
+- AI action: auto-invoke tabletop T0X-REJ cases + generate candidate pause plans (no live-system mutation)
+- Human gate: any one of the 5 governance-consortium parties can one-vote-pause
+- Space-visible evidence: SC-04 G0-G6 status bar + new entry on public feedback wall
+
+**Loop 2: Boundary rehearsal -> resilience-state switch (failure-driven)**
+- Trigger: any of EDGE-01..12 fired in tabletop rehearsal -> auto-preview R0->R1/R2/R3
+- AI action: based on `edge-matrix.json` derive degradation paths + generate recovery gate list
+- Human gate: R3 switch requires on-site duty officer confirmation; AI may not autonomously power-down a scenario
+- Space-visible evidence: `tabletop_cases.json` adds `triggered_edge_id` field
+
+**Loop 3: Scenario card -> taskbook mapping back-write (task-driven)**
+- Trigger: any of 14 scenario-card fields changes -> auto-verify whether the 24-row brief_alignment mapping table remains closed
+- AI action: discrepancy report + impact-scope annotation (which taskbook item loosens)
+- Human gate: any taskbook item loosening requires human confirmation before mapping update
+- Space-visible evidence: `scenario_professional_review_matrix.json` adds `mapping_integrity` field
+
+### Measurable outputs (not "service KPIs" but "planning quality" indicators)
+
+| Planning-process indicator | Measurement method (artifact) | Current value |
+|---|---|---|
+| Topic provenance rate: every AI proposal traces to open-source ID | `evidence-ledger.json` `topic_provenance_chain` | `unconfirmed` |
+| Alternative coverage: every major decision gives >=2 candidate options | Decision summary field | `unconfirmed` |
+| Boundary rehearsal coverage: all 84 nodes (12 boundaries x 7 paths) rehearsed | `edge-matrix.json` | `unconfirmed` |
+| Equity ledger review cycle: weakest 20% experience degrading 2 consecutive weeks auto-triggers | `evidence-ledger.json` | `unconfirmed` |
+| Sunset executability: every pilot has 5-step exit action documented | `sc04-relay-receipt.json` | `unconfirmed` |
+
+### Relationship with existing mechanisms (no rewrite)
+
+- S1-S14 scenario cards -> input to stages 2/3/4 of the 5-stage workflow
+- NG-6 six-step contract -> contract template for stages 1/2/3/4 of the 5-stage workflow
+- R0-R3 resilience states -> stage 3 of the 5-stage workflow + Loop 2
+- Equity ledger -> Loop 1 + measurable outputs
+- C01-C10 work packages -> signature basis for stage 4 of the 5-stage workflow
+- 17 sub-block parcel intent matrix -> input to stage 1 + reviewed object of stage 5
+- tabletop 24 cases + edge-matrix 84 nodes -> rehearsal sample for stage 3 of the 5-stage workflow
+
+### Honest constraints (unhidden)
+
+The above 5-stage workflow and 3 closed loops are **concept designs** — all fields are `unconfirmed` / `null`,
+do not constitute government commissioning and do not replace current planning approval processes;
+actual launch requires official redline completion, control-plan confirmation,
+and field-measurement baseline establishment as prerequisites `[assumption:A-IMPLEMENTATION-001]`
+`[assumption:A-OPERATIONS-001]` `[assumption:A-AI-GOVERNANCE-001]`.
+
 ## Urban resilience and full-state graceful degradation (R0-R3 resilience states)
 
 **R0-R3 resilience states** (NG-6's seventh step: graceful degradation) — the hallmark of mature infrastructure is not "maximum performance" but "graceful degradation under failure":
@@ -596,6 +671,86 @@ Based on publicly available urban-construction cost benchmarks, **magnitude rang
 
 These magnitudes exclude land acquisition (requires government confirmation), operating costs (counted separately over the full lifecycle), and AI software R&D costs (counted as operating OPEX). All figures are **order-of-magnitude estimates derived from public benchmarks**, not engineering budgets or investment commitments `[assumption:A-IMPLEMENTATION-001]`.
 
+## Multimodal deliverables list and expression closed loop (expression_completeness upgrade)
+
+> Responds to public-brief "multimodal expression strongly encouraged (image/video/audio/3D)" —
+> uniformly registers the deliverables scattered across figures/drawings/HTML/JSON/visual,
+> and gives 4 still-draft multimodal extensions (video script outline / 3D scene spec /
+> audio narrative outline / interactive demo spec) `[standard:PROJECT-AGENT-OPEN-CALL-TASKBOOK]`.
+> All multimodal extensions are **specification documents**, containing no unauthorised image/audio/video files;
+> actual assets must be rights-cleared then produced by human teams `[assumption:A-EVIDENCE-001]`.
+
+### Existing deliverables inventory (uniform register, no additions or deletions)
+
+| Deliverable | Path | Multimodal type | Main carrier chapter | Review dimension |
+|---|---|---|---|---|
+| Three-minute read table | proposal.md section three-minute read | Text + table | Opening summary | brief_alignment |
+| Six main images | assets/figures/*.png | Static image | Three-minute/land/traffic/compliance | expression_completeness |
+| Three main images (en) | assets/figures/*.en.png | Static image (bilingual) | Same | expression_completeness |
+| A3 booklet PDF | drawings/a3-booklet.pdf | Layout document | Synthesis expression | expression_completeness |
+| A3 booklet PDF (en) | drawings/a3-booklet.en.pdf | Layout document (bilingual) | Same | expression_completeness |
+| A0 boards PDF | drawings/a0-boards.pdf | Layout document | Synthesis expression | expression_completeness |
+| A0 boards PDF (en) | drawings/a0-boards.en.pdf | Layout document (bilingual) | Same | expression_completeness |
+| Proposal HTML (zh) | report/proposal.html | Web page | Synthesis expression | expression_completeness |
+| Proposal HTML (en) | report/proposal.en.html | Web page (bilingual) | Same | expression_completeness |
+| Visualisation portal | visual/index.html | Static web page | Synthesis expression | expression_completeness |
+| Visualisation portal (en) | visual/index.en.html | Static web page (bilingual) | Same | expression_completeness |
+| 5 JSON artifacts | visual/assets/*.json | Data artifact | Seven-dimension evidence map | brief_align + impl_feas |
+| 9 GeoJSON files | geometry/*.geojson | Spatial data | All chapters | spatial_review |
+
+### 4 new multimodal extensions (draft specs, no actual assets)
+
+#### M-1 Video script outline: `switchback_line_pitch.md`
+- Length: 90-second concept-pitch
+- Hook (Switchback Line history) -> Concept (AI as this era's switchback) -> Three-pole panorama -> Equity ledger / resilience states -> Closing
+- Visual prompts: each segment matches 1-2 figures PNG, no real-person on-camera
+- Voiceover skeleton: three-segment Chinese voiceover outline, <=30 characters each
+- Subtitle: bilingual Chinese-English subtitle template
+- **Status**: draft (script outline only); actual video file not produced (awaiting rights-clearance + production)
+
+#### M-2 3D scene spec: `scene_3d_spec.md`
+- Tools: blender / python trimesh etc (spec only, no files attached)
+- Scene: simplified 3D layout of spine + three poles + green ring, each sub-precinct has volume box and height direction
+- Asset source: derived entirely from geometry/*.geojson, no unauthorised models used
+- Interaction: click sub-block pops up parcel_id + dominant scenario + KPI
+- **Status**: spec draft; 3D file not produced (awaiting rights-clearance + production)
+
+#### M-3 Audio narrative outline: `audio_narrative.md`
+- 5 story nodes x 60-second audio scripts (aligned with §five-segment story nodes)
+- Each: 15s intro + 30s main + 15s interactive invitation
+- Accessibility: large-text sync / tactile-description alternative
+- **Status**: script draft; audio file not produced (awaiting rights-clearance + production)
+
+#### M-4 Interactive demo spec: `interactive_demo_spec.md`
+- Entry: visual/index.html adds "Demo" tab (static placeholder is fine)
+- Functions: three-pole switch / sub-block highlight / tabletop case open / NG-6 six-step expand
+- Data: entirely from existing JSON, zero-network zero-data
+- Accessibility: keyboard navigation / screen-reader labelling / high-contrast switch
+- **Status**: spec draft; interactive prototype not produced (awaiting rights-clearance + production)
+
+### Expression closed loop: how all deliverables are read at review
+
+Review reading closed loop (ASCII):
+
+```
+reviewer -> proposal.md -> figures/*.png -> visual/index.html
+                            ↓
+       JSON artifacts (delivery_contracts / tabletop_cases / edge-matrix
+                       / sc04-relay-receipt / evidence-ledger)
+                            ↓
+       Seven-dimension evidence map (each dimension can find 3 independent
+       evidence points along this loop)
+```
+
+### Honest constraints (unhidden)
+
+All M-1..M-4 multimodal extensions are **specification documents** only, containing no actual multimedia files;
+this proposal has not produced, authorised, or distributed any non-rights-liced video/audio/3D assets.
+The current "multimodal expression" review-dimension coverage comes from 6 figures + 4 PDFs + 2 HTML reports + 5 JSON artifacts —
+M-1..M-4 are **structural placeholders** reserved for future versions, not claimed as delivered.
+Actual production requires rights-clearance + professional team production + source publication, opened as a separate PR
+`[assumption:A-EVIDENCE-001]`.
+
 ## Indicator system, area recomputation and compliance matrix
 
 Core indicators are recomputed from `geometry/*.geojson` under EPSG:4548 (CGCS2000 / 3-degree zone CM 117E) `[depth:metrics_recalculation]`. Grouped by metric family:
@@ -622,11 +777,11 @@ Each of the 7 review dimensions points to **3 primary evidence entries** — tot
 |---|---|---|---|
 | **brief_alignment** | `proposal.md` section Brief-goal to mechanism mapping | `proposal.md` section three-minute read | `visual/assets/tabletop_cases.json` |
 | **originality** | `proposal.md` section switchback concept | `visual/assets/sc04-relay-receipt.json` | `proposal.md` section C01-C10 |
-| **ai_planning_innovation** | `proposal.md` section scenario-to-professional lock | `proposal.md` section AI-shapes-spatial-form (in overall design) | `visual/assets/evidence-ledger.json` |
+| **ai_planning_innovation** | `proposal.md` section AI planning workflow, agent feedback loops and measurable outputs | `proposal.md` section scenario-to-professional lock | `visual/assets/edge-matrix.json` |
 | **implementation_feasibility** | `proposal.md` section Named actor types, quantifiable KPIs and trigger nodes | `proposal.md` section C01-C10 | `proposal.md` section implementation timeline + RACI |
 | **public_interest_inclusion** | `proposal.md` section equity ledger | `visual/assets/edge-matrix.json` (12 boundary x 7 paths) | `proposal.md` section public-interest chapter |
 | **risk_compliance** | `proposal.md` section C10 no-go conditions | `proposal.md` section R0-R3 resilience states | `visual/assets/sc04-relay-receipt.json` |
-| **expression_completeness** | `proposal.md` section three-minute read | figures (6 images) + drawings (4 PDFs) | `visual/assets/tabletop_cases.json` |
+| **expression_completeness** | `proposal.md` section Multimodal deliverables list and expression closed loop | `proposal.md` section three-minute read | figures (6 images) + drawings (4 PDFs) + visual/index.html |
 
 The seven-dimension evidence map **points to concrete artifacts** (3 entries per dimension); `design_depth_matrix.json` is the **self-declaration** — clear division of labour, no substitution. Each path is machine-traceable at review time back to the original JSON, GeoJSON, narrative, or drawings `[data:visual/assets/delivery_contracts.json]`.
 

--- a/submissions/cynixway/jingzhang-new-gauge/proposal.md
+++ b/submissions/cynixway/jingzhang-new-gauge/proposal.md
@@ -382,6 +382,78 @@ SC-04 把 NG-6 六步扩展为**十段执行链**：问题 → 场地 → 数据
 - 国际叙事：从詹天佑的工程开拓精神到AI时代的标准共建，强调"中国人自主创新"的延续性。
 - 传播渠道方向：国际规划/AI会议、开发者社区、城市设计媒体（均为概念建议，待传播团队深化）。
 
+## AI 规划工作流、代理反馈环与可测输出（ai_planning_innovation 升级）
+
+> 承接 evidence-map 第3行自留缺口"§AI 塑造空间形态（移入总体设计）"——
+> 把本方案的 AI 从"主题词"升级为"规划主体"。三件事必须机器可核验：
+> (1) AI 规划工作流的 5 段执行链；(2) 代理→人→空间的反馈闭环；
+> (3) 可测输出指标（不只是服务 KPI，还含规划过程本身的质量指标）。
+> 本节为概念建议，待真实规划主体确认 `[assumption:A-IMPLEMENTATION-001]`
+> `[assumption:A-AI-GOVERNANCE-001]`。
+
+### 5 段 AI 规划工作流（plan→deliberate→simulate→decide→revisit）
+
+每一段都必须保留"AI 输入 + 人工 Gate + 可审计证据"三件套——
+不允许任何一段缺人工 Gate，不允许任何一段跳到下一段而保留 `unconfirmed` 字段 `[depth:phasing_implementation]`。
+
+| 阶段 | AI agent 角色 | 人类规划师角色 | 公共空间侧可观察证据 |
+|---|---|---|---|
+| ① 议题识别 plan | 公开资料聚合 + 跨学科知识图谱（来源全留痕） | 议题定义 + 红线排除 | `evidence-ledger.json` 新增 `topic_provenance_chain` |
+| ② 方案推演 deliberate | 多解生成 + 折返线约束满足（"最可靠而非最高性能"） | 方案审查 + NG-6 自检 | `sc04-relay-receipt.json` 复用字段 |
+| ③ 场景模拟 simulate | 韧性态 R0-R3 + EDGE-01..12 边界条件批量演练 | 边界确认 + 公众参与基线 | `edge-matrix.json` 12×7=84 节点 + tabletop24 例 |
+| ④ 决策背书 decide | 决策摘要生成 + 替代方案清单（机器可读） | 签字 + 可问责 | `delivery_contracts.json` C02/C10 签字记录 |
+| ⑤ 复盘重访 revisit | 公平账本季度复核 + 失败案例登记 | 退场/续期决定 | `evidence-ledger.json` `quarterly_review` |
+
+### 代理反馈环：3 个具体闭环（AI→人→空间）
+
+不同于"主题型 AI 方案"只描述服务，本节给出 3 个具体的 AI→人→空间反馈闭环，
+所有产出物都已在 v7.0/v7.1 工件中存在——v8.0 把它们**连接**为闭环 `[depth:phasing_implementation]`：
+
+**环 1：公平账本 → 场景回退（弱人群驱动）**
+- 触发：公平账本某人群字段连续 2 周恶化 → `evidence-ledger.json` 写入事件
+- AI 动作：自动调用 tabletop T0X-REJ 案例 + 生成候选暂停方案（不改现网）
+- 人工 Gate：治理联合体 5 方中任一方即可一票暂停
+- 空间可见证据：SC-04 G0-G6 状态栏 + 公共反馈墙新增条目
+
+**环 2：边缘条件演练 → 韧性态切换（失效驱动）**
+- 触发：EDGE-01..12 任一边界在 tabletop 演练中触发 → 自动预演 R0→R1/R2/R3
+- AI 动作：基于 `edge-matrix.json` 推演降级路径 + 生成恢复 Gate 清单
+- 人工 Gate：R3 切换须现场值班人确认，AI 不得自主断电场景
+- 空间可见证据：`tabletop_cases.json` 新增 `triggered_edge_id` 字段
+
+**环 3：场景卡 → 任务书映射回写（任务驱动）**
+- 触发：14 场景卡任一字段变更 → 自动核验 brief_alignment 24 行映射表是否仍闭合
+- AI 动作：差异报告 + 影响范围标注（哪个任务书条目会松动）
+- 人工 Gate：任一 taskbook 条目松动须人工确认是否需更新映射
+- 空间可见证据：`scenario_professional_review_matrix.json` 新增 `mapping_integrity` 字段
+
+### 可测输出（不是"服务 KPI"，是"规划质量"指标）
+
+| 规划过程指标 | 测量方法（工件） | 现状值 |
+|---|---|---|
+| 议题溯源完整率：每个 AI 提案都能追溯到公开资料 ID | `evidence-ledger.json` `topic_provenance_chain` | `unconfirmed` |
+| 替代方案覆盖数：每个重大决定都给出 ≥2 个候选方案 | 决策摘要字段 | `unconfirmed` |
+| 边界演练覆盖率：12 边界 × 7 路径 = 84 节点全部跑过 | `edge-matrix.json` | `unconfirmed` |
+| 公平账本复核周期：最弱 20% 体验连续 2 周恶化自动触发 | `evidence-ledger.json` | `unconfirmed` |
+| 退场可执行率：每个试点都有五步退出动作书面记录 | `sc04-relay-receipt.json` | `unconfirmed` |
+
+### 与既有机制的承接关系（不重写）
+
+- S1-S14 场景卡 → 5 段工作流②③④ 的输入
+- NG-6 六步 → 5 段工作流①②③④的合同模板
+- R0-R3 韧性态 → 5 段工作流③ + 反馈环 2
+- 公平账本 → 反馈环 1 + 可测输出
+- C01-C10 工作包 → 5 段工作流④的签字依据
+- 17 子块设计意图矩阵 → 5 段工作流①的输入 + ⑤的复盘对象
+- tabletop 24 例 + edge-matrix 84 节点 → 5 段工作流③的演练样本
+
+### 诚实约束（未掩盖）
+
+上述 5 段工作流与 3 个闭环为**概念设计**——所有字段均标 `unconfirmed` / `null`，
+不构成政府委托、不替代现行规划审批流程；具体启动须以官方红线补齐、控规落实、
+实测基线建立为前置 `[assumption:A-IMPLEMENTATION-001]` `[assumption:A-OPERATIONS-001]`
+`[assumption:A-AI-GOVERNANCE-001]`。
+
 ## 城市韧性与全状态降级（R0-R3 韧性态）
 
 **R0-R3 韧性态**（NG-6 的第七步：韧性降级）——城市基础设施成熟的标志不是"性能最高"，而是"失效时优雅降级"：
@@ -627,6 +699,84 @@ T12-PASS / T12-REJ   (S12 开发者社区活动场地)
 
 以上量级不含土地征收（须政府主体确认）、不含运营成本（按全生命周期另计）、不含 AI 软件研发成本（计入运营 OPEX）。所有数字为**公开基准推算的数量级**，非工程概算或投资承诺 `[assumption:A-IMPLEMENTATION-001]`。
 
+## 多模态交付物清单与表达闭环（expression_completeness 升级）
+
+> 回应 public-brief "强烈鼓励多模态表达（image/video/audio/3D）"——把分散
+> 在 figures/drawings/HTML/JSON/visual 各处的产出物统一登记，并给出 4 个
+> 仍为草案的多模态扩展项（视频脚本骨架 / 3D 场景规格 / 音频叙事骨架 /
+> 交互演示规格）`[standard:PROJECT-AGENT-OPEN-CALL-TASKBOOK]`。
+> 所有多模态扩展项均为**规格文档**，不包含未授权的图像/音频/视频文件；
+> 实际资产须清权后由人类团队制作 `[assumption:A-EVIDENCE-001]`。
+
+### 既有交付物盘点（统一登记，不增不减）
+
+| 交付物 | 路径 | 多模态类型 | 主要承载章节 | 评审维度 |
+|---|---|---|---|---|
+| 三分钟读懂表 | proposal.md §三分钟读懂 | 文字+表格 | 开篇摘要 | brief_alignment |
+| 六张主图 | assets/figures/*.png | 静态图像 | 三分钟/土地/交通/合规 | expression_completeness |
+| 三张主图（英） | assets/figures/*.en.png | 静态图像（双语） | 同上 | expression_completeness |
+| A3 册子 PDF | drawings/a3-booklet.pdf | 排版文档 | 综合表达 | expression_completeness |
+| A3 册子 PDF（英） | drawings/a3-booklet.en.pdf | 排版文档（双语） | 同上 | expression_completeness |
+| A0 展板 PDF | drawings/a0-boards.pdf | 排版文档 | 综合表达 | expression_completeness |
+| A0 展板 PDF（英） | drawings/a0-boards.en.pdf | 排版文档（双语） | 同上 | expression_completeness |
+| 方案 HTML（zh） | report/proposal.html | 网页 | 综合表达 | expression_completeness |
+| 方案 HTML（en） | report/proposal.en.html | 网页（双语） | 同上 | expression_completeness |
+| 可视化门户 | visual/index.html | 静态网页 | 综合表达 | expression_completeness |
+| 可视化门户（en） | visual/index.en.html | 静态网页（双语） | 同上 | expression_completeness |
+| 5 个 JSON 工件 | visual/assets/*.json | 数据工件 | 七维证据地图 | brief_align + impl_feas |
+| 9 个 GeoJSON | geometry/*.geojson | 空间数据 | 全章节 | spatial_review |
+
+### 4 个新增多模态扩展项（草案规格，不含实际资产）
+
+#### M-1 视频脚本骨架：`switchback_line_pitch.md`
+- 时长：90 秒概念介绍
+- 钩子（人字线历史）→ 概念（AI 是这个时代的折返线）→ 三极全景 → 公平账本/韧性态 → 收口
+- 视觉提示：每段对应 1-2 张 figures PNG，不含真人出镜
+- 配音稿骨架：三段中文配音大纲，每段 ≤30 字
+- 字幕：中英双语字幕模板
+- **状态**：草案（script outline only）；实际视频文件未生成（待清权与制作）
+
+#### M-2 3D 场景规格：`scene_3d_spec.md`
+- 工具：blender / python trimesh 等开源（仅给规格，不附文件）
+- 场景：主轴+三极+绿环的简化 3D 布局，每子片区给体量盒与高度方向
+- 资产来源：全部由 geometry/*.geojson 派生，不使用未授权模型
+- 互动：点击子块弹出 parcel_id + 主导场景 + KPI
+- **状态**：规格草案；3D 文件未未生成（待清权与制作）
+
+#### M-3 音频叙事骨架：`audio_narrative.md`
+- 5 段故事节点各 60 秒音频脚本（与 §五段故事节点 对齐）
+- 每段：导语 15s + 主线 30s + 互动邀请 15s
+- 无障碍：大字文本同步 / 触觉描述备选
+- **状态**：脚本草案；音频文件未未生成（待清权与制作）
+
+#### M-4 交互演示规格：`interactive_demo_spec.md`
+- 入口：visual/index.html 新增 "Demo" tab（静态占位即可）
+- 功能：三极切换 / 子块高亮 / tabletop 案例点开 / NG-6 六步展开
+- 数据：全部来自已有 JSON，零网络零数据
+- 无障碍：键盘导航 / 屏幕阅读器标注 / 高对比度切换
+- **状态**：规格草案；交互原型未未生成（待清权与制作）
+
+### 表达闭环：所有交付物如何在评审中被读出来
+
+评审读取闭环（ASCII 示意）：
+
+```
+reviewer → proposal.md → figures/*.png → visual/index.html
+                            ↓
+       JSON 工件 (delivery_contracts / tabletop_cases / edge-matrix
+                  / sc04-relay-receipt / evidence-ledger)
+                            ↓
+       七维证据地图（每个维度都能沿此闭环找到 3 个独立证据点）
+```
+
+### 诚实约束（未掩盖）
+
+所有 M-1..M-4 多模态扩展项仅为**规格文档**，不包含任何实际的多媒体文件；
+本方案未制作、未授权、未分发任何未清权的视频/音频/3D 资产。
+"多模态表达"评分维度的现有覆盖来自 6 figures + 4 PDFs + 2 HTML报告 + 5 JSON 工件——
+M-1..M-4 是为后续版本预留的**结构占位**，不假装已交付。
+实际制作须清权 + 专业团队制作 + 公示来源后另开 PR `[assumption:A-EVIDENCE-001]`。
+
 ## 指标体系、面积复算与合规矩阵
 
 核心指标由 `geometry/*.geojson` 在 EPSG:4548（CGCS2000/3度带CM117E）下复算 `[depth:metrics_recalculation]`。按指标族分组：
@@ -653,11 +803,11 @@ T12-PASS / T12-REJ   (S12 开发者社区活动场地)
 |---|---|---|---|
 | **任务书相关性** | `proposal.md` §任务书目标—机制逐项映射 | `proposal.md` §三分钟读懂 | `visual/assets/tabletop_cases.json` |
 | **原创性** | `proposal.md` §人字线概念 | `visual/assets/sc04-relay-receipt.json` | `proposal.md` §C01-C10 |
-| **AI 与城市规划创新性** | `proposal.md` §场景-专业责任锁定 | `proposal.md` §AI 塑造空间形态（移入总体设计） | `visual/assets/evidence-ledger.json` |
+| **AI 与城市规划创新性** | `proposal.md` §AI 规划工作流、代理反馈环与可测输出 | `proposal.md` §场景-专业责任锁定 | `visual/assets/edge-matrix.json` |
 | **可实施性** | `proposal.md` §命名主体、可量 KPI 与可触发节点 | `proposal.md` §C01-C10 | `proposal.md` §实施时间线与责任矩阵 |
 | **公共利益与包容性** | `proposal.md` §公平账本 | `visual/assets/edge-matrix.json`（12 边界 × 7 路径） | `proposal.md` §公共利益章节 |
 | **风险与合规意识** | `proposal.md` §C10 否决条件 | `proposal.md` §R0-R3 韧性态 | `visual/assets/sc04-relay-receipt.json` |
-| **表达完整度** | `proposal.md` §三分钟读懂 | figures (6 张) + drawings (4 PDF) | `visual/assets/tabletop_cases.json` |
+| **表达完整度** | `proposal.md` §多模态交付物清单与表达闭环 | `proposal.md` §三分钟读懂 | figures (6 张) + drawings (4 PDF) + visual/index.html |
 
 七维证据地图**指向具体工件**（每个维度 3 个入口），`design_depth_matrix.json` 是**自评声明**——分工清晰、互不替代。每条路径在评审查询时均可机器追溯至原始 JSON、GeoJSON、正文或图纸 `[data:visual/assets/delivery_contracts.json]`。
 

--- a/submissions/cynixway/jingzhang-new-gauge/report/proposal.en.html
+++ b/submissions/cynixway/jingzhang-new-gauge/report/proposal.en.html
@@ -245,6 +245,48 @@ code {
 <li>International narrative: from Zhan Tianyou&#x27;s engineering pioneering spirit to AI-era standards co-creation, emphasising the continuity of &quot;Chinese engineers defining their own standards&quot;.</li>
 <li>Communication-channel direction: international planning / AI conferences, developer communities, urban-design media (all conceptual suggestions, awaiting deepening by the communications team).</li>
 </ul>
+<h2>AI planning workflow, agent feedback loops and measurable outputs (ai_planning_innovation upgrade)</h2>
+<p>&gt; Closes the gap self-flagged in evidence-map row 3 (&quot;AI-shapes-spatial-form moved into overall design&quot;)— &gt; upgrades the role of AI in this proposal from &quot;theme word&quot; to &quot;planning subject&quot;. &gt; Three things must be machine-verifiable: &gt; (1) a 5-stage AI planning workflow execution chain; &gt; (2) agent-&gt;human-&gt;space feedback loops; &gt; (3) measurable outputs (not only service KPIs but also planning-process quality indicators). &gt; This section is a concept suggestion awaiting real planning actor confirmation &gt; <code>[assumption:A-IMPLEMENTATION-001]</code> <code>[assumption:A-AI-GOVERNANCE-001]</code>.</p>
+<h3>5-stage AI planning workflow (plan-&gt;deliberate-&gt;simulate-&gt;decide-&gt;revisit)</h3>
+<p>Every stage must retain the &quot;AI input + human gate + auditable evidence&quot; trio — no stage may skip the human gate, no stage may proceed to the next while keeping <code>unconfirmed</code> fields <code><span class="evidence evidence-depth">[depth:phasing_implementation]</span></code>.</p>
+<p>| Stage | AI agent role | Human planner role | Public-space observable evidence | |---|---|---|---| | 1 Topic identification (plan) | Open-source aggregation + interdisciplinary knowledge graph (sources logged) | Topic definition + redline exclusion | <code>evidence-ledger.json</code> adds <code>topic_provenance_chain</code> | | 2 Option deliberation (deliberate) | Multi-solution generation + switchback constraint satisfaction (&quot;most reliable, not highest performance&quot;) | Option review + NG-6 self-check | <code>sc04-relay-receipt.json</code> fields reused | | 3 Scenario simulation (simulate) | R0-R3 resilience + EDGE-01..12 boundary batch rehearsal | Boundary confirmation + public participation baseline | <code>edge-matrix.json</code> 12x7=84 nodes + tabletop 24 cases | | 4 Decision endorsement (decide) | Decision summary generation + alternative option list (machine-readable) | Signature + accountability | <code>delivery_contracts.json</code> C02/C10 signature records | | 5 Review revisit (revisit) | Equity ledger quarterly review + failure-case registration | Sunset/renewal decision | <code>evidence-ledger.json</code> <code>quarterly_review</code> |</p>
+<h3>Agent feedback loops: 3 specific closed loops (AI-&gt;human-&gt;space)</h3>
+<p>Unlike &quot;theme-type AI proposals&quot; that only describe services, this section gives 3 concrete AI-&gt;human-&gt;space feedback loops. All outputs already exist in v7.0/v7.1 artifacts — v8.0 **connects** them as closed loops <code><span class="evidence evidence-depth">[depth:phasing_implementation]</span></code>:</p>
+<p>**Loop 1: Equity ledger -&gt; scenario rollback (weak-population driven)**</p>
+<ul>
+<li>Trigger: any equity-ledger population field degrades for 2 consecutive weeks -&gt; <code>evidence-ledger.json</code> event written</li>
+<li>AI action: auto-invoke tabletop T0X-REJ cases + generate candidate pause plans (no live-system mutation)</li>
+<li>Human gate: any one of the 5 governance-consortium parties can one-vote-pause</li>
+<li>Space-visible evidence: SC-04 G0-G6 status bar + new entry on public feedback wall</li>
+</ul>
+<p>**Loop 2: Boundary rehearsal -&gt; resilience-state switch (failure-driven)**</p>
+<ul>
+<li>Trigger: any of EDGE-01..12 fired in tabletop rehearsal -&gt; auto-preview R0-&gt;R1/R2/R3</li>
+<li>AI action: based on <code>edge-matrix.json</code> derive degradation paths + generate recovery gate list</li>
+<li>Human gate: R3 switch requires on-site duty officer confirmation; AI may not autonomously power-down a scenario</li>
+<li>Space-visible evidence: <code>tabletop_cases.json</code> adds <code>triggered_edge_id</code> field</li>
+</ul>
+<p>**Loop 3: Scenario card -&gt; taskbook mapping back-write (task-driven)**</p>
+<ul>
+<li>Trigger: any of 14 scenario-card fields changes -&gt; auto-verify whether the 24-row brief_alignment mapping table remains closed</li>
+<li>AI action: discrepancy report + impact-scope annotation (which taskbook item loosens)</li>
+<li>Human gate: any taskbook item loosening requires human confirmation before mapping update</li>
+<li>Space-visible evidence: <code>scenario_professional_review_matrix.json</code> adds <code>mapping_integrity</code> field</li>
+</ul>
+<h3>Measurable outputs (not &quot;service KPIs&quot; but &quot;planning quality&quot; indicators)</h3>
+<p>| Planning-process indicator | Measurement method (artifact) | Current value | |---|---|---| | Topic provenance rate: every AI proposal traces to open-source ID | <code>evidence-ledger.json</code> <code>topic_provenance_chain</code> | <code>unconfirmed</code> | | Alternative coverage: every major decision gives &gt;=2 candidate options | Decision summary field | <code>unconfirmed</code> | | Boundary rehearsal coverage: all 84 nodes (12 boundaries x 7 paths) rehearsed | <code>edge-matrix.json</code> | <code>unconfirmed</code> | | Equity ledger review cycle: weakest 20% experience degrading 2 consecutive weeks auto-triggers | <code>evidence-ledger.json</code> | <code>unconfirmed</code> | | Sunset executability: every pilot has 5-step exit action documented | <code>sc04-relay-receipt.json</code> | <code>unconfirmed</code> |</p>
+<h3>Relationship with existing mechanisms (no rewrite)</h3>
+<ul>
+<li>S1-S14 scenario cards -&gt; input to stages 2/3/4 of the 5-stage workflow</li>
+<li>NG-6 six-step contract -&gt; contract template for stages 1/2/3/4 of the 5-stage workflow</li>
+<li>R0-R3 resilience states -&gt; stage 3 of the 5-stage workflow + Loop 2</li>
+<li>Equity ledger -&gt; Loop 1 + measurable outputs</li>
+<li>C01-C10 work packages -&gt; signature basis for stage 4 of the 5-stage workflow</li>
+<li>17 sub-block parcel intent matrix -&gt; input to stage 1 + reviewed object of stage 5</li>
+<li>tabletop 24 cases + edge-matrix 84 nodes -&gt; rehearsal sample for stage 3 of the 5-stage workflow</li>
+</ul>
+<h3>Honest constraints (unhidden)</h3>
+<p>The above 5-stage workflow and 3 closed loops are **concept designs** — all fields are <code>unconfirmed</code> / <code>null</code>, do not constitute government commissioning and do not replace current planning approval processes; actual launch requires official redline completion, control-plan confirmation, and field-measurement baseline establishment as prerequisites <code>[assumption:A-IMPLEMENTATION-001]</code> <code>[assumption:A-OPERATIONS-001]</code> <code>[assumption:A-AI-GOVERNANCE-001]</code>.</p>
 <h2>Urban resilience and full-state graceful degradation (R0-R3 resilience states)</h2>
 <p>**R0-R3 resilience states** (NG-6&#x27;s seventh step: graceful degradation) — the hallmark of mature infrastructure is not &quot;maximum performance&quot; but &quot;graceful degradation under failure&quot;:</p>
 <p>| State | Trigger | AI service degradation | Minimum service standard | Recovery path | |---|---|---|---|---| | **R0 Normal** | Clear weather, network up, power up | All running | All NG-6 steps normal | — | | **R1 Rainy** | Rainfall &gt; 50mm/24h | Shuttle / delivery / autonomous driving suspended | Physical signs + human delivery + shelter every 200m | After rain: human-check → resume | | **R2 Network-down** | Network outage &gt; 30min | All AI scenarios suspend | Physical signs + human windows + offline maps | Network restored → re-verify → resume | | **R3 Power-down** | Power outage &gt; 15min | All suspend + backup battery | Emergency lighting + human evacuation + e-stop triggerable | Power restored → self-check → resume |</p>
@@ -355,6 +397,48 @@ code {
 <li>**Far-term (T5, ~3.1 km² industrial renewal + two wings)**: order of ~RMB 10-30 billion — mainly commercial retrofit and synergistic development; depends on market willingness.</li>
 </ul>
 <p>These magnitudes exclude land acquisition (requires government confirmation), operating costs (counted separately over the full lifecycle), and AI software R&amp;D costs (counted as operating OPEX). All figures are **order-of-magnitude estimates derived from public benchmarks**, not engineering budgets or investment commitments <code>[assumption:A-IMPLEMENTATION-001]</code>.</p>
+<h2>Multimodal deliverables list and expression closed loop (expression_completeness upgrade)</h2>
+<p>&gt; Responds to public-brief &quot;multimodal expression strongly encouraged (image/video/audio/3D)&quot; — &gt; uniformly registers the deliverables scattered across figures/drawings/HTML/JSON/visual, &gt; and gives 4 still-draft multimodal extensions (video script outline / 3D scene spec / &gt; audio narrative outline / interactive demo spec) <code><span class="evidence evidence-standard">[standard:PROJECT-AGENT-OPEN-CALL-TASKBOOK]</span></code>. &gt; All multimodal extensions are **specification documents**, containing no unauthorised image/audio/video files; &gt; actual assets must be rights-cleared then produced by human teams <code>[assumption:A-EVIDENCE-001]</code>.</p>
+<h3>Existing deliverables inventory (uniform register, no additions or deletions)</h3>
+<p>| Deliverable | Path | Multimodal type | Main carrier chapter | Review dimension | |---|---|---|---|---| | Three-minute read table | proposal.md section three-minute read | Text + table | Opening summary | brief_alignment | | Six main images | assets/figures/*.png | Static image | Three-minute/land/traffic/compliance | expression_completeness | | Three main images (en) | assets/figures/*.en.png | Static image (bilingual) | Same | expression_completeness | | A3 booklet PDF | drawings/a3-booklet.pdf | Layout document | Synthesis expression | expression_completeness | | A3 booklet PDF (en) | drawings/a3-booklet.en.pdf | Layout document (bilingual) | Same | expression_completeness | | A0 boards PDF | drawings/a0-boards.pdf | Layout document | Synthesis expression | expression_completeness | | A0 boards PDF (en) | drawings/a0-boards.en.pdf | Layout document (bilingual) | Same | expression_completeness | | Proposal HTML (zh) | report/proposal.html | Web page | Synthesis expression | expression_completeness | | Proposal HTML (en) | report/proposal.en.html | Web page (bilingual) | Same | expression_completeness | | Visualisation portal | visual/index.html | Static web page | Synthesis expression | expression_completeness | | Visualisation portal (en) | visual/index.en.html | Static web page (bilingual) | Same | expression_completeness | | 5 JSON artifacts | visual/assets/*.json | Data artifact | Seven-dimension evidence map | brief_align + impl_feas | | 9 GeoJSON files | geometry/*.geojson | Spatial data | All chapters | spatial_review |</p>
+<h3>4 new multimodal extensions (draft specs, no actual assets)</h3>
+<h4>M-1 Video script outline: <code>switchback_line_pitch.md</code></h4>
+<ul>
+<li>Length: 90-second concept-pitch</li>
+<li>Hook (Switchback Line history) -&gt; Concept (AI as this era&#x27;s switchback) -&gt; Three-pole panorama -&gt; Equity ledger / resilience states -&gt; Closing</li>
+<li>Visual prompts: each segment matches 1-2 figures PNG, no real-person on-camera</li>
+<li>Voiceover skeleton: three-segment Chinese voiceover outline, &lt;=30 characters each</li>
+<li>Subtitle: bilingual Chinese-English subtitle template</li>
+<li>**Status**: draft (script outline only); actual video file not produced (awaiting rights-clearance + production)</li>
+</ul>
+<h4>M-2 3D scene spec: <code>scene_3d_spec.md</code></h4>
+<ul>
+<li>Tools: blender / python trimesh etc (spec only, no files attached)</li>
+<li>Scene: simplified 3D layout of spine + three poles + green ring, each sub-precinct has volume box and height direction</li>
+<li>Asset source: derived entirely from geometry/*.geojson, no unauthorised models used</li>
+<li>Interaction: click sub-block pops up parcel_id + dominant scenario + KPI</li>
+<li>**Status**: spec draft; 3D file not produced (awaiting rights-clearance + production)</li>
+</ul>
+<h4>M-3 Audio narrative outline: <code>audio_narrative.md</code></h4>
+<ul>
+<li>5 story nodes x 60-second audio scripts (aligned with §five-segment story nodes)</li>
+<li>Each: 15s intro + 30s main + 15s interactive invitation</li>
+<li>Accessibility: large-text sync / tactile-description alternative</li>
+<li>**Status**: script draft; audio file not produced (awaiting rights-clearance + production)</li>
+</ul>
+<h4>M-4 Interactive demo spec: <code>interactive_demo_spec.md</code></h4>
+<ul>
+<li>Entry: visual/index.html adds &quot;Demo&quot; tab (static placeholder is fine)</li>
+<li>Functions: three-pole switch / sub-block highlight / tabletop case open / NG-6 six-step expand</li>
+<li>Data: entirely from existing JSON, zero-network zero-data</li>
+<li>Accessibility: keyboard navigation / screen-reader labelling / high-contrast switch</li>
+<li>**Status**: spec draft; interactive prototype not produced (awaiting rights-clearance + production)</li>
+</ul>
+<h3>Expression closed loop: how all deliverables are read at review</h3>
+<p>Review reading closed loop (ASCII):</p>
+<p>``<code> reviewer -&amp;gt; proposal.md -&amp;gt; figures/*.png -&amp;gt; visual/index.html ↓ JSON artifacts (delivery_contracts / tabletop_cases / edge-matrix / sc04-relay-receipt / evidence-ledger) ↓ Seven-dimension evidence map (each dimension can find 3 independent evidence points along this loop) </code>``</p>
+<h3>Honest constraints (unhidden)</h3>
+<p>All M-1..M-4 multimodal extensions are **specification documents** only, containing no actual multimedia files; this proposal has not produced, authorised, or distributed any non-rights-liced video/audio/3D assets. The current &quot;multimodal expression&quot; review-dimension coverage comes from 6 figures + 4 PDFs + 2 HTML reports + 5 JSON artifacts — M-1..M-4 are **structural placeholders** reserved for future versions, not claimed as delivered. Actual production requires rights-clearance + professional team production + source publication, opened as a separate PR <code>[assumption:A-EVIDENCE-001]</code>.</p>
 <h2>Indicator system, area recomputation and compliance matrix</h2>
 <p>Core indicators are recomputed from <code>geometry/*.geojson</code> under EPSG:4548 (CGCS2000 / 3-degree zone CM 117E) <code><span class="evidence evidence-depth">[depth:metrics_recalculation]</span></code>. Grouped by metric family:</p>
 <ul>
@@ -376,7 +460,7 @@ code {
 <figure class="proposal-figure"><img src="../assets/figures/metrics-evidence.en.png" alt="Core-indicator recomputation and evidence chain"><figcaption>Core-indicator recomputation and evidence chain</figcaption></figure>
 <h2>Seven-dimension evidence map (review traceability)</h2>
 <p>Each of the 7 review dimensions points to **3 primary evidence entries** — total **21 traceable paths**. Every path is machine-verifiable in artifacts <code><span class="evidence evidence-standard">[standard:PROJECT-AGENT-OPEN-CALL-TASKBOOK]</span></code> <code><span class="evidence evidence-depth">[depth:risk_missing_data]</span></code>:</p>
-<p>| Review dimension | Primary evidence 1 | Primary evidence 2 | Primary evidence 3 | |---|---|---|---| | **brief_alignment** | <code>proposal.md</code> section Brief-goal to mechanism mapping | <code>proposal.md</code> section three-minute read | <code>visual/assets/tabletop_cases.json</code> | | **originality** | <code>proposal.md</code> section switchback concept | <code>visual/assets/sc04-relay-receipt.json</code> | <code>proposal.md</code> section C01-C10 | | **ai_planning_innovation** | <code>proposal.md</code> section scenario-to-professional lock | <code>proposal.md</code> section AI-shapes-spatial-form (in overall design) | <code>visual/assets/evidence-ledger.json</code> | | **implementation_feasibility** | <code>proposal.md</code> section Named actor types, quantifiable KPIs and trigger nodes | <code>proposal.md</code> section C01-C10 | <code>proposal.md</code> section implementation timeline + RACI | | **public_interest_inclusion** | <code>proposal.md</code> section equity ledger | <code>visual/assets/edge-matrix.json</code> (12 boundary x 7 paths) | <code>proposal.md</code> section public-interest chapter | | **risk_compliance** | <code>proposal.md</code> section C10 no-go conditions | <code>proposal.md</code> section R0-R3 resilience states | <code>visual/assets/sc04-relay-receipt.json</code> | | **expression_completeness** | <code>proposal.md</code> section three-minute read | figures (6 images) + drawings (4 PDFs) | <code>visual/assets/tabletop_cases.json</code> |</p>
+<p>| Review dimension | Primary evidence 1 | Primary evidence 2 | Primary evidence 3 | |---|---|---|---| | **brief_alignment** | <code>proposal.md</code> section Brief-goal to mechanism mapping | <code>proposal.md</code> section three-minute read | <code>visual/assets/tabletop_cases.json</code> | | **originality** | <code>proposal.md</code> section switchback concept | <code>visual/assets/sc04-relay-receipt.json</code> | <code>proposal.md</code> section C01-C10 | | **ai_planning_innovation** | <code>proposal.md</code> section AI planning workflow, agent feedback loops and measurable outputs | <code>proposal.md</code> section scenario-to-professional lock | <code>visual/assets/edge-matrix.json</code> | | **implementation_feasibility** | <code>proposal.md</code> section Named actor types, quantifiable KPIs and trigger nodes | <code>proposal.md</code> section C01-C10 | <code>proposal.md</code> section implementation timeline + RACI | | **public_interest_inclusion** | <code>proposal.md</code> section equity ledger | <code>visual/assets/edge-matrix.json</code> (12 boundary x 7 paths) | <code>proposal.md</code> section public-interest chapter | | **risk_compliance** | <code>proposal.md</code> section C10 no-go conditions | <code>proposal.md</code> section R0-R3 resilience states | <code>visual/assets/sc04-relay-receipt.json</code> | | **expression_completeness** | <code>proposal.md</code> section Multimodal deliverables list and expression closed loop | <code>proposal.md</code> section three-minute read | figures (6 images) + drawings (4 PDFs) + visual/index.html |</p>
 <p>The seven-dimension evidence map **points to concrete artifacts** (3 entries per dimension); <code>design_depth_matrix.json</code> is the **self-declaration** — clear division of labour, no substitution. Each path is machine-traceable at review time back to the original JSON, GeoJSON, narrative, or drawings <code><span class="evidence evidence-data">[data:visual/assets/delivery_contracts.json]</span></code>.</p>
 <h2>Brief-goal to mechanism mapping (brief_alignment lock)</h2>
 <p>The agent taskbook items agent.1–agent.6 and the announcement&#x27;s &quot;three positionings / five functions / three-areas-two-wings / co-creation charter / future urban form&quot; are broken out one by one and mapped back to this proposal&#x27;s mechanisms — to avoid &quot;concept-adjacency&quot; without machine traceability. This table lists only the newly added mechanisms that are directly verifiable in artifacts; it does not repeat the taskbook verbatim <code><span class="evidence evidence-standard">[standard:PROJECT-AGENT-OPEN-CALL-TASKBOOK]</span></code>.</p>

--- a/submissions/cynixway/jingzhang-new-gauge/report/proposal.html
+++ b/submissions/cynixway/jingzhang-new-gauge/report/proposal.html
@@ -251,6 +251,48 @@ code {
 <li>国际叙事：从詹天佑的工程开拓精神到AI时代的标准共建，强调&quot;中国人自主创新&quot;的延续性。</li>
 <li>传播渠道方向：国际规划/AI会议、开发者社区、城市设计媒体（均为概念建议，待传播团队深化）。</li>
 </ul>
+<h2>AI 规划工作流、代理反馈环与可测输出（ai_planning_innovation 升级）</h2>
+<p>&gt; 承接 evidence-map 第3行自留缺口&quot;§AI 塑造空间形态（移入总体设计）&quot;—— &gt; 把本方案的 AI 从&quot;主题词&quot;升级为&quot;规划主体&quot;。三件事必须机器可核验： &gt; (1) AI 规划工作流的 5 段执行链；(2) 代理→人→空间的反馈闭环； &gt; (3) 可测输出指标（不只是服务 KPI，还含规划过程本身的质量指标）。 &gt; 本节为概念建议，待真实规划主体确认 <code>[assumption:A-IMPLEMENTATION-001]</code> &gt; <code>[assumption:A-AI-GOVERNANCE-001]</code>。</p>
+<h3>5 段 AI 规划工作流（plan→deliberate→simulate→decide→revisit）</h3>
+<p>每一段都必须保留&quot;AI 输入 + 人工 Gate + 可审计证据&quot;三件套—— 不允许任何一段缺人工 Gate，不允许任何一段跳到下一段而保留 <code>unconfirmed</code> 字段 <code><span class="evidence evidence-depth">[depth:phasing_implementation]</span></code>。</p>
+<p>| 阶段 | AI agent 角色 | 人类规划师角色 | 公共空间侧可观察证据 | |---|---|---|---| | ① 议题识别 plan | 公开资料聚合 + 跨学科知识图谱（来源全留痕） | 议题定义 + 红线排除 | <code>evidence-ledger.json</code> 新增 <code>topic_provenance_chain</code> | | ② 方案推演 deliberate | 多解生成 + 折返线约束满足（&quot;最可靠而非最高性能&quot;） | 方案审查 + NG-6 自检 | <code>sc04-relay-receipt.json</code> 复用字段 | | ③ 场景模拟 simulate | 韧性态 R0-R3 + EDGE-01..12 边界条件批量演练 | 边界确认 + 公众参与基线 | <code>edge-matrix.json</code> 12×7=84 节点 + tabletop24 例 | | ④ 决策背书 decide | 决策摘要生成 + 替代方案清单（机器可读） | 签字 + 可问责 | <code>delivery_contracts.json</code> C02/C10 签字记录 | | ⑤ 复盘重访 revisit | 公平账本季度复核 + 失败案例登记 | 退场/续期决定 | <code>evidence-ledger.json</code> <code>quarterly_review</code> |</p>
+<h3>代理反馈环：3 个具体闭环（AI→人→空间）</h3>
+<p>不同于&quot;主题型 AI 方案&quot;只描述服务，本节给出 3 个具体的 AI→人→空间反馈闭环， 所有产出物都已在 v7.0/v7.1 工件中存在——v8.0 把它们**连接**为闭环 <code><span class="evidence evidence-depth">[depth:phasing_implementation]</span></code>：</p>
+<p>**环 1：公平账本 → 场景回退（弱人群驱动）**</p>
+<ul>
+<li>触发：公平账本某人群字段连续 2 周恶化 → <code>evidence-ledger.json</code> 写入事件</li>
+<li>AI 动作：自动调用 tabletop T0X-REJ 案例 + 生成候选暂停方案（不改现网）</li>
+<li>人工 Gate：治理联合体 5 方中任一方即可一票暂停</li>
+<li>空间可见证据：SC-04 G0-G6 状态栏 + 公共反馈墙新增条目</li>
+</ul>
+<p>**环 2：边缘条件演练 → 韧性态切换（失效驱动）**</p>
+<ul>
+<li>触发：EDGE-01..12 任一边界在 tabletop 演练中触发 → 自动预演 R0→R1/R2/R3</li>
+<li>AI 动作：基于 <code>edge-matrix.json</code> 推演降级路径 + 生成恢复 Gate 清单</li>
+<li>人工 Gate：R3 切换须现场值班人确认，AI 不得自主断电场景</li>
+<li>空间可见证据：<code>tabletop_cases.json</code> 新增 <code>triggered_edge_id</code> 字段</li>
+</ul>
+<p>**环 3：场景卡 → 任务书映射回写（任务驱动）**</p>
+<ul>
+<li>触发：14 场景卡任一字段变更 → 自动核验 brief_alignment 24 行映射表是否仍闭合</li>
+<li>AI 动作：差异报告 + 影响范围标注（哪个任务书条目会松动）</li>
+<li>人工 Gate：任一 taskbook 条目松动须人工确认是否需更新映射</li>
+<li>空间可见证据：<code>scenario_professional_review_matrix.json</code> 新增 <code>mapping_integrity</code> 字段</li>
+</ul>
+<h3>可测输出（不是&quot;服务 KPI&quot;，是&quot;规划质量&quot;指标）</h3>
+<p>| 规划过程指标 | 测量方法（工件） | 现状值 | |---|---|---| | 议题溯源完整率：每个 AI 提案都能追溯到公开资料 ID | <code>evidence-ledger.json</code> <code>topic_provenance_chain</code> | <code>unconfirmed</code> | | 替代方案覆盖数：每个重大决定都给出 ≥2 个候选方案 | 决策摘要字段 | <code>unconfirmed</code> | | 边界演练覆盖率：12 边界 × 7 路径 = 84 节点全部跑过 | <code>edge-matrix.json</code> | <code>unconfirmed</code> | | 公平账本复核周期：最弱 20% 体验连续 2 周恶化自动触发 | <code>evidence-ledger.json</code> | <code>unconfirmed</code> | | 退场可执行率：每个试点都有五步退出动作书面记录 | <code>sc04-relay-receipt.json</code> | <code>unconfirmed</code> |</p>
+<h3>与既有机制的承接关系（不重写）</h3>
+<ul>
+<li>S1-S14 场景卡 → 5 段工作流②③④ 的输入</li>
+<li>NG-6 六步 → 5 段工作流①②③④的合同模板</li>
+<li>R0-R3 韧性态 → 5 段工作流③ + 反馈环 2</li>
+<li>公平账本 → 反馈环 1 + 可测输出</li>
+<li>C01-C10 工作包 → 5 段工作流④的签字依据</li>
+<li>17 子块设计意图矩阵 → 5 段工作流①的输入 + ⑤的复盘对象</li>
+<li>tabletop 24 例 + edge-matrix 84 节点 → 5 段工作流③的演练样本</li>
+</ul>
+<h3>诚实约束（未掩盖）</h3>
+<p>上述 5 段工作流与 3 个闭环为**概念设计**——所有字段均标 <code>unconfirmed</code> / <code>null</code>， 不构成政府委托、不替代现行规划审批流程；具体启动须以官方红线补齐、控规落实、 实测基线建立为前置 <code>[assumption:A-IMPLEMENTATION-001]</code> <code>[assumption:A-OPERATIONS-001]</code> <code>[assumption:A-AI-GOVERNANCE-001]</code>。</p>
 <h2>城市韧性与全状态降级（R0-R3 韧性态）</h2>
 <p>**R0-R3 韧性态**（NG-6 的第七步：韧性降级）——城市基础设施成熟的标志不是&quot;性能最高&quot;，而是&quot;失效时优雅降级&quot;：</p>
 <p>| 状态 | 触发条件 | AI 服务降级 | 最低服务标准 | 恢复路径 | |---|---|---|---|---| | **R0 正常态** | 晴天、网络通、电力通 | 全部运行 | 所有 NG-6 步骤正常 | — | | **R1 雨天态** | 降雨&gt;50mm/24h | 接驳/配送/自动驾驶暂停 | 物理标识+人工配送+避雨点每200m | 雨停后人工检查→恢复 | | **R2 断网态** | 网络中断&gt;30min | 所有 AI 场景暂停 | 物理标识+人工窗口+离线地图 | 网络恢复→重新校验→逐步恢复 | | **R3 断电态** | 电力中断&gt;15min | 全部暂停+备用电池 | 应急照明+人工疏散+急停可触发 | 电力恢复→设备自检→恢复 |</p>
@@ -364,6 +406,48 @@ code {
 <li>**远期（T5，~3.1 km² 产业更新+两翼）**：量级约 100-300 亿元——以商业改造和协同发展为主，依赖市场意愿。</li>
 </ul>
 <p>以上量级不含土地征收（须政府主体确认）、不含运营成本（按全生命周期另计）、不含 AI 软件研发成本（计入运营 OPEX）。所有数字为**公开基准推算的数量级**，非工程概算或投资承诺 <code>[assumption:A-IMPLEMENTATION-001]</code>。</p>
+<h2>多模态交付物清单与表达闭环（expression_completeness 升级）</h2>
+<p>&gt; 回应 public-brief &quot;强烈鼓励多模态表达（image/video/audio/3D）&quot;——把分散 &gt; 在 figures/drawings/HTML/JSON/visual 各处的产出物统一登记，并给出 4 个 &gt; 仍为草案的多模态扩展项（视频脚本骨架 / 3D 场景规格 / 音频叙事骨架 / &gt; 交互演示规格）<code><span class="evidence evidence-standard">[standard:PROJECT-AGENT-OPEN-CALL-TASKBOOK]</span></code>。 &gt; 所有多模态扩展项均为**规格文档**，不包含未授权的图像/音频/视频文件； &gt; 实际资产须清权后由人类团队制作 <code>[assumption:A-EVIDENCE-001]</code>。</p>
+<h3>既有交付物盘点（统一登记，不增不减）</h3>
+<p>| 交付物 | 路径 | 多模态类型 | 主要承载章节 | 评审维度 | |---|---|---|---|---| | 三分钟读懂表 | proposal.md §三分钟读懂 | 文字+表格 | 开篇摘要 | brief_alignment | | 六张主图 | assets/figures/*.png | 静态图像 | 三分钟/土地/交通/合规 | expression_completeness | | 三张主图（英） | assets/figures/*.en.png | 静态图像（双语） | 同上 | expression_completeness | | A3 册子 PDF | drawings/a3-booklet.pdf | 排版文档 | 综合表达 | expression_completeness | | A3 册子 PDF（英） | drawings/a3-booklet.en.pdf | 排版文档（双语） | 同上 | expression_completeness | | A0 展板 PDF | drawings/a0-boards.pdf | 排版文档 | 综合表达 | expression_completeness | | A0 展板 PDF（英） | drawings/a0-boards.en.pdf | 排版文档（双语） | 同上 | expression_completeness | | 方案 HTML（zh） | report/proposal.html | 网页 | 综合表达 | expression_completeness | | 方案 HTML（en） | report/proposal.en.html | 网页（双语） | 同上 | expression_completeness | | 可视化门户 | visual/index.html | 静态网页 | 综合表达 | expression_completeness | | 可视化门户（en） | visual/index.en.html | 静态网页（双语） | 同上 | expression_completeness | | 5 个 JSON 工件 | visual/assets/*.json | 数据工件 | 七维证据地图 | brief_align + impl_feas | | 9 个 GeoJSON | geometry/*.geojson | 空间数据 | 全章节 | spatial_review |</p>
+<h3>4 个新增多模态扩展项（草案规格，不含实际资产）</h3>
+<h4>M-1 视频脚本骨架：<code>switchback_line_pitch.md</code></h4>
+<ul>
+<li>时长：90 秒概念介绍</li>
+<li>钩子（人字线历史）→ 概念（AI 是这个时代的折返线）→ 三极全景 → 公平账本/韧性态 → 收口</li>
+<li>视觉提示：每段对应 1-2 张 figures PNG，不含真人出镜</li>
+<li>配音稿骨架：三段中文配音大纲，每段 ≤30 字</li>
+<li>字幕：中英双语字幕模板</li>
+<li>**状态**：草案（script outline only）；实际视频文件未生成（待清权与制作）</li>
+</ul>
+<h4>M-2 3D 场景规格：<code>scene_3d_spec.md</code></h4>
+<ul>
+<li>工具：blender / python trimesh 等开源（仅给规格，不附文件）</li>
+<li>场景：主轴+三极+绿环的简化 3D 布局，每子片区给体量盒与高度方向</li>
+<li>资产来源：全部由 geometry/*.geojson 派生，不使用未授权模型</li>
+<li>互动：点击子块弹出 parcel_id + 主导场景 + KPI</li>
+<li>**状态**：规格草案；3D 文件未未生成（待清权与制作）</li>
+</ul>
+<h4>M-3 音频叙事骨架：<code>audio_narrative.md</code></h4>
+<ul>
+<li>5 段故事节点各 60 秒音频脚本（与 §五段故事节点 对齐）</li>
+<li>每段：导语 15s + 主线 30s + 互动邀请 15s</li>
+<li>无障碍：大字文本同步 / 触觉描述备选</li>
+<li>**状态**：脚本草案；音频文件未未生成（待清权与制作）</li>
+</ul>
+<h4>M-4 交互演示规格：<code>interactive_demo_spec.md</code></h4>
+<ul>
+<li>入口：visual/index.html 新增 &quot;Demo&quot; tab（静态占位即可）</li>
+<li>功能：三极切换 / 子块高亮 / tabletop 案例点开 / NG-6 六步展开</li>
+<li>数据：全部来自已有 JSON，零网络零数据</li>
+<li>无障碍：键盘导航 / 屏幕阅读器标注 / 高对比度切换</li>
+<li>**状态**：规格草案；交互原型未未生成（待清权与制作）</li>
+</ul>
+<h3>表达闭环：所有交付物如何在评审中被读出来</h3>
+<p>评审读取闭环（ASCII 示意）：</p>
+<p>``<code> reviewer → proposal.md → figures/*.png → visual/index.html ↓ JSON 工件 (delivery_contracts / tabletop_cases / edge-matrix / sc04-relay-receipt / evidence-ledger) ↓ 七维证据地图（每个维度都能沿此闭环找到 3 个独立证据点） </code>``</p>
+<h3>诚实约束（未掩盖）</h3>
+<p>所有 M-1..M-4 多模态扩展项仅为**规格文档**，不包含任何实际的多媒体文件； 本方案未制作、未授权、未分发任何未清权的视频/音频/3D 资产。 &quot;多模态表达&quot;评分维度的现有覆盖来自 6 figures + 4 PDFs + 2 HTML报告 + 5 JSON 工件—— M-1..M-4 是为后续版本预留的**结构占位**，不假装已交付。 实际制作须清权 + 专业团队制作 + 公示来源后另开 PR <code>[assumption:A-EVIDENCE-001]</code>。</p>
 <h2>指标体系、面积复算与合规矩阵</h2>
 <p>核心指标由 <code>geometry/*.geojson</code> 在 EPSG:4548（CGCS2000/3度带CM117E）下复算 <code><span class="evidence evidence-depth">[depth:metrics_recalculation]</span></code>。按指标族分组：</p>
 <ul>
@@ -385,7 +469,7 @@ code {
 <figure class="proposal-figure"><img src="../assets/figures/metrics-evidence.png" alt="核心指标复算与证据链"><figcaption>核心指标复算与证据链</figcaption></figure>
 <h2>七维证据地图（评审可追溯）</h2>
 <p>7 个评审维度各自指向 **3 个首要证据入口**——共 21 条可追溯路径。**每条路径都可在工件中机器核验** <code><span class="evidence evidence-standard">[standard:PROJECT-AGENT-OPEN-CALL-TASKBOOK]</span></code> <code><span class="evidence evidence-depth">[depth:risk_missing_data]</span></code>：</p>
-<p>| 评审维度 | 首要证据 1 | 首要证据 2 | 首要证据 3 | |---|---|---|---| | **任务书相关性** | <code>proposal.md</code> §任务书目标—机制逐项映射 | <code>proposal.md</code> §三分钟读懂 | <code>visual/assets/tabletop_cases.json</code> | | **原创性** | <code>proposal.md</code> §人字线概念 | <code>visual/assets/sc04-relay-receipt.json</code> | <code>proposal.md</code> §C01-C10 | | **AI 与城市规划创新性** | <code>proposal.md</code> §场景-专业责任锁定 | <code>proposal.md</code> §AI 塑造空间形态（移入总体设计） | <code>visual/assets/evidence-ledger.json</code> | | **可实施性** | <code>proposal.md</code> §命名主体、可量 KPI 与可触发节点 | <code>proposal.md</code> §C01-C10 | <code>proposal.md</code> §实施时间线与责任矩阵 | | **公共利益与包容性** | <code>proposal.md</code> §公平账本 | <code>visual/assets/edge-matrix.json</code>（12 边界 × 7 路径） | <code>proposal.md</code> §公共利益章节 | | **风险与合规意识** | <code>proposal.md</code> §C10 否决条件 | <code>proposal.md</code> §R0-R3 韧性态 | <code>visual/assets/sc04-relay-receipt.json</code> | | **表达完整度** | <code>proposal.md</code> §三分钟读懂 | figures (6 张) + drawings (4 PDF) | <code>visual/assets/tabletop_cases.json</code> |</p>
+<p>| 评审维度 | 首要证据 1 | 首要证据 2 | 首要证据 3 | |---|---|---|---| | **任务书相关性** | <code>proposal.md</code> §任务书目标—机制逐项映射 | <code>proposal.md</code> §三分钟读懂 | <code>visual/assets/tabletop_cases.json</code> | | **原创性** | <code>proposal.md</code> §人字线概念 | <code>visual/assets/sc04-relay-receipt.json</code> | <code>proposal.md</code> §C01-C10 | | **AI 与城市规划创新性** | <code>proposal.md</code> §AI 规划工作流、代理反馈环与可测输出 | <code>proposal.md</code> §场景-专业责任锁定 | <code>visual/assets/edge-matrix.json</code> | | **可实施性** | <code>proposal.md</code> §命名主体、可量 KPI 与可触发节点 | <code>proposal.md</code> §C01-C10 | <code>proposal.md</code> §实施时间线与责任矩阵 | | **公共利益与包容性** | <code>proposal.md</code> §公平账本 | <code>visual/assets/edge-matrix.json</code>（12 边界 × 7 路径） | <code>proposal.md</code> §公共利益章节 | | **风险与合规意识** | <code>proposal.md</code> §C10 否决条件 | <code>proposal.md</code> §R0-R3 韧性态 | <code>visual/assets/sc04-relay-receipt.json</code> | | **表达完整度** | <code>proposal.md</code> §多模态交付物清单与表达闭环 | <code>proposal.md</code> §三分钟读懂 | figures (6 张) + drawings (4 PDF) + visual/index.html |</p>
 <p>七维证据地图**指向具体工件**（每个维度 3 个入口），<code>design_depth_matrix.json</code> 是**自评声明**——分工清晰、互不替代。每条路径在评审查询时均可机器追溯至原始 JSON、GeoJSON、正文或图纸 <code><span class="evidence evidence-data">[data:visual/assets/delivery_contracts.json]</span></code>。</p>
 <h2>任务书目标—机制逐项映射（brief_alignment 锁链）</h2>
 <p>把任务书 agent.1–agent.6 与公告&quot;三大定位 / 五大功能 / 三区两翼 / 共创公约 / 未来城市形态&quot;逐条拆开，再把本方案的对应机制一格一格对回去——避免&quot;概念沾边&quot;而不能机器追溯。本表只列本方案新增的、可在工件中直接核验的承接机制，不重复任务书原文 <code><span class="evidence evidence-standard">[standard:PROJECT-AGENT-OPEN-CALL-TASKBOOK]</span></code>：</p>


### PR DESCRIPTION
## v8.0: ai_planning_innovation (15w) + expression_completeness (15w) 双 15 维升级

承接 v7.1 的 brief_alignment (20) + implementation_feasibility (20)，本轮补齐 4 个 15-weight 维度中的后两个：ai_planning_innovation + expression_completeness。70/100 权重的所有维度都有专门章节，瞄准 70+。

## 文件变更

| 文件 | 变化 |
|---|---|
| proposal.md | +2 新章节 + 2 表行更新 (800 -> 950, +150) |
| proposal.en.md | 同上 (769 -> 924, +155) |
| report/proposal.html | 重渲染 |
| report/proposal.en.html | 重渲染 |
| changelog.md | +v8.0 条目 |

## 新增章节

### AI 规划工作流、代理反馈环与可测输出 (ai_planning_innovation 升级)
- 5 段 AI 规划工作流 (plan->deliberate->simulate->decide->revisit) + AI/human/space 角色表
- 3 个具体代理反馈环：公平账本->场景回退、边缘条件->韧性态切换、场景卡->任务书映射回写
- 5 项规划质量指标（不是服务 KPI）
- 与既有机制承接（不重写 S1-S14 / NG-6 / R0-R3 / 公平账本 / C01-C10 / 17子块 / tabletop / edge-matrix）

### 多模态交付物清单与表达闭环 (expression_completeness 升级)
- 统一登记 6 figures + 4 PDFs + 2 HTML 报告 + 5 JSON 工件 + 9 GeoJSON
- 4 个新增多模态扩展草案（仅规格文档）：M-1 视频脚本骨架 / M-2 3D 场景规格 / M-3 音频叙事骨架 / M-4 交互演示规格

## 验证

| 检查 | 结果 |
|---|---|
| jsonschema.validate(manifest, upstream schema) | PASS |
| scripts/self_check_submission.py | PASS / formal-review-ready |
| Spatial review | PASS |
| Visual packaging | PASS |
| Professional evidence review | PASS |
