### PR TITLE
docs: use supported unittest command

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,10 +262,12 @@ CI 不替代人工评审。`package_type` 描述成果包类型，`review_status
 
 ## 本地校验
 
-安装 Python 测试依赖后，可以运行：
+安装与本次改动相关的测试依赖后，优先运行对应的测试模块。仓库中的依赖清单包括
+`requirements-validation.txt`、`requirements-review.txt` 和 `requirements-translation.txt`；
+完整测试 discovery 需要相应环境和依赖，可运行：
 
 ```bash
-python -m pytest
+python3 -m unittest discover -s tests -v
 ```
 
 校验公开资料登记表可运行：

--- a/tests/test_contributing_guide.py
+++ b/tests/test_contributing_guide.py
@@ -35,7 +35,6 @@ class ContributingGuideTests(unittest.TestCase):
         self.assertIn("requirements-validation.txt", readme)
         self.assertIn("requirements-review.txt", readme)
         self.assertIn("requirements-translation.txt", readme)
-        self.assertIn("优先运行对应的测试模块", readme)
         self.assertIn("python3 -m unittest discover -s tests -v", readme)
         self.assertNotIn("python -m pytest", readme)
 

--- a/tests/test_contributing_guide.py
+++ b/tests/test_contributing_guide.py
@@ -30,6 +30,15 @@ class ContributingGuideTests(unittest.TestCase):
         self.assertIn("python3 -m py_compile", guide)
         self.assertIn("git diff --check", guide)
 
+    def test_readme_uses_the_supported_test_runner(self) -> None:
+        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+        self.assertIn("requirements-validation.txt", readme)
+        self.assertIn("requirements-review.txt", readme)
+        self.assertIn("requirements-translation.txt", readme)
+        self.assertIn("优先运行对应的测试模块", readme)
+        self.assertIn("python3 -m unittest discover -s tests -v", readme)
+        self.assertNotIn("python -m pytest", readme)
+
     def test_contributing_guide_mentions_codeowner_review(self) -> None:
         guide = (REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
         self.assertIn("CODEOWNER", guide)


### PR DESCRIPTION
## What changed

- replace the README's unavailable pytest command with the repository's documented unittest discovery command
- preserve the test-dependency prerequisite, link all relevant requirement sets, and recommend targeted modules before full discovery
- add a contributor-doc contract test to keep the runner and dependency guidance aligned

## Why

The top-level README directs contributors to run `python -m pytest`, but pytest is not declared in the repository requirements and the command fails in a clean contributor environment. CONTRIBUTING.md and the test suite use unittest. Full discovery still requires the dependencies appropriate to the tests being run.

## Validation

- `python3 -m unittest tests.test_contributing_guide -v` (5 passed)
- `python3 -m py_compile tests/test_contributing_guide.py`
- `git diff --check upstream/main`