### PR TITLE
fix: scaffold commercial land with official code

### DIFF
--- a/scripts/scaffold_ai_submission.py
+++ b/scripts/scaffold_ai_submission.py
@@ -200,7 +200,7 @@ def land_use_features(site_geom: Any) -> list[dict[str, Any]]:
     cuts = [
         (minx, minx + (maxx - minx) * PARTITION_FRACTIONS[0], "0802", "AI研发创新用地"),
         (minx + (maxx - minx) * PARTITION_FRACTIONS[0], minx + (maxx - minx) * PARTITION_FRACTIONS[1], "1401", "公园绿地与开敞空间"),
-        (minx + (maxx - minx) * PARTITION_FRACTIONS[1], minx + (maxx - minx) * PARTITION_FRACTIONS[2], "05", "产业服务与商业服务用地"),
+        (minx + (maxx - minx) * PARTITION_FRACTIONS[1], minx + (maxx - minx) * PARTITION_FRACTIONS[2], "09", "产业服务与商业服务用地"),
     ]
     generated = []
     features = []

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -157,6 +157,23 @@ def run_scaffold(output_dir: Path, stage: str = "formal", cwd: Path = REPO_ROOT)
     )
 
 
+class LandUseScaffoldContractTests(unittest.TestCase):
+    def test_scaffold_uses_official_commercial_service_land_code(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "submission"
+            result = run_scaffold(output_dir)
+            self.assertEqual(0, result.returncode, result.stderr)
+            land_use = json.loads(
+                (output_dir / "geometry" / "land_use.geojson").read_text(encoding="utf-8")
+            )
+            codes = {
+                feature["properties"].get("land_use_code")
+                for feature in land_use["features"]
+            }
+            self.assertIn("09", codes)
+            self.assertNotIn("05", codes)
+
+
 def complete_scaffold(
     output_dir: Path,
     synchronized_paths: tuple[str, ...] = (),


### PR DESCRIPTION
## What changed

- make the formal submission scaffold emit official `09` for its commercial-service land feature instead of `05`
- add a regression that generates a real scaffold and verifies `09` is present while `05` is absent

## Why

PR #3017 fixed the shared land-use registry on `main`: `05` now correctly means wetland and `09` means commercial-service land. The scaffold was not updated in that merge, so a newly generated formal package still labels its commercial-service feature as wetland. This follow-up aligns generated packages with the corrected contract.

This PR was narrowed after #3017 merged; all now-duplicated enum and validator changes were removed.

## Validation

- `python3 -m unittest tests.test_agent_scaffold_and_self_check.LandUseScaffoldContractTests -v` — PASS
- `python3 -m py_compile scripts/scaffold_ai_submission.py tests/test_agent_scaffold_and_self_check.py` — PASS
- `python3 scripts/scaffold_ai_submission.py --help` — PASS
- `git diff --check upstream/main...HEAD` — PASS

Exact head: `e7961f2524457ef76a20839cf9b543659edc558a`
Base verified: `4177b075dfb887170690ac2e082a47f4a64c7b16`