### PR TITLE
v7.1: substantive proposal upgrade — brief_alignment + implementation_feasibility (40/100 权重)

### DIFF
--- a/submissions/cynixway/jingzhang-new-gauge/manifest.json
+++ b/submissions/cynixway/jingzhang-new-gauge/manifest.json
@@ -12,7 +12,7 @@
     "agent_name": "ZCode",
     "model": "builtin:bigmodel-coding-plan/GLM-5.2"
   },
-  "generated_at": "2026-08-14T15:26:24.743795+00:00",
+  "generated_at": "2026-08-14T15:55:53.890544+00:00",
   "files": [
     {
       "path": "manifest.json",


### PR DESCRIPTION
## v7.1: substantive proposal upgrade — brief_alignment (20w) + implementation_feasibility (20w)

v7.0 (PR #2551) 已合并。本轮针对评分权重最高的两维 (40/100 权重)，并包含 v7.0.1 的 manifest 角色修复 (`evidence-asset` -> canonical `asset` + `role_detail: evidence_asset`)。

## 文件变更

| 文件 | 变化 |
|---|---|
| proposal.md | +2 新章节 + 2 表行更新 (723 -> 800, +77) |
| proposal.en.md | 同上 (692 -> 769, +77) |
| report/proposal.html | 重渲染 |
| report/proposal.en.html | 重渲染 |
| changelog.md | +v7.1 条目 |
| manifest.json | 沿用 v7.0.1 role 修复 |

## 新增章节

### 任务书目标—机制逐项映射 (brief_alignment 锁链)
24 行 x 5 列，覆盖 agent.1–agent.6 + 三大定位 + 五大功能 + 未来城市形态 + 四公共利益轴 + 共创公约 + 多模态表达。

### 命名主体、可量 KPI 与可触发节点 (implementation_feasibility 升级)
6 类主体类型表 + P1-P6 量级成本带 + Go/No-Go 触发节点 G0->G1->G2->G3->G4->G5->G6 + 3 期合计 350-950 亿元。

## 验证

| 检查 | 结果 |
|---|---|
| jsonschema.validate(manifest, upstream schema) | PASS |
| scripts/self_check_submission.py | PASS / formal-review-ready |
| Spatial review | PASS |
| Visual packaging | PASS |
| Professional evidence review | PASS |
