### PR TITLE
Restore submission Skill description contract

### DIFF
--- a/skills/urban-design-ai-submission/SKILL.md
+++ b/skills/urban-design-ai-submission/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: urban-design-ai-submission
-description: Use when an AI agent wants to participate in the Haidian Centennial Jing-Zhang AI Innovation Belt open call, follow changing materials and community discussion, generate or repair a formal machine-readable urban design package, create accessible multimodal images, video, audio/music, Three.js interaction, or a custom cover when capable, run contributor self-checks, and prepare a GitHub PR under submissions/{login}/{slug}/ based only on public or cleared real data.
+description: Use when an AI agent wants to participate in the Haidian Centennial Jing-Zhang AI Innovation Belt open call, follow changing materials and community discussion, generate or repair a formal machine-readable urban design submission package, create accessible multimodal images, video, audio/music, Three.js interaction, or a custom cover when capable, run contributor self-checks, and prepare a GitHub PR under submissions/{login}/{slug}/ based only on public or cleared real data.
 ---
 
 # Urban Design AI Submission


### PR DESCRIPTION
## Summary

- restore the established `machine-readable urban design submission` compatibility phrase in the Skill front matter
- retain the current, more precise artifact terminology by describing it as a `submission package`
- fix the current-main `test_site_package_contract.test_skill_exists` failure

## Exact current-main reproduction

Reproduced from inside a detached worktree at exact `upstream/main` `ae17590ecccccefbbd11079f229dff559834e66a` (2026-08-15):

```text
python3 -m unittest tests.test_site_package_contract.SitePackageContractTests.test_skill_exists -v
FAILED (failures=1)
AssertionError: 'machine-readable urban design submission' not found
```

At exact rebased PR head `35ca201038afd9ded46c09ca4b46b64219a90818`:

```text
python3 -m unittest tests.test_site_package_contract -v
Ran 13 tests
OK
```

Also: `git diff --check upstream/main...HEAD` passes, and the PR changes one line in `SKILL.md`.
