### PR TITLE
fix: contain and restore artifact viewer focus

### DIFF
--- a/proposal-artifact-viewer.js
+++ b/proposal-artifact-viewer.js
@@ -5,6 +5,14 @@
   const palette = ['#65b7ff', '#ffc46b', '#9d8cff', '#62d6a8', '#e08b78', '#75c7bd'];
   let config = null;
   let selectedIndex = -1;
+  let returnFocusElement = null;
+
+  const focusableSelector = [
+    'a[href]', 'button:not([disabled])', 'input:not([disabled])',
+    'select:not([disabled])', 'textarea:not([disabled])', 'audio[controls]',
+    'video[controls]', 'summary', 'iframe',
+    '[tabindex]:not([tabindex="-1"])', '[contenteditable="true"]'
+  ].join(',');
 
   const escapeHTML = value => String(value ?? '').replace(/[&<>"']/g, ch => ({
     '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
@@ -358,6 +366,33 @@
     elements.forEach(element => observer.observe(element));
   }
 
+  function focusableElements(viewer) {
+    return [...viewer.querySelectorAll(focusableSelector)].filter(element =>
+      !element.hasAttribute('hidden') && element.getAttribute('aria-hidden') !== 'true' && element.getClientRects().length
+    );
+  }
+
+  function trapFocus(event, viewer) {
+    const elements = focusableElements(viewer);
+    if (!elements.length) {
+      event.preventDefault();
+      viewer.focus({preventScroll: true});
+      return;
+    }
+    const first = elements[0];
+    const last = elements[elements.length - 1];
+    if (!viewer.contains(document.activeElement)) {
+      event.preventDefault();
+      first.focus({preventScroll: true});
+    } else if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus({preventScroll: true});
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus({preventScroll: true});
+    }
+  }
+
   async function renderSelected(item) {
     const body = document.getElementById('artifactViewerBody');
     const path = item.path;
@@ -397,6 +432,10 @@
     const item = config.artifacts[selectedIndex];
     const viewer = document.getElementById('artifactViewer');
     const body = document.getElementById('artifactViewerBody');
+    if (viewer.hidden) {
+      const active = document.activeElement;
+      returnFocusElement = active && typeof active.focus === 'function' ? active : null;
+    }
     document.getElementById('artifactViewerType').textContent = config.type(path);
     document.getElementById('artifactViewerTitle').textContent = config.label(path);
     document.getElementById('artifactViewerPath').textContent = path;
@@ -413,16 +452,24 @@
 
   function close() {
     const viewer = document.getElementById('artifactViewer');
-    if (!viewer) return;
+    if (!viewer || viewer.hidden) return;
+    const restoreFocus = returnFocusElement;
+    returnFocusElement = null;
     viewer.hidden = true; viewer.setAttribute('aria-hidden', 'true');
     document.body.classList.remove('artifact-viewer-open');
+    if (restoreFocus?.isConnected) restoreFocus.focus({preventScroll: true});
   }
 
   function bindViewer() {
     document.getElementById('artifactViewerClose')?.addEventListener('click', close);
     document.getElementById('artifactPrev')?.addEventListener('click', () => selectedIndex > 0 && open(config.artifacts[selectedIndex - 1].path));
     document.getElementById('artifactNext')?.addEventListener('click', () => selectedIndex < config.artifacts.length - 1 && open(config.artifacts[selectedIndex + 1].path));
-    document.addEventListener('keydown', event => { if (event.key === 'Escape' && !document.getElementById('artifactViewer')?.hidden) { event.stopImmediatePropagation(); close(); } }, true);
+    document.addEventListener('keydown', event => {
+      const viewer = document.getElementById('artifactViewer');
+      if (!viewer || viewer.hidden) return;
+      if (event.key === 'Escape') { event.preventDefault(); event.stopImmediatePropagation(); close(); return; }
+      if (event.key === 'Tab') trapFocus(event, viewer);
+    }, true);
   }
 
   function mount(options) {

--- a/proposal-view.html
+++ b/proposal-view.html
@@ -279,7 +279,7 @@ button{font:inherit;color:inherit}
   </div>
   <div class="artifact-groups" id="artifactGroups"></div>
 </section>
-<section class="artifact-viewer" id="artifactViewer" hidden aria-hidden="true" aria-label="方案文件查看器">
+<section class="artifact-viewer" id="artifactViewer" hidden aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="artifactViewerTitle" tabindex="-1">
   <header class="artifact-viewer-head">
     <div class="artifact-viewer-ident"><span class="artifact-viewer-type" id="artifactViewerType">FILE</span><div class="artifact-viewer-copy"><div class="artifact-viewer-title" id="artifactViewerTitle">方案文件</div><div class="artifact-viewer-path" id="artifactViewerPath"></div></div></div>
     <div class="artifact-viewer-actions">

--- a/tests/test_proposal_artifact_viewer_focus.py
+++ b/tests/test_proposal_artifact_viewer_focus.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ProposalArtifactViewerFocusTests(unittest.TestCase):
+    def test_artifact_viewer_declares_modal_dialog_semantics(self) -> None:
+        html = (ROOT / "proposal-view.html").read_text(encoding="utf-8")
+        self.assertIn(
+            'id="artifactViewer" hidden aria-hidden="true" role="dialog" '
+            'aria-modal="true" aria-labelledby="artifactViewerTitle" tabindex="-1"',
+            html,
+        )
+
+    @unittest.skipUnless(shutil.which("node"), "Node.js is required for focus tests")
+    def test_focus_is_trapped_and_restored_for_every_close_path(self) -> None:
+        harness = r"""
+const fs = require('fs');
+const vm = require('vm');
+
+const documentListeners = new Map();
+let document;
+
+class ElementStub {
+  constructor(id, {hidden = false} = {}) {
+    this.id = id;
+    this.hidden = hidden;
+    this.disabled = false;
+    this.isConnected = true;
+    this.innerHTML = '';
+    this.textContent = '';
+    this.attributes = new Map();
+    this.listeners = new Map();
+    this.focusables = [];
+    this.classList = {add() {}, remove() {}};
+  }
+  addEventListener(type, listener) { this.listeners.set(type, listener); }
+  setAttribute(name, value) { this.attributes.set(name, String(value)); }
+  getAttribute(name) { return this.attributes.get(name) ?? null; }
+  hasAttribute(name) { return this.attributes.has(name); }
+  getClientRects() { return this.hidden ? [] : [{}]; }
+  focus() { document.activeElement = this; }
+  contains(element) { return element === this || this.focusables.includes(element); }
+  querySelectorAll() {
+    return this.focusables.filter(element => !element.disabled && !element.hidden);
+  }
+}
+
+const ids = Object.fromEntries([
+  'artifactGroups', 'artifactViewer', 'artifactViewerBody', 'artifactViewerType',
+  'artifactViewerTitle', 'artifactViewerPath', 'artifactRawLink', 'artifactPrev',
+  'artifactNext', 'artifactViewerClose'
+].map(id => [id, new ElementStub(id, {hidden: id === 'artifactViewer'})]));
+const opener = new ElementStub('opener');
+const secondOpener = new ElementStub('secondOpener');
+const background = new ElementStub('background');
+ids.artifactViewer.focusables = [
+  ids.artifactPrev, ids.artifactNext, ids.artifactRawLink, ids.artifactViewerClose
+];
+
+document = {
+  activeElement: opener,
+  body: new ElementStub('body'),
+  getElementById(id) { return ids[id] || null; },
+  querySelectorAll() { return []; },
+  addEventListener(type, listener) { documentListeners.set(type, listener); }
+};
+const window = {};
+vm.runInNewContext(fs.readFileSync(process.argv[1], 'utf8'), {
+  window, document, URL, console
+});
+
+const viewer = window.ProposalArtifactViewer.mount({
+  artifacts: [
+    {path: 'first.md', group: 'narrative'},
+    {path: 'second.md', group: 'narrative'}
+  ],
+  groups: {narrative: {zh: '正文'}},
+  url: path => path,
+  type: () => 'MD',
+  label: path => path,
+  fetchText: async path => `# ${path}`,
+  fetchJSON: async () => ({})
+});
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function keydown(key, shiftKey = false) {
+  const event = {
+    key,
+    shiftKey,
+    defaultPrevented: false,
+    propagationStopped: false,
+    preventDefault() { this.defaultPrevented = true; },
+    stopImmediatePropagation() { this.propagationStopped = true; }
+  };
+  documentListeners.get('keydown')(event);
+  return event;
+}
+
+(async () => {
+  await viewer.open('first.md');
+  assert(document.activeElement === ids.artifactViewerClose, 'open must focus close');
+
+  let event = keydown('Tab');
+  assert(event.defaultPrevented, 'forward Tab at the last control must be trapped');
+  assert(document.activeElement === ids.artifactNext, 'forward Tab must wrap to first enabled control');
+
+  event = keydown('Tab', true);
+  assert(event.defaultPrevented, 'reverse Tab at the first control must be trapped');
+  assert(document.activeElement === ids.artifactViewerClose, 'reverse Tab must wrap to last control');
+
+  background.focus();
+  event = keydown('Tab');
+  assert(event.defaultPrevented, 'background focus must be pulled into the modal');
+  assert(document.activeElement === ids.artifactNext, 'background focus must return to first control');
+
+  await ids.artifactNext.listeners.get('click')();
+  keydown('Escape');
+  assert(ids.artifactViewer.hidden, 'Escape must close the viewer');
+  assert(document.activeElement === opener, 'Escape must restore the original opener after navigation');
+
+  secondOpener.focus();
+  await viewer.open('second.md');
+  ids.artifactViewerClose.listeners.get('click')();
+  assert(ids.artifactViewer.hidden, 'close button must close the viewer');
+  assert(document.activeElement === secondOpener, 'close button must restore its opener');
+})().catch(error => { console.error(error); process.exitCode = 1; });
+"""
+        completed = subprocess.run(
+            ["node", "-e", harness, str(ROOT / "proposal-artifact-viewer.js")],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- declare the full-screen artifact viewer as a labelled modal dialog
- trap forward/reverse Tab navigation inside its currently visible controls
- remember the element that opened the viewer and restore it on both Escape and close-button exits, including after previous/next navigation
- cover the focus lifecycle with a dependency-free Node DOM harness

## Problem

The viewer moved focus to its close button when opened, but closing left focus on that now-hidden button. Tab could also move into controls behind the full-screen overlay. Keyboard and assistive-technology users therefore lost their place in the artifact list and could interact with obscured page content.

The focusable set includes links, form controls, media controls, summaries, iframes, explicit tab stops, and editable content; hidden/disabled elements are excluded at event time so previous/next state and asynchronously rendered content do not stale the trap.

#1056 changes the same JavaScript file but addresses stale asynchronous render results only. This PR does not alter rendering epochs or content selection; the behaviors and regression files are separate.

## Verification

- `python3 -m unittest tests.test_proposal_artifact_viewer_focus -v` (2 passed)
- focused existing gallery viewer assertion passed
- `node --check proposal-artifact-viewer.js`
- `python3 -m py_compile tests/test_proposal_artifact_viewer_focus.py`
- `git diff --check`
- Chromium interaction: open focuses Close; Tab and Shift+Tab remain in the dialog; Escape restores the originating artifact card