### PR TITLE
fix: align scaffold land-use labels

### DIFF
--- a/scripts/scaffold_ai_submission.py
+++ b/scripts/scaffold_ai_submission.py
@@ -32,6 +32,7 @@ from render_proposal_html import render_html
 from source_registry_utils import load_source_registry, source_registry_bullets_zh, summarize_source_registry
 
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
 PROJECT_ID = "centennial-jingzhang-ai-belt"
 SITE_PACKAGE_VERSION = "0.1.0"
 STAGES = {"formal"}
@@ -195,16 +196,16 @@ def load_boundary(repo_root: Path, stage: str) -> tuple[dict[str, Any], str, str
     return boundary
 
 
-def land_use_features(site_geom: Any) -> list[dict[str, Any]]:
+def land_use_features(site_geom: Any, land_use_labels: dict[str, str]) -> list[dict[str, Any]]:
     minx, miny, maxx, maxy = site_geom.bounds
     cuts = [
-        (minx, minx + (maxx - minx) * PARTITION_FRACTIONS[0], "0802", "科研用地"),
-        (minx + (maxx - minx) * PARTITION_FRACTIONS[0], minx + (maxx - minx) * PARTITION_FRACTIONS[1], "1401", "公园绿地"),
-        (minx + (maxx - minx) * PARTITION_FRACTIONS[1], minx + (maxx - minx) * PARTITION_FRACTIONS[2], "09", "商业服务业用地"),
+        (minx, minx + (maxx - minx) * PARTITION_FRACTIONS[0], "0802"),
+        (minx + (maxx - minx) * PARTITION_FRACTIONS[0], minx + (maxx - minx) * PARTITION_FRACTIONS[1], "1401"),
+        (minx + (maxx - minx) * PARTITION_FRACTIONS[1], minx + (maxx - minx) * PARTITION_FRACTIONS[2], "09"),
     ]
     generated = []
     features = []
-    for index, (left, right, code, name_zh) in enumerate(cuts, start=1):
+    for index, (left, right, code) in enumerate(cuts, start=1):
         geom = polygonal(site_geom.intersection(box(left, miny, right, maxy)))
         if geom.is_empty:
             continue
@@ -215,7 +216,7 @@ def land_use_features(site_geom: Any) -> list[dict[str, Any]]:
                 "LAND_USE",
                 geom,
                 land_use_code=code,
-                name_zh=name_zh,
+                name_zh=land_use_labels[code],
             )
         )
     remainder = polygonal(site_geom.difference(unary_union(generated)))
@@ -226,7 +227,7 @@ def land_use_features(site_geom: Any) -> list[dict[str, Any]]:
                 "LAND_USE",
                 remainder,
                 land_use_code="0702",
-                name_zh="城镇社区服务设施用地",
+                name_zh=land_use_labels["0702"],
             )
         )
     return features
@@ -956,6 +957,8 @@ def make_package(submission_dir: Path, repo_root: Path, stage: str, agent_id: st
     site_props = dict(boundary_feature.get("properties") or {})
     site_props["area_sqm_declared"] = round(projected_area(site_geom), 3)
     source_registry_summary = summarize_source_registry(load_source_registry(repo_root))
+    land_use_registry = load_json(REPO_ROOT / "brief" / "site-package" / "enums" / "land_use_codes.json")
+    land_use_labels = {item["code"]: item["label_zh"] for item in land_use_registry["codes"]}
 
     green_geom = derived_polygon(site_geom, 0.30, 0.16, 0.46, 0.84)
     public_geom = derived_polygon(site_geom, 0.49, 0.32, 0.66, 0.70)
@@ -976,7 +979,9 @@ def make_package(submission_dir: Path, repo_root: Path, stage: str, agent_id: st
             ],
         ),
         "key_areas.geojson": collection("key_areas_official", key_area_features),
