### PR TITLE
Fix scaffold commercial land use code

### DIFF
--- a/scripts/scaffold_ai_submission.py
+++ b/scripts/scaffold_ai_submission.py
@@ -200,7 +200,7 @@ def land_use_features(site_geom: Any) -> list[dict[str, Any]]:
     cuts = [
         (minx, minx + (maxx - minx) * PARTITION_FRACTIONS[0], "0802", "AI研发创新用地"),
         (minx + (maxx - minx) * PARTITION_FRACTIONS[0], minx + (maxx - minx) * PARTITION_FRACTIONS[1], "1401", "公园绿地与开敞空间"),
-        (minx + (maxx - minx) * PARTITION_FRACTIONS[1], minx + (maxx - minx) * PARTITION_FRACTIONS[2], "05", "产业服务与商业服务用地"),
+        (minx + (maxx - minx) * PARTITION_FRACTIONS[1], minx + (maxx - minx) * PARTITION_FRACTIONS[2], "09", "产业服务与商业服务用地"),
     ]
     generated = []
     features = []

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -485,6 +485,30 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
             self.assertEqual(expected, {key: agent[key] for key in expected})
             self.assertEqual(expected, {key: manifest["agent"][key] for key in expected})
 
+    def test_scaffold_uses_commercial_service_code_for_commercial_partition(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "submissions" / "alice" / "land-use-codes"
+            scaffold = run_scaffold(output_dir)
+            self.assertEqual(0, scaffold.returncode, scaffold.stdout + scaffold.stderr)
+
+            land_use = json.loads(
+                (output_dir / "geometry" / "land_use.geojson").read_text(encoding="utf-8")
+            )
+            commercial = [
+                feature
+                for feature in land_use["features"]
+                if "商业服务" in feature["properties"].get("name_zh", "")
+            ]
+            self.assertEqual(1, len(commercial))
+            self.assertEqual("09", commercial[0]["properties"]["land_use_code"])
+            self.assertNotIn(
+                "05",
+                {
+                    feature["properties"].get("land_use_code")
+                    for feature in commercial
+                },
+            )
+
     def test_finalize_blocks_v2_package_without_required_bilingual_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             output_dir = Path(tmp) / "submissions" / "alice" / "missing-bilingual"


### PR DESCRIPTION
## Summary

- generate the commercial-service partition with official code `09` instead of wetland code `05`
- add a scaffold regression that inspects generated `land_use.geojson` and pins the commercial feature to `09`
- keep historical participant packages and scoring unchanged

## Verification

- `python3 -m unittest tests.test_agent_scaffold_and_self_check -q` (34 tests PASS)
- `git diff --check`

Fixes #3018