### PR TITLE
fix: validate SVG visual assets as XML

### DIFF
--- a/scripts/svg_asset_safety.py
+++ b/scripts/svg_asset_safety.py
@@ -1,0 +1,204 @@
+"""Statically validate standalone SVG visual assets without rendering them."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from urllib.parse import unquote
+from xml.parsers import expat
+
+
+SVG_NAMESPACE = "http://www.w3.org/2000/svg"
+XML_NAMESPACE = "http://www.w3.org/XML/1998/namespace"
+MAX_SVG_BYTES = 5 * 1024 * 1024
+FORBIDDEN_ELEMENTS = {
+    "script",
+    "foreignobject",
+    "iframe",
+    "object",
+    "embed",
+    "handler",
+    "listener",
+    "link",
+    "audio",
+    "video",
+    "animate",
+    "animatemotion",
+    "animatetransform",
+    "set",
+    "discard",
+}
+URI_ATTRIBUTES = {"href", "src", "data", "poster", "action", "formaction", "base"}
+URI_SCHEME_RE = re.compile(r"^[a-z][a-z0-9+.-]*:", re.I)
+CSS_COMMENT_RE = re.compile(r"/\*.*?\*/", re.S)
+CSS_LINE_CONTINUATION_RE = re.compile(r"\\(?:\r\n|[\n\r\f])")
+CSS_ESCAPE_RE = re.compile(r"\\([0-9a-fA-F]{1,6})(?:\s)?|\\(.)", re.S)
+CSS_URL_RE = re.compile(r"\burl\s*\(\s*(['\"]?)(.*?)\1\s*\)", re.I | re.S)
+CSS_IMPORT_RE = re.compile(
+    r"@import\s+(?:url\s*\(\s*)?(['\"]?)([^'\"\s;)]+)\1",
+    re.I,
+)
+
+
+class _RejectedDeclaration(Exception):
+    pass
+
+
+def _local_name(name: str) -> str:
+    return name.rsplit("}", 1)[-1].rsplit(":", 1)[-1].casefold()
+
+
+def _expanded_name(name: str) -> tuple[str, str]:
+    if "}" in name:
+        namespace, local = name.rsplit("}", 1)
+        return namespace, local.casefold()
+    return "", name.rsplit(":", 1)[-1].casefold()
+
+
+def _decode_css_escapes(text: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        if match.group(1) is not None:
+            codepoint = int(match.group(1), 16)
+            return chr(codepoint) if codepoint <= 0x10FFFF else ""
+        return match.group(2) or ""
+
+    without_comments = CSS_COMMENT_RE.sub("", text)
+    without_continuations = CSS_LINE_CONTINUATION_RE.sub("", without_comments)
+    return CSS_ESCAPE_RE.sub(replace, without_continuations)
+
+
+def _is_external_or_active_uri(value: str) -> bool:
+    stripped = value.strip()
+    if not stripped:
+        return False
+    if "\\" in stripped or any(ord(character) <= 0x20 for character in stripped):
+        return True
+    if stripped.startswith("/") or URI_SCHEME_RE.match(stripped) is not None:
+        return True
+    local_path = stripped.split("#", 1)[0].split("?", 1)[0]
+    for _ in range(2):
+        local_path = unquote(local_path)
+    return ".." in Path(local_path).parts
+
+
+def _css_has_external_or_active_uri(text: str) -> bool:
+    normalized = _decode_css_escapes(text)
+    targets = [match.group(2) for match in CSS_URL_RE.finditer(normalized)]
+    targets.extend(match.group(2) for match in CSS_IMPORT_RE.finditer(normalized))
+    return any(_is_external_or_active_uri(target) for target in targets)
+
+
+def svg_text_issues(text: str) -> list[str]:
+    reasons: set[str] = set()
+    element_stack: list[str] = []
+    style_buffers: list[list[str]] = []
+    root_seen = False
+    parser = expat.ParserCreate(namespace_separator="}")
+    parser.SetParamEntityParsing(expat.XML_PARAM_ENTITY_PARSING_NEVER)
+
+    def reject_declaration() -> None:
+        reasons.add("SVG must not contain DOCTYPE or entity declarations")
+        raise _RejectedDeclaration
+
+    def start_element(name: str, attributes: dict[str, str]) -> None:
+        nonlocal root_seen
+        namespace, local = _expanded_name(name)
+        if not root_seen:
+            root_seen = True
+            if local != "svg":
+                reasons.add("SVG root element must be <svg>")
+            if namespace != SVG_NAMESPACE:
+                reasons.add("SVG root element must use the SVG namespace")
+        elif namespace != SVG_NAMESPACE:
+            reasons.add("SVG must not contain foreign-namespace elements")
+        element_stack.append(local)
+        if local in FORBIDDEN_ELEMENTS:
+            reasons.add(f"SVG must not contain <{local}> elements")
+        if local == "style":
+            style_buffers.append([])
+        for raw_name, value in attributes.items():
+            attribute_namespace, attribute = _expanded_name(raw_name)
+            if attribute.startswith("on"):
+                reasons.add("SVG must not contain event-handler attributes")
+            if attribute_namespace == XML_NAMESPACE and attribute == "base":
+                reasons.add("SVG must not use xml:base")
+            if attribute in URI_ATTRIBUTES and _is_external_or_active_uri(value):
+                reasons.add("SVG must not use external, data, or script URIs")
+            if _css_has_external_or_active_uri(value):
+                reasons.add("SVG CSS must not load external, data, or script resources")
+
+    def end_element(name: str) -> None:
+        local = _local_name(name)
+        if local == "style" and style_buffers:
+            if _css_has_external_or_active_uri("".join(style_buffers.pop())):
+                reasons.add("SVG CSS must not load external, data, or script resources")
+        if element_stack:
+            element_stack.pop()
+
+    def character_data(data: str) -> None:
+        if style_buffers:
+            style_buffers[-1].append(data)
+
+    def processing_instruction(target: str, data: str) -> None:
+        reasons.add("SVG must not contain processing instructions")
+
+    def xml_declaration(version: str, encoding: str | None, standalone: int) -> None:
+        if encoding and encoding.casefold().replace("_", "-") not in {"utf-8", "utf8"}:
+            reasons.add("SVG XML declarations must specify UTF-8 encoding")
+
+    parser.StartElementHandler = start_element
+    parser.EndElementHandler = end_element
+    parser.CharacterDataHandler = character_data
+    parser.StartDoctypeDeclHandler = lambda *args: reject_declaration()
+    parser.EntityDeclHandler = lambda *args: reject_declaration()
+    parser.ExternalEntityRefHandler = lambda *args: reject_declaration()
+    parser.ProcessingInstructionHandler = processing_instruction
+    parser.XmlDeclHandler = xml_declaration
+    try:
+        parser.Parse(text, True)
+    except _RejectedDeclaration:
+        pass
+    except expat.ExpatError as exc:
+        reasons.add(
+            f"SVG must be well-formed XML (line {exc.lineno}, column {exc.offset})"
+        )
+    return sorted(reasons)
+
+
+def visual_svg_asset_issues(submission_dir: Path) -> list[tuple[str, str]]:
+    assets_root = submission_dir / "visual" / "assets"
+    if assets_root.is_symlink():
+        return [("visual/assets", "visual SVG asset paths must not use symbolic links")]
+    if not assets_root.is_dir():
+        return []
+
+    issues: list[tuple[str, str]] = []
+    try:
+        paths = sorted(assets_root.rglob("*"))
+    except OSError as exc:
+        return [("visual/assets", f"unable to inspect visual SVG assets: {exc}")]
+    for path in paths:
+        rel_path = path.relative_to(submission_dir).as_posix()
+        if path.is_symlink():
+            if path.suffix.lower() == ".svg" or path.is_dir():
+                issues.append(
+                    (rel_path, "visual SVG asset paths must not use symbolic links")
+                )
+            continue
+        if not path.is_file() or path.suffix.lower() != ".svg":
+            continue
+        try:
+            with path.open("rb") as source:
+                payload = source.read(MAX_SVG_BYTES + 1)
+            if len(payload) > MAX_SVG_BYTES:
+                issues.append((rel_path, f"SVG assets must be <= {MAX_SVG_BYTES} bytes"))
+                continue
+            text = payload.decode("utf-8-sig")
+        except UnicodeDecodeError:
+            issues.append((rel_path, "SVG assets must be UTF-8 text"))
+            continue
+        except OSError as exc:
+            issues.append((rel_path, f"unable to read visual SVG asset: {exc}"))
+            continue
+        issues.extend((rel_path, reason) for reason in svg_text_issues(text))
+    return issues

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -21,6 +21,7 @@ from typing import Iterable
 from front_matter import parse_front_matter
 from git_blob_hashes import git_blob_sha256
 from metric_types import is_json_number
+from svg_asset_safety import visual_svg_asset_issues
 
 
 POLICY_ROOT = Path(__file__).resolve().parents[1]
@@ -2532,6 +2533,8 @@ def validate_ai_package_dir(
                 f"{proposal_dir}/visual/{visual_name}",
                 translation_advisory=visual_name != "index.html" and not strict_bilingual,
             )
+    for rel_path, message in visual_svg_asset_issues(base):
+        report.add_error(f"{proposal_dir}/{rel_path}: {message}")
 
     for geometry_name in sorted(ALLOWED_GEOMETRY_FILES):
         geometry_path = base / "geometry" / geometry_name

--- a/scripts/visual_review.py
+++ b/scripts/visual_review.py
@@ -10,6 +10,7 @@ Checks performed
 - ``visual/index.html`` exists and is valid UTF-8.
 - The page contains no remote-resource patterns (no ``<iframe>``, ``fetch()``,
   ``WebSocket``, remote ``<script src>``, remote CSS ``@import``, etc.).
+- SVG files under ``visual/assets`` are well-formed, passive, and self-contained.
 - The page contains the 14 required Chinese-language content markers
   (总览地图, 三层范围, 重点区域, …).
 - Metric ``data-metric`` / ``data-value`` attributes declare finite numeric
@@ -44,6 +45,7 @@ from pathlib import Path
 from typing import Any
 
 from metric_types import is_json_number
+from svg_asset_safety import visual_svg_asset_issues
 
 
 REQUIRED_TEXT_MARKERS = [
@@ -171,6 +173,8 @@ def review_visual(submission_dir: Path) -> VisualReport:
     for pattern, message in FORBIDDEN_PATTERNS:
         if pattern.search(text):
             report.add("VISUAL_REMOTE_OR_ACTIVE_CONTENT", "blocking", display_path, message)
+    for rel_path, message in visual_svg_asset_issues(submission_dir):
+        report.add("VISUAL_REMOTE_OR_ACTIVE_CONTENT", "blocking", rel_path, message)
 
     plain = re.sub(r"<[^>]+>", " ", text)
     plain = html.unescape(re.sub(r"\s+", " ", plain))

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -3126,6 +3126,24 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertIn("visual/index.en.html", "\n".join(report.errors))
             self.assertIn("iframe", "\n".join(report.errors))
 
+    def test_undeclared_svg_asset_receives_xml_safety_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/ai-urban-loop"
+            changed = self.write_minimal_ai_package(root, base)
+            asset = root / base / "visual" / "assets" / "nested" / "active.svg"
+            asset.parent.mkdir(parents=True)
+            asset.write_text(
+                '<svg xmlns="http://www.w3.org/2000/svg"><image href="https://example.com/a.png"/></svg>',
+                encoding="utf-8",
+            )
+            changed.append(f"{base}/visual/assets/nested/active.svg")
+            report = validate_submission(root, "alice", changed)
+            self.assertFalse(report.ok)
+            joined = "\n".join(report.errors)
+            self.assertIn("visual/assets/nested/active.svg", joined)
+            self.assertIn("external, data, or script URIs", joined)
+
     def test_stale_translation_manifest_hash_is_non_blocking(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_svg_asset_safety.py
+++ b/tests/test_svg_asset_safety.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from svg_asset_safety import visual_svg_asset_issues  # noqa: E402
+
+
+SVG_NS = "http://www.w3.org/2000/svg"
+
+
+def write_svg(root: Path, content: str | bytes, name: str = "icon.svg") -> Path:
+    submission = root / "submissions" / "alice" / "svg-package"
+    asset = submission / "visual" / "assets" / name
+    asset.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, bytes):
+        asset.write_bytes(content)
+    else:
+        asset.write_text(content, encoding="utf-8")
+    return submission
+
+
+class SvgAssetSafetyTests(unittest.TestCase):
+    def test_local_references_and_unsafe_text_inside_comments_are_allowed(self) -> None:
+        content = f"""<svg xmlns="{SVG_NS}" viewBox="0 0 10 10">
+<!-- <!DOCTYPE svg><script>comment only</script> -->
+<defs><linearGradient id="paint"><stop offset="1"/></linearGradient></defs>
+<style>.shape {{ fill: url(#paint); }} .texture {{ fill: url(icons/pattern.svg#tile); }}</style>
+<rect class="shape" width="10" height="10"/>
+<use href="#paint"/><image href="icons/local.png"/>
+</svg>"""
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_svg(Path(tmp), content)
+            self.assertEqual(visual_svg_asset_issues(submission), [])
+
+    def test_active_container_elements_are_rejected_namespace_independently(self) -> None:
+        for element in [
+            "script",
+            "foreignObject",
+            "iframe",
+            "object",
+            "embed",
+            "handler",
+            "listener",
+            "link",
+            "audio",
+            "video",
+            "animate",
+            "animateMotion",
+            "animateTransform",
+            "set",
+            "discard",
+        ]:
+            with self.subTest(element=element), tempfile.TemporaryDirectory() as tmp:
+                content = f'<svg xmlns="{SVG_NS}"><{element}/></svg>'
+                submission = write_svg(Path(tmp), content)
+                messages = [message for _, message in visual_svg_asset_issues(submission)]
+                self.assertIn(f"SVG must not contain <{element.casefold()}> elements", messages)
+
+    def test_event_handlers_and_external_or_active_uris_are_rejected(self) -> None:
+        cases = [
+            f'<svg xmlns="{SVG_NS}" onload="run()"/>',
+            f'<svg xmlns="{SVG_NS}"><image href="https://example.com/a.png"/></svg>',
+            f'<svg xmlns="{SVG_NS}"><image href="//example.com/a.png"/></svg>',
+            f'<svg xmlns="{SVG_NS}"><image href="data:image/png;base64,AA=="/></svg>',
+            f'<svg xmlns="{SVG_NS}"><a href="java&#x0A;script:run()"/></svg>',
+            f'<svg xmlns="{SVG_NS}"><image href="/outside-package.svg"/></svg>',
+            f'<svg xmlns="{SVG_NS}"><image href="icons\\outside.svg"/></svg>',
+            f'<svg xmlns="{SVG_NS}"><image href="icons/%252e%252e/outside.svg"/></svg>',
+            (
+                f'<svg xmlns="{SVG_NS}" xmlns:xlink="http://www.w3.org/1999/xlink">'
+                '<use xlink:href="file:///tmp/item.svg"/></svg>'
+            ),
+        ]
+        for content in cases:
+            with self.subTest(content=content), tempfile.TemporaryDirectory() as tmp:
+                submission = write_svg(Path(tmp), content)
+                self.assertTrue(visual_svg_asset_issues(submission))
+
+    def test_css_urls_and_imports_are_checked_in_attributes_and_style_elements(self) -> None:
+        cases = [
+            f'<svg xmlns="{SVG_NS}"><rect style="fill:url(https://example.com/a.svg)"/></svg>',
+            f'<svg xmlns="{SVG_NS}"><style>@import "//example.com/a.css";</style></svg>',
+            f'<svg xmlns="{SVG_NS}"><rect fill="url(j\\61vascript:run())"/></svg>',
+        ]
+        for content in cases:
+            with self.subTest(content=content), tempfile.TemporaryDirectory() as tmp:
+                submission = write_svg(Path(tmp), content)
+                messages = [message for _, message in visual_svg_asset_issues(submission)]
+                self.assertIn(
+                    "SVG CSS must not load external, data, or script resources",
+                    messages,
+                )
+
+    def test_doctype_entities_and_processing_instructions_are_rejected(self) -> None:
+        cases = [
+            f'<!DOCTYPE svg [<!ENTITY x SYSTEM "file:///etc/passwd">]><svg xmlns="{SVG_NS}">&x;</svg>',
+            f'<?xml-stylesheet href="https://example.com/a.css"?><svg xmlns="{SVG_NS}"/>',
+        ]
+        for content in cases:
+            with self.subTest(content=content), tempfile.TemporaryDirectory() as tmp:
+                submission = write_svg(Path(tmp), content)
+                self.assertTrue(visual_svg_asset_issues(submission))
+
+    def test_encoding_xml_shape_and_root_element_are_validated(self) -> None:
+        cases = [
+            (b"\xff\xfe", "SVG assets must be UTF-8 text"),
+            (f'<svg xmlns="{SVG_NS}"><path></svg>', "SVG must be well-formed XML"),
+            ("<html/>", "SVG root element must be <svg>"),
+            ("<svg/>", "SVG root element must use the SVG namespace"),
+            (
+                f'<?xml version="1.0" encoding="ISO-8859-1"?><svg xmlns="{SVG_NS}"/>',
+                "SVG XML declarations must specify UTF-8 encoding",
+            ),
+        ]
+        for content, expected in cases:
+            with self.subTest(expected=expected), tempfile.TemporaryDirectory() as tmp:
+                submission = write_svg(Path(tmp), content)
+                messages = [message for _, message in visual_svg_asset_issues(submission)]
+                self.assertTrue(any(message.startswith(expected) for message in messages), messages)
+
+    def test_utf8_bom_and_utf8_xml_declaration_are_allowed(self) -> None:
+        content = f'<?xml version="1.0" encoding="UTF-8"?><svg xmlns="{SVG_NS}"/>'.encode()
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_svg(Path(tmp), b"\xef\xbb\xbf" + content)
+            self.assertEqual([], visual_svg_asset_issues(submission))
+
+    def test_svg_reads_are_bounded(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_svg(Path(tmp), f'<svg xmlns="{SVG_NS}"/>')
+            with mock.patch("svg_asset_safety.MAX_SVG_BYTES", 4):
+                messages = [message for _, message in visual_svg_asset_issues(submission)]
+            self.assertIn("SVG assets must be <= 4 bytes", messages)
+
+    def test_foreign_namespace_elements_and_xml_base_are_rejected(self) -> None:
+        cases = [
+            f'<svg xmlns="{SVG_NS}" xmlns:h="urn:other"><h:section/></svg>',
+            f'<svg xmlns="{SVG_NS}" xml:base="images/"/>',
+        ]
+        for content in cases:
+            with self.subTest(content=content), tempfile.TemporaryDirectory() as tmp:
+                submission = write_svg(Path(tmp), content)
+                self.assertTrue(visual_svg_asset_issues(submission))
+
+    def test_nested_and_undeclared_assets_are_discovered_from_disk(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_svg(
+                Path(tmp),
+                f'<svg xmlns="{SVG_NS}"><script/></svg>',
+                "nested/undeclared.SVG",
+            )
+            issues = visual_svg_asset_issues(submission)
+            self.assertEqual(issues[0][0], "visual/assets/nested/undeclared.SVG")
+
+    def test_svg_symlinks_are_rejected_without_following_them(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission = write_svg(root, f'<svg xmlns="{SVG_NS}"/>', "real.svg")
+            linked = submission / "visual" / "assets" / "linked.svg"
+            linked.symlink_to(root / "outside.svg")
+            issues = visual_svg_asset_issues(submission)
+            self.assertIn(
+                ("visual/assets/linked.svg", "visual SVG asset paths must not use symbolic links"),
+                issues,
+            )
+
+    def test_symlinked_asset_directories_are_rejected_without_traversal(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            submission = write_svg(root, f'<svg xmlns="{SVG_NS}"/>', "real.svg")
+            outside = root / "outside"
+            outside.mkdir()
+            (outside / "active.svg").write_text(
+                f'<svg xmlns="{SVG_NS}"><script/></svg>', encoding="utf-8"
+            )
+            linked = submission / "visual" / "assets" / "linked"
+            linked.symlink_to(outside, target_is_directory=True)
+            issues = visual_svg_asset_issues(submission)
+            self.assertIn(
+                ("visual/assets/linked", "visual SVG asset paths must not use symbolic links"),
+                issues,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_visual_review.py
+++ b/tests/test_visual_review.py
@@ -86,6 +86,21 @@ class VisualReviewTests(unittest.TestCase):
             self.assertFalse(report.ok)
             self.assertIn("VISUAL_REMOTE_OR_ACTIVE_CONTENT", {issue.check_id for issue in report.issues})
 
+    def test_undeclared_active_svg_asset_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_valid_visual_package(Path(tmp))
+            asset = submission / "visual" / "assets" / "nested" / "active.svg"
+            asset.parent.mkdir(parents=True)
+            asset.write_text(
+                '<svg xmlns="http://www.w3.org/2000/svg"><script>run()</script></svg>',
+                encoding="utf-8",
+            )
+            report = review_visual(submission)
+            self.assertFalse(report.ok)
+            issue = next(item for item in report.issues if item.path.endswith("active.svg"))
+            self.assertEqual(issue.check_id, "VISUAL_REMOTE_OR_ACTIVE_CONTENT")
+            self.assertIn("<script>", issue.message)
+
     def test_metric_mismatch_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             submission = write_valid_visual_package(Path(tmp))


### PR DESCRIPTION
## Summary

- discover every on-disk `visual/assets/**/*.svg`, including nested and undeclared files
- parse SVG with the standard-library Expat XML parser and reject malformed/non-UTF-8 content, DTD/entity declarations, processing instructions, active/embed/SMIL elements, event attributes, unsafe URIs, and remote/data/script CSS resources
- apply the same scanner in both `validate_submission` and standalone `visual_review`, with symbolic-link handling that fails closed

## Why

`.svg` is an allowed visual asset, but both existing gates only inspect `visual/index*.html`. An SVG could therefore carry `<script>`, `foreignObject`, event handlers, external images, `javascript:` links, CSS imports, or XML external entities without either gate reporting it. This is the scoped SVG follow-up explicitly left outside #2231; #2231 handles CSS/JavaScript files only.

The scanner is XML-aware rather than applying HTML regexes to XML. Expanded element and attribute names cover namespace prefixes, XML character references are decoded before URI checks, DTD handling aborts before entity expansion, and local fragment/relative references remain supported.

## Compatibility

Scanned current `main@1179e7ed6`: 24 SVG visual assets across 17 packages, with zero issues. The existing corpus uses 29 local presentation references of the form `url(#id)`; those remain accepted.

## Verification

- `python3 -m unittest tests.test_submission_workflow tests.test_visual_review tests.test_svg_asset_safety` (170 passed)
- Python 3.9: `tests.test_svg_asset_safety tests.test_visual_review` (22 passed) plus `py_compile`
- `python3 -m py_compile scripts/svg_asset_safety.py scripts/validate_submission.py scripts/visual_review.py tests/test_svg_asset_safety.py tests/test_visual_review.py tests/test_submission_workflow.py`
- `git diff --check`
- current-main corpus scan: 17 packages, 24 SVG files, 0 issues