### PR TITLE
Fix(1.2): 版本号声明对齐 — iteration v1.1→v1.2（双语 front matter）

### DIFF
--- a/submissions/Soulteion/new-jingzhang-ai-belt/manifest.json
+++ b/submissions/Soulteion/new-jingzhang-ai-belt/manifest.json
@@ -26,7 +26,7 @@
       "role": "narrative",
       "required": true,
       "language": "zh",
-      "sha256": "1ba81231a622989867977da718c5f6b8cabc048375313046b9fcba495fe69cbf"
+      "sha256": "fbfa700758d75fd4dd10bfadfcd46f005de79b5255d55168451a6da5bb7741ea"
     },
     {
       "path": "agent.json",
@@ -56,7 +56,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "fdccb4632ea44d80f848d658a03c4e7aae23587fd0273972d94365337eecf133"
+      "sha256": "aa5776418a0415ddce02c7437b1bb022bdfaad53e0810fc501a66cf4857d47b7"
     },
     {
       "path": "compliance_matrix.json",
@@ -211,7 +211,7 @@
       "required": true,
       "language": "en",
       "translation_of": "proposal.md",
-      "sha256": "6f65fbd19dc3bae438837e8b93bae6e931b987995bfdaabe33c9c54961a7445e"
+      "sha256": "5ef0a785ab9c526f71a8daf142b74d20d8b08754cf678f6d905e6db3142d1d4a"
     },
     {
       "path": "report/proposal.en.html",

--- a/submissions/Soulteion/new-jingzhang-ai-belt/proposal.en.md
+++ b/submissions/Soulteion/new-jingzhang-ai-belt/proposal.en.md
@@ -9,7 +9,7 @@ license: "COMMUNITY-DISPLAY-ONLY"
 summary: "Taking the self-reliance spirit of the zigzag railway as its origin, the proposal reshapes the Jing-Zhang Heritage Park into a north-south 'human-centered AI public spine', with Zhongzhiyuan, the Beijing AI Origin Community and Dazhongsi as the three cores, and the Zhongguancun technology-service wing and Xiaoyuehe scenario wing as the two wings, forming an 'one-spine three-cores, four-belt two-wings, multi-node network' AI innovation belt."
 tracks: ["ai-traffic-walkability", "enterprise-services-ecosystem", "civic-agent-governance"]
 scenarios: ["ai-traffic-walkability", "enterprise-service-copilot", "public-safety-operations-review"]
-iteration: "v1.1"
+iteration: "v1.2"
 ---
 
 # New Jing-Zhang AI Innovation Belt: From the Centennial Zigzag Railway to a Human-Centered AI City

--- a/submissions/Soulteion/new-jingzhang-ai-belt/proposal.md
+++ b/submissions/Soulteion/new-jingzhang-ai-belt/proposal.md
@@ -9,7 +9,7 @@ license: "COMMUNITY-DISPLAY-ONLY"
 summary: "以'人'字形铁路的自主创新精神为原点，将京张遗址公园塑造为贯穿南北的'人本AI公共脊'，以众智园、北京AI原点社区、大钟寺三处重点片区为三芯，以中关村科技服务翼与小月河场景赋能翼为两翼，形成'一脊三芯·四带两翼·多点成网'的AI创新带整体方案。"
 tracks: ["ai-traffic-walkability", "enterprise-services-ecosystem", "civic-agent-governance"]
 scenarios: ["ai-traffic-walkability", "enterprise-service-copilot", "public-safety-operations-review"]
-iteration: "v1.1"
+iteration: "v1.2"
 ---
 
 # 新京张·AI创新带：从百年人字形铁路到人本AI城市

--- a/submissions/Soulteion/new-jingzhang-ai-belt/self_check.json
+++ b/submissions/Soulteion/new-jingzhang-ai-belt/self_check.json
@@ -59,7 +59,7 @@
       "ai_package_stages": {
         "submissions/Soulteion/new-jingzhang-ai-belt": "formal"
       },
-      "total_bytes": 4895725,
+      "total_bytes": 4894930,
       "maintainer_bypass": false
     },
     "stderr": ""


### PR DESCRIPTION
# Fix: v1.2 版本号声明对齐

延续已合并的 v1.2（PR #2559）的小修复：

## 问题
v1.2 更新了三个证据矩阵、正文与来源注册，但 `proposal.md` / `proposal.en.md` 的 front matter `iteration` 字段仍为 `v1.1`，与 `changelog.md` 声明的 v1.2 不符，公开方案页将显示错误版本号。

## 修复
- 两个语言的 `iteration` 字段统一为 `v1.2`
- 重新渲染 HTML（`report/proposal.html` / `proposal.en.html`）并刷新 manifest 哈希

## 验证
- `render_proposal_html.py` ✅
- `refresh_submission_manifest.py` ✅
- `self_check_submission.py --mark-self-checked` ✅（formal-review-ready）
- `participant_preflight.py --check-push` ✅
- 暂存区 blob 哈希与 manifest 0 不匹配（core.autocrlf=false 确保 CI 哈希一致）