-        "land_use.geojson": collection("land_use_topology_partition", land_use_features(site_geom)),
+        "land_use.geojson": collection(
+            "land_use_topology_partition", land_use_features(site_geom, land_use_labels)
+        ),
         "buildings.geojson": collection(
             "building_footprints_scaffold",
             [feature("BLDG-001", "BUILDING_FOOTPRINT", building_geom, building_type="ai_r_and_d", name_zh="AI研发示范建筑基底")],

--- a/scripts/scaffold_ai_submission.py
+++ b/scripts/scaffold_ai_submission.py
@@ -32,7 +32,6 @@ from render_proposal_html import render_html
 from source_registry_utils import load_source_registry, source_registry_bullets_zh, summarize_source_registry
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
 PROJECT_ID = "centennial-jingzhang-ai-belt"
 SITE_PACKAGE_VERSION = "0.1.0"
 STAGES = {"formal"}
@@ -957,7 +956,7 @@ def make_package(submission_dir: Path, repo_root: Path, stage: str, agent_id: st
     site_props = dict(boundary_feature.get("properties") or {})
     site_props["area_sqm_declared"] = round(projected_area(site_geom), 3)
     source_registry_summary = summarize_source_registry(load_source_registry(repo_root))
-    land_use_registry = load_json(REPO_ROOT / "brief" / "site-package" / "enums" / "land_use_codes.json")
+    land_use_registry = load_json(repo_root / "brief" / "site-package" / "enums" / "land_use_codes.json")
     land_use_labels = {item["code"]: item["label_zh"] for item in land_use_registry["codes"]}
 
     green_geom = derived_polygon(site_geom, 0.30, 0.16, 0.46, 0.84)

--- a/scripts/scaffold_ai_submission.py
+++ b/scripts/scaffold_ai_submission.py
@@ -198,8 +198,8 @@ def load_boundary(repo_root: Path, stage: str) -> tuple[dict[str, Any], str, str
 def land_use_features(site_geom: Any) -> list[dict[str, Any]]:
     minx, miny, maxx, maxy = site_geom.bounds
     cuts = [
-        (minx, minx + (maxx - minx) * PARTITION_FRACTIONS[0], "0802", "AI研发创新用地"),
-        (minx + (maxx - minx) * PARTITION_FRACTIONS[0], minx + (maxx - minx) * PARTITION_FRACTIONS[1], "1401", "公园绿地与开敞空间"),
+        (minx, minx + (maxx - minx) * PARTITION_FRACTIONS[0], "0802", "科研用地"),
+        (minx + (maxx - minx) * PARTITION_FRACTIONS[0], minx + (maxx - minx) * PARTITION_FRACTIONS[1], "1401", "公园绿地"),
         (minx + (maxx - minx) * PARTITION_FRACTIONS[1], minx + (maxx - minx) * PARTITION_FRACTIONS[2], "09", "商业服务业用地"),
     ]
     generated = []
@@ -226,7 +226,7 @@ def land_use_features(site_geom: Any) -> list[dict[str, Any]]:
                 "LAND_USE",
                 remainder,
                 land_use_code="0702",
-                name_zh="社区服务与配套用地",
+                name_zh="城镇社区服务设施用地",
             )
         )
     return features

--- a/scripts/scaffold_ai_submission.py
+++ b/scripts/scaffold_ai_submission.py
@@ -200,7 +200,7 @@ def land_use_features(site_geom: Any) -> list[dict[str, Any]]:
     cuts = [
         (minx, minx + (maxx - minx) * PARTITION_FRACTIONS[0], "0802", "AI研发创新用地"),
         (minx + (maxx - minx) * PARTITION_FRACTIONS[0], minx + (maxx - minx) * PARTITION_FRACTIONS[1], "1401", "公园绿地与开敞空间"),
-        (minx + (maxx - minx) * PARTITION_FRACTIONS[1], minx + (maxx - minx) * PARTITION_FRACTIONS[2], "09", "产业服务与商业服务用地"),
+        (minx + (maxx - minx) * PARTITION_FRACTIONS[1], minx + (maxx - minx) * PARTITION_FRACTIONS[2], "09", "商业服务业用地"),
     ]
     generated = []
     features = []

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -501,6 +501,7 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
             ]
             self.assertEqual(1, len(commercial))
             self.assertEqual("09", commercial[0]["properties"]["land_use_code"])
