### PR TITLE
fix: tolerate invalid language storage on public pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1432,8 +1432,32 @@ const T = {
 };
 
 // ── i18n engine ───────────────────────────────────────────────
-let lang = localStorage.getItem('lang') ||
-           (navigator.language && navigator.language.startsWith('zh') ? 'zh' : 'en');
+function normalizeLanguage(value) {
+  return value === 'zh' || value === 'en' ? value : null;
+}
+
+function initialLanguage() {
+  let stored = null;
+  try {
+    stored = localStorage.getItem('lang');
+  } catch {
+    stored = null;
+  }
+  const validStored = normalizeLanguage(stored);
+  if (validStored) return validStored;
+  const browserLanguage = String(navigator.language || '').toLowerCase();
+  return browserLanguage.startsWith('zh') ? 'zh' : 'en';
+}
+
+function rememberLanguage(value) {
+  try {
+    localStorage.setItem('lang', value);
+  } catch {
+    // Restricted storage should not prevent the page from switching language.
+  }
+}
+
+let lang = initialLanguage();
 
 const STATUS_META = {
   formal_review_ready: {
@@ -1584,7 +1608,7 @@ function applyLang(l) {
   const filmTime = film?.currentTime || 0;
   const filmWasPlaying = film ? !film.paused : false;
   lang = l;
-  localStorage.setItem('lang', l);
+  rememberLanguage(l);
   document.documentElement.lang = l === 'zh' ? 'zh-CN' : 'en';
   document.title = T[l]['page.title'];
   document.getElementById('langToggle').textContent = T[l]['lang.toggle'];

--- a/submissions.html
+++ b/submissions.html
@@ -518,7 +518,32 @@ const T = {
   }
 };
 
-let lang = localStorage.getItem('lang') || (navigator.language.startsWith('zh') ? 'zh' : 'en');
+function normalizeLanguage(value) {
+  return value === 'zh' || value === 'en' ? value : null;
+}
+
+function initialLanguage() {
+  let stored = null;
+  try {
+    stored = localStorage.getItem('lang');
+  } catch {
+    stored = null;
+  }
+  const validStored = normalizeLanguage(stored);
+  if (validStored) return validStored;
+  const browserLanguage = String(navigator.language || '').toLowerCase();
+  return browserLanguage.startsWith('zh') ? 'zh' : 'en';
+}
+
+function rememberLanguage(value) {
+  try {
+    localStorage.setItem('lang', value);
+  } catch {
+    // Restricted storage should not prevent the page from switching language.
+  }
+}
+
+let lang = initialLanguage();
 
 const STATUS_META = {
   formal_review_ready: {
@@ -777,7 +802,7 @@ window.addEventListener('popstate', () => {
 });
 
 function applyLang(l) {
-  lang = l; localStorage.setItem('lang', l);
+  lang = l; rememberLanguage(l);
   document.documentElement.lang = l === 'zh' ? 'zh-CN' : 'en';
   document.title = T[l]['page.title'];
   document.getElementById('langToggle').textContent = T[l]['lang.toggle'];

--- a/tests/test_frontend_language_storage_pages.py
+++ b/tests/test_frontend_language_storage_pages.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class FrontendLanguageStoragePageTests(unittest.TestCase):
+    def run_language_harness(self, page: str, stored: str | None, browser: str | None, *, fail_get: bool = False, fail_set: bool = False) -> dict:
+        source = (ROOT / page).read_text(encoding="utf-8")
+        start = source.index("// ── i18n engine") if page == "index.html" else source.index("function normalizeLanguage")
+        end = source.index("const STATUS_META", start)
+        helper = source[start:end]
+        script = f"""
+const vm = require('vm');
+const storage = {{
+  value: {json.dumps(stored)},
+  writes: [],
+  getItem() {{ if ({str(fail_get).lower()}) throw new Error('blocked'); return this.value; }},
+  setItem(key, value) {{ if ({str(fail_set).lower()}) throw new Error('blocked'); this.value = value; this.writes.push([key, value]); }}
+}};
+const context = {{ localStorage: storage, navigator: {{ language: {json.dumps(browser)} }} }};
+vm.runInNewContext({json.dumps(helper + "\nglobalThis.__language = lang; globalThis.__initial = initialLanguage; globalThis.__remember = rememberLanguage;")}, context);
+let remembered = null;
+try {{ context.__remember('en'); remembered = {{value: storage.value, writes: storage.writes}}; }} catch (error) {{ remembered = {{error: String(error)}}; }}
+console.log(JSON.stringify({{initial: context.__language, afterWrite: remembered}}));
+"""
+        completed = subprocess.run(["node", "-e", script], text=True, capture_output=True, check=False)
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        return json.loads(completed.stdout)
+
+    def test_both_pages_normalize_stored_language_and_browser_fallback(self) -> None:
+        for page in ("index.html", "submissions.html"):
+            with self.subTest(page=page):
+                self.assertEqual(self.run_language_harness(page, "en", "zh-CN")["initial"], "en")
+                self.assertEqual(self.run_language_harness(page, "zh-CN", "zh-CN")["initial"], "zh")
+                self.assertEqual(self.run_language_harness(page, "invalid", "fr-FR")["initial"], "en")
+                self.assertEqual(self.run_language_harness(page, None, "zh-Hant")["initial"], "zh")
+
+    def test_both_pages_survive_storage_read_and_write_errors(self) -> None:
+        for page in ("index.html", "submissions.html"):
+            with self.subTest(page=page):
+                result = self.run_language_harness(page, "en", "en", fail_get=True, fail_set=True)
+                self.assertEqual(result["initial"], "en")
+                self.assertNotIn("error", result["afterWrite"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frontend_language_storage_pages.py
+++ b/tests/test_frontend_language_storage_pages.py
@@ -15,6 +15,8 @@ class FrontendLanguageStoragePageTests(unittest.TestCase):
         start = source.index("// ── i18n engine") if page == "index.html" else source.index("function normalizeLanguage")
         end = source.index("const STATUS_META", start)
         helper = source[start:end]
+        harness_source = helper + "\nglobalThis.__language = lang; globalThis.__initial = initialLanguage; globalThis.__remember = rememberLanguage;"
+        encoded_harness_source = json.dumps(harness_source)
         script = f"""
 const vm = require('vm');
 const storage = {{
@@ -24,7 +26,7 @@ const storage = {{
   setItem(key, value) {{ if ({str(fail_set).lower()}) throw new Error('blocked'); this.value = value; this.writes.push([key, value]); }}
 }};
 const context = {{ localStorage: storage, navigator: {{ language: {json.dumps(browser)} }} }};
-vm.runInNewContext({json.dumps(helper + "\nglobalThis.__language = lang; globalThis.__initial = initialLanguage; globalThis.__remember = rememberLanguage;")}, context);
+vm.runInNewContext({encoded_harness_source}, context);
 let remembered = null;
 try {{ context.__remember('en'); remembered = {{value: storage.value, writes: storage.writes}}; }} catch (error) {{ remembered = {{error: String(error)}}; }}
 console.log(JSON.stringify({{initial: context.__language, afterWrite: remembered}}));


### PR DESCRIPTION
## Summary

Harden the language preference bootstrap and toggle on `index.html` and `submissions.html`.

Current behavior directly uses `localStorage.getItem('lang')`, so an invalid persisted value such as `zh-CN` or `garbage` makes `T[lang]` undefined and breaks the inline page script. Storage access can also throw in restricted browser contexts, and `submissions.html` assumes `navigator.language` is always a string.

This change:

- accepts only `zh` and `en`;
- falls back to the browser language, then English;
- catches storage read and write failures;
- keeps the existing language toggle behavior;
- leaves the three pages already covered by #2075 unchanged.

## Verification

- `python3 -m unittest tests.test_frontend_language_storage_pages -v` (2 passed)
- Node VM coverage for both pages: valid, invalid, missing, browser fallback, blocked read, and blocked write cases
- `python3 -m py_compile tests/test_frontend_language_storage_pages.py`
- `git diff --check`
