### PR TITLE
Align Rail Memory readiness with current provisional-data policy

### DIFF
--- a/submissions/AsaZhou923/rail-memory-ai-commons/changelog.md
+++ b/submissions/AsaZhou923/rail-memory-ai-commons/changelog.md
@@ -1,5 +1,11 @@
 # 方案迭代记录
 
+## v0.4 - 2026-08-15
+
+- Aligned the readiness claim with the current official Skill contract: missing organizer-supplied official polygons remain a disclosed provisional-data limitation and recomputation trigger, but no longer appear as a participant-controlled content-scoring blocker.
+- Preserved medium data confidence, every provisional-boundary warning, and the requirement for official geometry and professional confirmation before statutory, approval, precise-area, or implementation use.
+- Migrated the merged package to the current persisted four-gate self-check contract using the state-appropriate `refresh_submission_manifest.py` workflow, including the strengthened finite-number and pending-Git-blob validation rules.
+
 ## v0.3 - 2026-08-10
 
 - Addressed the requested change on [PR #1389](https://github.com/open-city-ai/haidian/pull/1389) by aligning `manifest.validation_claim.self_checked` with the persisted all-pass `self_check.json` and a fresh exact-head self-check.

--- a/submissions/AsaZhou923/rail-memory-ai-commons/manifest.json
+++ b/submissions/AsaZhou923/rail-memory-ai-commons/manifest.json
@@ -56,7 +56,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "0f5bcb43e3bcc1cbfafff39dfc833e6a5960b1b38e1ec32c0266c426cab15d35"
+      "sha256": "6aa137a030ef3af6f8f6e9264662812bcc20b66a080ec9dcc3abf62934b6e8aa"
     },
     {
       "path": "compliance_matrix.json",
@@ -288,9 +288,8 @@
   ],
   "validation_claim": {
     "self_checked": true,
-    "known_blockers": [
-      "Official exact site and key-area CAD/GIS polygons are unavailable in the public site package; current geometry is provisional and must be recomputed before professional scoring or implementation use."
-    ],
-    "data_confidence": "medium"
+    "known_blockers": [],
+    "data_confidence": "medium",
+    "readiness_contract": "persisted-self-check-v1"
   }
 }

