### PR TITLE
Fix local checks for verified participant aliases

### DIFF
--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -55,6 +55,10 @@ from validate_submission import (
     format_report,
     validate_submission,
 )
+from participant_owner_aliases import (
+    PARTICIPANT_OWNER_ALIASES_PATH,
+    authorized_legacy_submission_dirs,
+)
 
 
 COMMENT_MARKER = "<!-- haidian-submission-validation -->"
@@ -68,7 +72,6 @@ RETRYABLE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 # with the path and head-specific download error after the retry budget.
 RETRYABLE_STATUS_CODES = frozenset({404, 429, 500, 502, 503, 504})
 TRUSTED_REVIEW_GATE_TIMEOUT_SECONDS = 180
-PARTICIPANT_OWNER_ALIASES_PATH = "data/participant_owner_aliases.json"
 
 
 def _http_error_message(error: urllib.error.HTTPError) -> str:
@@ -409,56 +412,6 @@ def strict_manifest_paths_for(files: list[dict]) -> list[str]:
         if isinstance(filename, str) and filename.endswith("/manifest.json"):
             paths.add(filename)
     return sorted(paths)
-
-
-def authorized_legacy_submission_dirs(
-    repo_root: Path, github_user_id: object, current_login: str
-) -> set[str]:
-    """Resolve maintainer-controlled rename aliases from trusted GitHub identity."""
-    if not isinstance(github_user_id, int) or isinstance(github_user_id, bool):
-        return set()
-    policy_path = repo_root / PARTICIPANT_OWNER_ALIASES_PATH
-    try:
-        policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return set()
-    aliases = policy.get("aliases") if isinstance(policy, dict) else None
-    if not isinstance(aliases, list):
-        return set()
-    for item in aliases:
-        if not isinstance(item, dict):
-            continue
-        configured_user_id = item.get("github_user_id")
-        if (
-            not isinstance(configured_user_id, int)
-            or isinstance(configured_user_id, bool)
-            or configured_user_id != github_user_id
-        ):
-            continue
-        configured_login = item.get("current_login")
-        if not isinstance(configured_login, str) or configured_login.casefold() != current_login.casefold():
-            continue
-        legacy_login = item.get("legacy_login")
-        if not isinstance(legacy_login, str) or not legacy_login:
-            return set()
-        legacy_dirs = item.get("legacy_submission_dirs")
-        if not isinstance(legacy_dirs, list):
-            return set()
-        result: set[str] = set()
-        for value in legacy_dirs:
-            if not isinstance(value, str):
-                return set()
-            parts = PurePosixPath(value).parts
-            if (
-                len(parts) != 3
-                or parts[0] != "submissions"
-                or parts[1] != legacy_login
-                or ".." in parts
-            ):
-                return set()
-            result.add(PurePosixPath(value).as_posix())
-        return result
-    return set()
 
 
 def reserved_legacy_login_user_id(repo_root: Path, login: str) -> int | None:

--- a/scripts/participant_owner_aliases.py
+++ b/scripts/participant_owner_aliases.py
@@ -1,0 +1,64 @@
+"""Resolve maintainer-controlled participant login aliases.
+
+Aliases are accepted only when both the current login and GitHub's stable
+numeric user ID match the repository policy.  Invalid or unavailable policy
+data always fails closed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path, PurePosixPath
+
+
+PARTICIPANT_OWNER_ALIASES_PATH = "data/participant_owner_aliases.json"
+
+
+def authorized_legacy_submission_dirs(
+    repo_root: Path, github_user_id: object, current_login: str
+) -> set[str]:
+    """Return legacy package directories owned by a verified current identity."""
+    if not isinstance(github_user_id, int) or isinstance(github_user_id, bool):
+        return set()
+    policy_path = repo_root / PARTICIPANT_OWNER_ALIASES_PATH
+    try:
+        policy = json.loads(policy_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return set()
+    aliases = policy.get("aliases") if isinstance(policy, dict) else None
+    if not isinstance(aliases, list):
+        return set()
+    for item in aliases:
+        if not isinstance(item, dict):
+            continue
+        configured_user_id = item.get("github_user_id")
+        if (
+            not isinstance(configured_user_id, int)
+            or isinstance(configured_user_id, bool)
+            or configured_user_id != github_user_id
+        ):
+            continue
+        configured_login = item.get("current_login")
+        if not isinstance(configured_login, str) or configured_login.casefold() != current_login.casefold():
+            continue
+        legacy_login = item.get("legacy_login")
+        if not isinstance(legacy_login, str) or not legacy_login:
+            return set()
+        legacy_dirs = item.get("legacy_submission_dirs")
+        if not isinstance(legacy_dirs, list):
+            return set()
+        result: set[str] = set()
+        for value in legacy_dirs:
+            if not isinstance(value, str):
+                return set()
+            parts = PurePosixPath(value).parts
+            if (
+                len(parts) != 3
+                or parts[0] != "submissions"
+                or parts[1] != legacy_login
+                or ".." in parts
+            ):
+                return set()
+            result.add(PurePosixPath(value).as_posix())
+        return result
+    return set()

--- a/scripts/participant_preflight.py
+++ b/scripts/participant_preflight.py
@@ -52,6 +52,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from participant_owner_aliases import authorized_legacy_submission_dirs
+
 
 GITHUB_HARD_FILE_LIMIT = 100 * 1024 * 1024
 LARGE_FILE_WARNING = 25 * 1024 * 1024
@@ -128,18 +130,20 @@ def check_push(repo_root: Path, branch: str) -> dict[str, Any]:
     }
 
 
-def run_self_check(repo_root: Path, submission_rel: str, pr_author: str) -> dict[str, Any]:
-    completed = run(
-        [
-            sys.executable,
-            str(repo_root / "scripts" / "self_check_submission.py"),
-            submission_rel,
-            "--pr-author",
-            pr_author,
-            "--json",
-        ],
-        repo_root,
-    )
+def run_self_check(
+    repo_root: Path, submission_rel: str, pr_author: str, pr_author_id: int | None
+) -> dict[str, Any]:
+    command = [
+        sys.executable,
+        str(repo_root / "scripts" / "self_check_submission.py"),
+        submission_rel,
+        "--pr-author",
+        pr_author,
+        "--json",
+    ]
+    if pr_author_id is not None:
+        command.extend(["--pr-author-id", str(pr_author_id)])
+    completed = run(command, repo_root)
     try:
         output: Any = json.loads(completed.stdout) if completed.stdout.strip() else {}
     except json.JSONDecodeError:
@@ -165,11 +169,15 @@ def inspect(args: argparse.Namespace) -> dict[str, Any]:
     parts = Path(submission_rel).parts
     blockers: list[str] = []
     warnings: list[str] = []
+    authorized_legacy_dirs = authorized_legacy_submission_dirs(
+        repo_root, args.pr_author_id, args.pr_author
+    )
     if len(parts) != 3 or parts[0] != "submissions":
         blockers.append("submission path must be submissions/<github-login>/<proposal-slug>")
-    elif parts[1] != args.pr_author:
+    elif parts[1] != args.pr_author and submission_rel not in authorized_legacy_dirs:
         blockers.append(
-            f"submission owner '{parts[1]}' does not exactly match PR author '{args.pr_author}'"
+            f"submission owner '{parts[1]}' does not exactly match PR author '{args.pr_author}'; "
+            "for a maintainer-approved login alias, pass the stable GitHub user ID with --pr-author-id"
         )
     if not submission_dir.is_dir():
         blockers.append(f"submission directory does not exist: {submission_rel}")
@@ -241,7 +249,9 @@ def inspect(args: argparse.Namespace) -> dict[str, Any]:
 
     self_check: dict[str, Any] | None = None
     if not args.skip_self_check and submission_dir.is_dir():
-        self_check = run_self_check(repo_root, submission_rel, args.pr_author)
+        self_check = run_self_check(
+            repo_root, submission_rel, args.pr_author, args.pr_author_id
+        )
         if not self_check["ok"]:
             blockers.append("submission self-check failed; repair the reported issues before pushing")
 
@@ -317,6 +327,11 @@ def main(argv: list[str] | None = None) -> int:
         "--pr-author",
         required=True,
         help="Exact GitHub login of the PR author; must match the directory owner",
+    )
+    parser.add_argument(
+        "--pr-author-id",
+        type=int,
+        help="Stable numeric GitHub user ID; required only for a maintainer-approved login alias",
     )
     parser.add_argument(
         "--repo-root",

--- a/scripts/self_check_submission.py
+++ b/scripts/self_check_submission.py
@@ -264,6 +264,7 @@ def build_self_check(
     submission_dir: Path,
     pr_author: str,
     *,
+    pr_author_id: int | None = None,
     allow_pending_self_check: bool = False,
 ) -> dict[str, Any]:
     repo_root = repo_root.resolve()
@@ -278,6 +279,8 @@ def build_self_check(
         pr_author,
         "--json",
     ]
+    if pr_author_id is not None:
+        validation_command.extend(["--pr-author-id", str(pr_author_id)])
     if allow_pending_self_check:
         validation_command.append("--allow-pending-self-check")
     validation = run_json_command(validation_command)
@@ -477,6 +480,11 @@ def main() -> int:
         help="Exact GitHub login of the PR author; must match the directory owner",
     )
     parser.add_argument(
+        "--pr-author-id",
+        type=int,
+        help="Stable numeric GitHub user ID; required only for a maintainer-approved login alias",
+    )
+    parser.add_argument(
         "--repo-root",
         default=".",
         help="Repository root directory (default: current working directory)",
@@ -505,6 +513,7 @@ def main() -> int:
         repo_root,
         submission_dir,
         args.pr_author,
+        pr_author_id=args.pr_author_id,
         allow_pending_self_check=args.mark_self_checked,
     )
     if args.mark_self_checked:
@@ -519,7 +528,12 @@ def main() -> int:
                 report.setdefault("next_actions", []).append(error)
                 report["self_checked_manifest_updated"] = False
             else:
-                verified = build_self_check(repo_root, submission_dir, args.pr_author)
+                verified = build_self_check(
+                    repo_root,
+                    submission_dir,
+                    args.pr_author,
+                    pr_author_id=args.pr_author_id,
+                )
                 if verified["ok"]:
                     report = verified
                     report["self_checked_manifest_updated"] = True

--- a/scripts/validate_local_submission.py
+++ b/scripts/validate_local_submission.py
@@ -31,6 +31,7 @@ import sys
 from pathlib import Path
 
 from validate_submission import format_report, validate_submission
+from participant_owner_aliases import authorized_legacy_submission_dirs
 
 
 def repo_relative(path: Path, repo_root: Path) -> str:
@@ -90,6 +91,11 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("submission_dir")
     parser.add_argument("--pr-author", required=True)
+    parser.add_argument(
+        "--pr-author-id",
+        type=int,
+        help="Stable numeric GitHub user ID; required only for a maintainer-approved login alias",
+    )
     parser.add_argument("--repo-root", default=".")
     parser.add_argument("--json", action="store_true")
     parser.add_argument(
@@ -118,6 +124,9 @@ def main() -> int:
         strict_manifest_paths=strict_manifest_paths(changed_files)
         if args.strict_manifest
         else (),
+        authorized_legacy_submission_dirs=authorized_legacy_submission_dirs(
+            repo_root, args.pr_author_id, args.pr_author
+        ),
     )
     if args.json:
         print(json.dumps(report.to_dict(), ensure_ascii=False, indent=2))

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -3629,6 +3629,36 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
             self.assertIn("Result: PASS", completed.stdout)
 
+    def test_local_submission_wrapper_accepts_only_verified_owner_alias(self) -> None:
+        base = "submissions/zymk8353/jingzhang-safe-return-line"
+        common = [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "validate_local_submission.py"),
+            base,
+            "--repo-root",
+            str(REPO_ROOT),
+            "--pr-author",
+            "zyaoii",
+            "--json",
+        ]
+        allowed = subprocess.run(
+            [*common, "--pr-author-id", "51290995"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(allowed.returncode, 0, allowed.stdout + allowed.stderr)
+        self.assertTrue(json.loads(allowed.stdout)["ok"])
+
+        denied = subprocess.run(
+            [*common, "--pr-author-id", "7"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(denied.returncode, 0)
+        self.assertFalse(json.loads(denied.stdout)["ok"])
+
     def test_local_submission_wrapper_can_enforce_forward_manifest_contract(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary

- share the fail-closed participant owner alias resolver between trusted CI and local tools
- add `--pr-author-id` to the local validator, four-gate self-check, and participant preflight
- preserve exact-login enforcement when the stable ID is missing, incorrect, or absent from maintainer policy

## Verification

- `python3 -m unittest tests.test_submission_workflow tests.test_agent_scaffold_and_self_check tests.test_lightweight_participant_flow -q` (189 tests PASS)
- `python3 scripts/self_check_submission.py submissions/zymk8353/jingzhang-safe-return-line --repo-root . --pr-author zyaoii --pr-author-id 51290995 --json` (PASS)
- missing/wrong stable ID remains FAIL

Fixes #2210