### PR TITLE
Correct official land use classification codes

### DIFF
--- a/brief/site-package/enums/land_use_codes.json
+++ b/brief/site-package/enums/land_use_codes.json
@@ -1,8 +1,13 @@
 {
   "schema_version": "0.1.0",
   "source_id": "SRC-2023-MNR-LAND-USE-CLASSIFICATION",
-  "note": "Project subset for AI urban design submissions. Import the full official code table before final statutory planning use.",
+  "note": "Project subset from the numeric code system in 自然资发〔2023〕234号. This is distinct from the letter codes in GB 50137-2011. Import the full official code table before final statutory planning use.",
   "codes": [
+    {
+      "code": "05",
+      "label_zh": "湿地",
+      "level": 1
+    },
     {
       "code": "07",
       "label_zh": "居住用地",
@@ -49,9 +54,29 @@
       "level": 2
     },
     {
-      "code": "05",
+      "code": "09",
       "label_zh": "商业服务业用地",
       "level": 1
+    },
+    {
+      "code": "0901",
+      "label_zh": "商业用地",
+      "level": 2
+    },
+    {
+      "code": "0902",
+      "label_zh": "商务金融用地",
+      "level": 2
+    },
+    {
+      "code": "0903",
+      "label_zh": "娱乐用地",
+      "level": 2
+    },
+    {
+      "code": "0904",
+      "label_zh": "其他商业服务业用地",
+      "level": 2
     },
     {
       "code": "1207",
@@ -85,4 +110,3 @@
     }
   ]
 }
-

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -53,6 +53,25 @@ from github_pr_validation import (  # noqa: E402
 from validate_local_submission import discover_submission_files  # noqa: E402
 
 
+class LandUseCodeRegistryTests(unittest.TestCase):
+    def test_wetland_and_commercial_service_codes_match_official_numeric_system(self) -> None:
+        registry = json.loads(
+            (REPO_ROOT / "brief/site-package/enums/land_use_codes.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        labels = {item["code"]: item["label_zh"] for item in registry["codes"]}
+
+        self.assertEqual("湿地", labels["05"])
+        self.assertEqual("商业服务业用地", labels["09"])
+        self.assertEqual(
+            {"0901", "0902", "0903", "0904"},
+            {code for code in labels if code.startswith("09") and len(code) == 4},
+        )
+        self.assertIn("自然资发〔2023〕234号", registry["note"])
+        self.assertIn("GB 50137-2011", registry["note"])
+
+
 class ComplianceMatrixNamespaceTests(unittest.TestCase):
     def test_standard_ids_are_separate_from_source_ids(self) -> None:
         requirements = []


### PR DESCRIPTION
## Summary

- restore `05` to the official 2023 classification meaning, 湿地
- add `09` and `0901`–`0904` for commercial service land
- identify the numeric 自然资发〔2023〕234号 system as distinct from GB 50137-2011 letter codes
- add a regression that pins both code families and the source note

Existing packages using either `05` or `09` remain accepted by the allow-list; this does not rewrite participant submissions or apply a retroactive scoring change.

## Verification

- official `.doc` attachment from the repository-registered China government source extracted locally and checked for `05 = 湿地`, `09 = 商业服务业用地`, and `0901`–`0904`
- `python3 -m unittest tests.test_submission_workflow -q` (149 tests PASS)
- `python3 -m json.tool brief/site-package/enums/land_use_codes.json`

Fixes #2977