### PR TITLE
fix: ignore package artifacts in source advisory

### DIFF
--- a/scripts/score_submission.py
+++ b/scripts/score_submission.py
@@ -98,6 +98,20 @@ PUBLIC_TERMS = ["居民", "青年", "学生", "企业", "高校", "游客", "无
 RISK_TERMS = ["公开", "非公开", "隐私", "版权", "授权", "复核", "风险", "合规", "涉密", "边界"]
 MANUAL_REVIEW_TERMS = ["内部资料", "内部数据", "非公开空间数据", "未公开图件", "无需审批", "保证落地", "一定实施"]
 
+# These are first-party audit artifacts inside a formal submission package,
+# not public evidence that needs a source-registry record.
+PACKAGE_ARTIFACT_NAMES = {
+    "agent.json",
+    "assumptions.json",
+    "compliance_matrix.json",
+    "design_depth_matrix.json",
+    "manifest.json",
+    "metrics.json",
+    "self_check.json",
+    "sources.json",
+    "standard_matrix.json",
+}
+
 
 @dataclass
 class CheckResult:
@@ -274,6 +288,14 @@ def reference_lines(reference_section: str) -> list[str]:
     return lines
 
 
+def is_package_artifact_reference(line: str) -> bool:
+    """Return true when a reference bullet names only local package artifacts."""
+    if re.search(r"https?://", line, flags=re.IGNORECASE):
+        return False
+    file_tokens = re.findall(r"[\w./-]+\.(?:json|geojson)", line, flags=re.IGNORECASE)
+    return bool(file_tokens) and all(Path(token).name in PACKAGE_ARTIFACT_NAMES for token in file_tokens)
+
+
 def match_sources(text: str, reference_section: str, sources: list[dict[str, Any]]) -> tuple[list[SourceMatch], list[str]]:
     haystack = f"{text}\n{reference_section}"
     matched: list[SourceMatch] = []
@@ -298,7 +320,9 @@ def match_sources(text: str, reference_section: str, sources: list[dict[str, Any
     unmatched = []
     for line in reference_lines(reference_section):
         normalized = line.replace("`", "")
-        if not any(token and token in normalized for token in matched_tokens):
+        if not any(token and token in normalized for token in matched_tokens) and not is_package_artifact_reference(
+            normalized
+        ):
             unmatched.append(line)
     return matched, unmatched
 

--- a/scripts/score_submission.py
+++ b/scripts/score_submission.py
@@ -293,7 +293,7 @@ def is_package_artifact_reference(line: str) -> bool:
     if re.search(r"https?://", line, flags=re.IGNORECASE):
         return False
     file_tokens = re.findall(r"[\w./-]+\.(?:json|geojson)", line, flags=re.IGNORECASE)
-    return bool(file_tokens) and all(Path(token).name in PACKAGE_ARTIFACT_NAMES for token in file_tokens)
+    return bool(file_tokens) and all(token in PACKAGE_ARTIFACT_NAMES for token in file_tokens)
 
 
 def match_sources(text: str, reference_section: str, sources: list[dict[str, Any]]) -> tuple[list[SourceMatch], list[str]]:

--- a/scripts/score_submission.py
+++ b/scripts/score_submission.py
@@ -293,7 +293,13 @@ def is_package_artifact_reference(line: str) -> bool:
     if re.search(r"https?://", line, flags=re.IGNORECASE):
         return False
     file_tokens = re.findall(r"[\w./-]+\.(?:json|geojson)", line, flags=re.IGNORECASE)
-    return bool(file_tokens) and all(token in PACKAGE_ARTIFACT_NAMES for token in file_tokens)
+    if not file_tokens or not all(token in PACKAGE_ARTIFACT_NAMES for token in file_tokens):
+        return False
+
+    remainder = line
+    for token in file_tokens:
+        remainder = remainder.replace(token, "", 1)
+    return re.fullmatch(r"(?:[\s`*_()\[\]{},，、;；:+&/|]|and|与|及)*", remainder, flags=re.IGNORECASE) is not None
 
 
 def match_sources(text: str, reference_section: str, sources: list[dict[str, Any]]) -> tuple[list[SourceMatch], list[str]]:

--- a/tests/test_score_submission.py
+++ b/tests/test_score_submission.py
@@ -202,6 +202,21 @@ class ScoreSubmissionTests(unittest.TestCase):
             self.assertEqual(self.check_map(report)["公开资料引用"], STATUS_NEEDS_WORK)
             self.assertEqual(report.unmatched_reference_lines, ["`research/field-observations.json`"])
 
+    def test_nested_package_artifact_name_still_needs_source_status_note(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write_source_index(root)
+            body = VALID_BODY.replace(
+                "- `brief/public-brief.md`\n- `brief/README.md`",
+                "- `brief/public-brief.md`\n- `research/manifest.json`",
+            )
+            proposal = self.write_proposal(root, body)
+
+            report = score_proposal(root, proposal)
+
+            self.assertEqual(self.check_map(report)["公开资料引用"], STATUS_NEEDS_WORK)
+            self.assertEqual(report.unmatched_reference_lines, ["`research/manifest.json`"])
+
     def test_weak_landing_path_needs_work(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_score_submission.py
+++ b/tests/test_score_submission.py
@@ -178,7 +178,7 @@ class ScoreSubmissionTests(unittest.TestCase):
             self.write_source_index(root)
             body = VALID_BODY.replace(
                 "- `brief/public-brief.md`\n- `brief/README.md`",
-                "- `brief/public-brief.md`\n- `metrics.json`, `assumptions.json` 与 `compliance_matrix.json` 为本方案机器可读索引。",
+                "- `brief/public-brief.md`\n- `metrics.json`, `assumptions.json` 与 `compliance_matrix.json`",
             )
             proposal = self.write_proposal(root, body)
 
@@ -186,6 +186,27 @@ class ScoreSubmissionTests(unittest.TestCase):
 
             self.assertEqual(self.check_map(report)["公开资料引用"], STATUS_PASS)
             self.assertEqual(report.unmatched_reference_lines, [])
+
+    def test_package_artifact_does_not_hide_descriptive_source_claim(self) -> None:
+        claims = [
+            "居民访谈与现场观察结论见 metrics.json",
+            "未公开内部数据已汇总到 assumptions.json",
+            "第三方商业热力数据见 metrics.json",
+        ]
+        for claim in claims:
+            with self.subTest(claim=claim), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                self.write_source_index(root)
+                body = VALID_BODY.replace(
+                    "- `brief/public-brief.md`\n- `brief/README.md`",
+                    f"- `brief/public-brief.md`\n- {claim}",
+                )
+                proposal = self.write_proposal(root, body)
+
+                report = score_proposal(root, proposal)
+
+                self.assertEqual(self.check_map(report)["公开资料引用"], STATUS_NEEDS_WORK)
+                self.assertEqual(report.unmatched_reference_lines, [claim])
 
     def test_unknown_local_reference_still_needs_source_status_note(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_score_submission.py
+++ b/tests/test_score_submission.py
@@ -172,6 +172,36 @@ class ScoreSubmissionTests(unittest.TestCase):
             )
             self.assertEqual(report.unmatched_reference_lines, [])
 
+    def test_local_package_artifacts_do_not_require_public_source_records(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write_source_index(root)
+            body = VALID_BODY.replace(
+                "- `brief/public-brief.md`\n- `brief/README.md`",
+                "- `brief/public-brief.md`\n- `metrics.json`, `assumptions.json` 与 `compliance_matrix.json` 为本方案机器可读索引。",
+            )
+            proposal = self.write_proposal(root, body)
+
+            report = score_proposal(root, proposal)
+
+            self.assertEqual(self.check_map(report)["公开资料引用"], STATUS_PASS)
+            self.assertEqual(report.unmatched_reference_lines, [])
+
+    def test_unknown_local_reference_still_needs_source_status_note(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write_source_index(root)
+            body = VALID_BODY.replace(
+                "- `brief/public-brief.md`\n- `brief/README.md`",
+                "- `brief/public-brief.md`\n- `research/field-observations.json`",
+            )
+            proposal = self.write_proposal(root, body)
+
+            report = score_proposal(root, proposal)
+
+            self.assertEqual(self.check_map(report)["公开资料引用"], STATUS_NEEDS_WORK)
+            self.assertEqual(report.unmatched_reference_lines, ["`research/field-observations.json`"])
+
     def test_weak_landing_path_needs_work(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## What changed

- treats formal package audit files such as `metrics.json`, `assumptions.json`, and the required matrices as first-party package artifacts rather than unregistered public sources
- keeps unknown local evidence files and any URL subject to the existing source/public-status warning
- adds regression coverage for both cases

## Reproduction

On exact `main` at `4932063f8a3a1fec988b06e3a812aa0ed2b64d1f`, running `score_submission.py` on `submissions/siddhartha-yz/edgecase-jingzhang/proposal.md` reported its own required JSON indexes as unmatched references and produced 7 pass / 1 needs-work.

With this patch, the same proposal reports 8 pass / 0 needs-work. An unregistered `research/field-observations.json` reference still reports needs-work.

## Validation

- `python3 -m unittest tests.test_score_submission -v`: 11/11 PASS
- exact proposal regression with `--strict`: 8/8 PASS
- `python3 -m compileall -q scripts/score_submission.py`: PASS
- `git diff --check`: PASS
- exact-diff common secret-signature scan: no matches

Pytest was unavailable in the active Python environment, so the focused standard-library unittest suite was used directly.