--- a/submissions/AsaZhou923/rail-memory-ai-commons/self_check.json
+++ b/submissions/AsaZhou923/rail-memory-ai-commons/self_check.json
@@ -1,75 +1,198 @@
 {
+  "ok": true,
+  "submission_dir": "submissions/AsaZhou923/rail-memory-ai-commons",
+  "pr_author": "AsaZhou923",
+  "stage": "formal",
+  "deterministic_validation": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "errors": [],
+      "warnings": [
+        "submissions/AsaZhou923/rail-memory-ai-commons/geometry/site_boundary.geojson: uses provisional boundary; do not treat it as an official redline or precise-area basis. Organizer data gaps do not block content scoring; recalculate when official geometry is supplied"
+      ],
+      "proposal_files": [
+        "submissions/AsaZhou923/rail-memory-ai-commons/proposal.md"
+      ],
+      "changelog_files": [
+        "submissions/AsaZhou923/rail-memory-ai-commons/changelog.md"
+      ],
+      "changed_files": [
+        "submissions/AsaZhou923/rail-memory-ai-commons/agent.json",
+        "submissions/AsaZhou923/rail-memory-ai-commons/assets/figures/key-areas.en.png",
+        "submissions/AsaZhou923/rail-memory-ai-commons/assets/figures/key-areas.png",
+        "submissions/AsaZhou923/rail-memory-ai-commons/assets/figures/land-use-structure.en.png",
+        "submissions/AsaZhou923/rail-memory-ai-commons/assets/figures/land-use-structure.png",
+        "submissions/AsaZhou923/rail-memory-ai-commons/assets/figures/metrics-evidence.en.png",
+        "submissions/AsaZhou923/rail-memory-ai-commons/assets/figures/metrics-evidence.png",
+        "submissions/AsaZhou923/rail-memory-ai-commons/assets/figures/mobility-bluegreen.en.png",
+        "submissions/AsaZhou923/rail-memory-ai-commons/assets/figures/mobility-bluegreen.png",
+        "submissions/AsaZhou923/rail-memory-ai-commons/assets/figures/site-overview.en.png",
+        "submissions/AsaZhou923/rail-memory-ai-commons/assets/figures/site-overview.png",
+        "submissions/AsaZhou923/rail-memory-ai-commons/assumptions.json",
+        "submissions/AsaZhou923/rail-memory-ai-commons/changelog.md",
+        "submissions/AsaZhou923/rail-memory-ai-commons/compliance_matrix.json",
+        "submissions/AsaZhou923/rail-memory-ai-commons/design_depth_matrix.json",
+        "submissions/AsaZhou923/rail-memory-ai-commons/drawings/a0-boards.en.pdf",
+        "submissions/AsaZhou923/rail-memory-ai-commons/drawings/a0-boards.pdf",
+        "submissions/AsaZhou923/rail-memory-ai-commons/drawings/a3-booklet.en.pdf",
+        "submissions/AsaZhou923/rail-memory-ai-commons/drawings/a3-booklet.pdf",
+        "submissions/AsaZhou923/rail-memory-ai-commons/geometry/buildings.geojson",
+        "submissions/AsaZhou923/rail-memory-ai-commons/geometry/constraints.geojson",
+        "submissions/AsaZhou923/rail-memory-ai-commons/geometry/green_space.geojson",
+        "submissions/AsaZhou923/rail-memory-ai-commons/geometry/key_areas.geojson",
+        "submissions/AsaZhou923/rail-memory-ai-commons/geometry/land_use.geojson",
+        "submissions/AsaZhou923/rail-memory-ai-commons/geometry/phasing.geojson",
+        "submissions/AsaZhou923/rail-memory-ai-commons/geometry/public_space.geojson",
+        "submissions/AsaZhou923/rail-memory-ai-commons/geometry/roads.geojson",
+        "submissions/AsaZhou923/rail-memory-ai-commons/geometry/site_boundary.geojson",
+        "submissions/AsaZhou923/rail-memory-ai-commons/manifest.json",
+        "submissions/AsaZhou923/rail-memory-ai-commons/metrics.json",
+        "submissions/AsaZhou923/rail-memory-ai-commons/proposal.en.md",
+        "submissions/AsaZhou923/rail-memory-ai-commons/proposal.md",
+        "submissions/AsaZhou923/rail-memory-ai-commons/report/copyright_statement.md",
+        "submissions/AsaZhou923/rail-memory-ai-commons/report/narrative.md",
+        "submissions/AsaZhou923/rail-memory-ai-commons/report/proposal.en.html",
+        "submissions/AsaZhou923/rail-memory-ai-commons/report/proposal.html",
+        "submissions/AsaZhou923/rail-memory-ai-commons/self_check.json",
+        "submissions/AsaZhou923/rail-memory-ai-commons/sources.json",
+        "submissions/AsaZhou923/rail-memory-ai-commons/standard_matrix.json",
+        "submissions/AsaZhou923/rail-memory-ai-commons/visual/index.en.html",
+        "submissions/AsaZhou923/rail-memory-ai-commons/visual/index.html"
+      ],
+      "ai_package_stages": {
+        "submissions/AsaZhou923/rail-memory-ai-commons": "formal"
+      },
+      "total_bytes": 5007535,
+      "maintainer_bypass": false
+    },
+    "stderr": ""
+  },
+  "spatial_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "stage": "formal",
+      "issues": [
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-001",
+          "expected": null,
+          "actual": null
+        },
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-002",
+          "expected": null,
+          "actual": null
+        },
+        {
+          "check_id": "KEY_AREA_PROVISIONAL",
+          "severity": "minor",
+          "target_file": "geometry/key_areas.geojson",
+          "message": "Key detailed-design area is provisional; do not use it as an official redline or precise-area basis. Content scoring remains eligible.",
+          "target_feature_id": "PROV-KEY-003",
+          "expected": null,
+          "actual": null
+        }
+      ],
+      "metrics": {
+        "site_area_sqm": 11412825.386,
+        "green_space_area_sqm": 1408600.768,
+        "public_space_area_sqm": 836345.643,
+        "building_footprint_area_sqm": 2333931.619,
+        "green_ratio": 0.123423,
+        "public_space_ratio": 0.073281
+      }
+    },
+    "stderr": ""
+  },
+  "visual_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "issues": [],
+      "metrics_seen": {
+        "site_area_sqm": 11412825.386,
+        "green_ratio": 0.123423,
+        "public_space_ratio": 0.073281
+      }
+    },
+    "stderr": ""
+  },
+  "professional_review": {
+    "returncode": 0,
+    "ok": true,
+    "stdout": {
+      "ok": true,
+      "issues": [],
+      "summary": {
+        "standard_matrix_items": 5,
+        "design_depth_items": 15,
+        "known_metric_refs_required": 29,
+        "proposal_format_version": "2",
+        "evidence_contract": "section-anchors-plus-structured-audit",
+        "proposal_reference_counts": {
+          "source": 15,
+          "standard": 4,
+          "depth": 15,
+          "data": 11,
+          "metric": 5
+        }
+      }
+    },
+    "stderr": ""
+  },
+  "spatial_issue_ids": [
+    "KEY_AREA_PROVISIONAL",
+    "KEY_AREA_PROVISIONAL",
+    "KEY_AREA_PROVISIONAL"
+  ],
+  "visual_issue_ids": [],
+  "professional_issue_ids": [],
+  "missing_review_dependencies": [],
+  "can_enter_formal_review": true,
+  "package_type": "professional_design_package",
+  "review_status": "formal-review-ready",
+  "next_actions": [],
   "schema_version": "0.1.0",
   "checks": [
     {
-      "check_id": "BOUNDARY_TRUST",
+      "check_id": "DETERMINISTIC_VALIDATION",
       "result": "pass",
-      "severity": "major",
-      "target": "geometry/site_boundary.geojson",
-      "message": "Provisional boundary is present; replace with official redline before professional scoring."
+      "severity": "blocking",
+      "target": "validate_local_submission.py",
+      "message": "deterministic_validation: PASS"
     },
     {
-      "check_id": "KEY_AREAS_TRUST",
+      "check_id": "SPATIAL_REVIEW",
       "result": "pass",
-      "severity": "major",
-      "target": "geometry/key_areas.geojson",
-      "message": "Three required key areas are provisional; replace with official polygons before professional scoring."
+      "severity": "blocking",
+      "target": "spatial_review.py",
+      "message": "spatial_review: PASS"
     },
     {
-      "check_id": "LAND_USE_TOPOLOGY",
+      "check_id": "VISUAL_PACKAGING",
       "result": "pass",
-      "severity": "major",
-      "target": "geometry/land_use.geojson",
-      "message": "Initial land-use polygons are derived from site boundary partitioning."
-    },
-    {
-      "check_id": "VISUAL_STATIC",
-      "result": "pass",
-      "severity": "info",
-      "target": "visual/index.html",
-      "message": "Static HTML visualization is generated without external dependencies."
+      "severity": "blocking",
+      "target": "visual_review.py",
+      "message": "visual_review: PASS"
     },
     {
       "check_id": "PROFESSIONAL_EVIDENCE",
       "result": "pass",
-      "severity": "major",
-      "target": "proposal.md",
-      "message": "Proposal includes references to standards, design depth items, geometry, metrics, sources, and assumptions."
-    },
-    {
-      "check_id": "BILINGUAL_CONTRACT",
-      "result": "pass",
-      "severity": "major",
-      "target": "proposal.en.md",
-      "message": "Chinese-primary narrative, English counterpart, ten localized figures, two localized HTML pairs, and four localized PDFs are present."
-    },
-    {
-      "check_id": "GEOMETRY_METRIC_RECOMPUTE",
-      "result": "pass",
-      "severity": "major",
-      "target": "metrics.json",
-      "message": "Site area, building footprint, green-space area and ratio, and public-space area and ratio recompute from the provisional GeoJSON within validator tolerance."
-    },
-    {
-      "check_id": "SCENARIO_CATALOG",
-      "result": "pass",
-      "severity": "major",
-      "target": "geometry/public_space.geojson",
-      "message": "Twelve Memory Point scenario cards, four industry validation scenarios, and four distinct pilgrimage or honor nodes are cataloged with human review and exit boundaries."
-    },
-    {
-      "check_id": "PDF_RENDER_QA",
-      "result": "pass",
-      "severity": "info",
-      "target": "drawings/",
-      "message": "All four final PDFs contain at least five pages, permit text extraction, and render through Poppler without blank pages or blocking visual defects."
-    },
-    {
-      "check_id": "SOURCE_RIGHTS_BOUNDARY",
-      "result": "pass",
-      "severity": "major",
-      "target": "sources.json",
-      "message": "Official sources and background-only benchmarks are registered with citation, reuse, temporal, and local-control limitations; no third-party visual assets are redistributed."
+      "severity": "blocking",
+      "target": "professional_review.py",
+      "message": "professional_review: PASS"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- remove the obsolete participant-controlled blocker for unavailable organizer-supplied official polygons
- preserve medium data confidence and all provisional-boundary/recalculation warnings
- migrate the merged package to the current `persisted-self-check-v1` four-gate report

## Why

The current official Skill states that missing organizer geometry does not block content scoring. The merged package still listed that external data gap in `manifest.validation_claim.known_blockers`, so the generated gallery classified the otherwise passing package as `needs_revision`.

This revision changes readiness metadata, not spatial evidence. Official site and key-area polygons are still unavailable; the submitted geometry remains provisional and cannot support redlines, precise-area claims, approval, or implementation use.

## Scope

- `changelog.md`
- `manifest.json`
- `self_check.json`

The proposal, assumptions, sources, geometry, metrics, figures, HTML, and PDFs are unchanged because their evidence and provisional-data disclosures remain current.

## Verification

- four-gate self-check: PASS (`DETERMINISTIC_VALIDATION`, `SPATIAL_REVIEW`, `VISUAL_PACKAGING`, `PROFESSIONAL_EVIDENCE`)
- `review_status=formal-review-ready`, `can_enter_formal_review=true`, `next_actions=[]`
- participant preflight with push dry-run: PASS; zero blockers, warnings, or outside-scope files
- local gallery classification: `formal_review_ready`
- strengthened numeric checks: 318 GeoJSON ordinates and 29 known metrics, with zero boolean, non-finite, or oversized-invalid numeric values

## Remaining external/professional confirmation

Official site/key-area geometry, planning controls, road redlines, utilities, ownership, heritage, fire safety, legal/privacy review, and field verification remain required before statutory, precise-area, approval, or implementation use.

Related: #1368, #1389