+            self.assertEqual("商业服务业用地", commercial[0]["properties"]["name_zh"])
             self.assertNotIn(
                 "05",
                 {

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -295,6 +295,7 @@ def official_feature(feature_id: str, layer: str, geometry: dict, **props) -> di
 
 
 def write_official_site_package(root: Path) -> None:
+    write_land_use_registry(root)
     geometry_dir = root / "brief" / "site-package" / "geometry"
     geometry_dir.mkdir(parents=True, exist_ok=True)
     features = [
@@ -324,7 +325,15 @@ def write_official_site_package(root: Path) -> None:
     )
 
 
+def write_land_use_registry(root: Path) -> None:
+    enum_dir = root / "brief" / "site-package" / "enums"
+    enum_dir.mkdir(parents=True, exist_ok=True)
+    source = REPO_ROOT / "brief" / "site-package" / "enums" / "land_use_codes.json"
+    (enum_dir / "land_use_codes.json").write_bytes(source.read_bytes())
+
+
 def write_provisional_site_package(root: Path) -> None:
+    write_land_use_registry(root)
     geometry_dir = root / "brief" / "site-package" / "geometry"
     geometry_dir.mkdir(parents=True, exist_ok=True)
     source = REPO_ROOT / "brief" / "site-package" / "geometry" / "provisional_boundaries.geojson"

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -485,7 +485,7 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
             self.assertEqual(expected, {key: agent[key] for key in expected})
             self.assertEqual(expected, {key: manifest["agent"][key] for key in expected})
 
-    def test_scaffold_uses_commercial_service_code_for_commercial_partition(self) -> None:
+    def test_scaffold_land_use_code_labels_match_registry(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             output_dir = Path(tmp) / "submissions" / "alice" / "land-use-codes"
             scaffold = run_scaffold(output_dir)
@@ -494,21 +494,23 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
             land_use = json.loads(
                 (output_dir / "geometry" / "land_use.geojson").read_text(encoding="utf-8")
             )
-            commercial = [
-                feature
-                for feature in land_use["features"]
-                if "商业服务" in feature["properties"].get("name_zh", "")
-            ]
-            self.assertEqual(1, len(commercial))
-            self.assertEqual("09", commercial[0]["properties"]["land_use_code"])
-            self.assertEqual("商业服务业用地", commercial[0]["properties"]["name_zh"])
-            self.assertNotIn(
-                "05",
-                {
-                    feature["properties"].get("land_use_code")
-                    for feature in commercial
-                },
+            registry = json.loads(
+                (REPO_ROOT / "brief/site-package/enums/land_use_codes.json").read_text(
+                    encoding="utf-8"
+                )
             )
+            labels = {item["code"]: item["label_zh"] for item in registry["codes"]}
+            generated = {
+                feature["properties"]["land_use_code"]: feature["properties"]["name_zh"]
+                for feature in land_use["features"]
+            }
+
+            self.assertEqual(
+                {code: labels[code] for code in generated},
+                generated,
+            )
+            self.assertIn("09", generated)
+            self.assertNotIn("05", generated)
 
     def test_finalize_blocks_v2_package_without_required_bilingual_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- align every scaffolded land-use `name_zh` with the authoritative code label in `brief/site-package/enums/land_use_codes.json`
- source generated labels directly from that enum instead of duplicating them in Python
- replace the single commercial-label assertion with a registry-driven regression check covering all generated land-use partitions

After #3021 corrected the generated commercial code from `05` to `09`, the scaffold still emitted stale or descriptive labels beside codes `09`, `0802`, `1401`, and `0702`. The exact-main audit showed the initial fix covered only `09`; this update makes the enum the single source of truth so future label changes flow into generated packages automatically.

## Validation

- `python3 -m unittest tests.test_agent_scaffold_and_self_check -q` (34 tests)
- `python3 -m unittest tests.test_submission_workflow.LandUseCodeRegistryTests -q`
- `python3 -m py_compile scripts/scaffold_ai_submission.py tests/test_agent_scaffold_and_self_check.py`
- `git diff --check`
- scoped secret-pattern scan

Rebased and revalidated against `upstream/main` `d797abfb267b32d75128ac8d378ad724f5c4076a`.