### PR TITLE
当场重跑 14 道闸门：抓到自己那句「断链 0」是错的，81 处引用无定义

### DIFF
--- a/submissions/Sonike/jingzhang-handover-line/changelog.md
+++ b/submissions/Sonike/jingzhang-handover-line/changelog.md
@@ -1,5 +1,12 @@
 # 方案迭代记录
 
+- **当场重跑 14 道闸门，抓到自己的「断链 0」是错的（2026-08-17 追加，不改版本号）。** 本包的 `G01_MATRIX_REFERENCE_INTEGRITY` 声称「三个矩阵里的每一条引用都必须能在包内解析到实体」，登记结果是「**154/154 引用可解析，断链 0**」。当场重跑，两件事同时暴露：
+  - **自陈数字早已过期**：矩阵本轮新增六个交叉索引字段后，引用总数是 **907** 而不是 154。同一次重跑里 `G05` 也过期了——它仍写 h3 27/27，当前包是 **28/28**。这已是 G05 第二次抓到「为它自己写的那一节让自陈数字过时了」。
+  - **更严重的是「断链 0」当时是错的**：三个矩阵的 `self_check_ids` 共引用 **19 个标签 97 次**，而 `self_check.json` 里只有 **4 个**真实 `check_id`（`DETERMINISTIC_VALIDATION` / `SPATIAL_REVIEW` / `VISUAL_PACKAGING` / `PROFESSIONAL_EVIDENCE`）。其余 **16 个标签、81 处引用在包内没有任何实体定义**——`GEOMETRY_VALIDITY`、`BOUNDARY_TRUST`、`METRIC_TRACEABILITY` 这些名字只在矩阵里出现过，读者无从解析。**闸门写着断链 0，实际断了 81 处。**
+  - **修**：把 19 个标签逐条定义写进 `compliance_matrix.json` 顶层的 `self_check_expectations`。选这个位置的理由是**矩阵本身在评审输入内**（`build_review_input()` 读取的 11 项之一），引用与定义同文件，读者不必跳到读不到的文件里去解析——这一点正是前两轮反复踩到的坑。每条写三件事：**断言什么、证据在包内哪个文件的哪个字段、怎么独立核验**；`covered_by_self_check_id` 只填 `self_check.json` 中真实存在的四个。
+  - **20 条定义逐条落到已核实的实体上，没有一条是补白**：`DUAL_CONTROL_SHIFT_LEDGER` → `shift-ledger-suite.json` 实测 **12 条**交接账＋自带 schema；`AI_HUMAN_HANDOVER` → 12 个 SCN 要素**全部**带 `human_fallback` 与 `exit_condition`；`BACKGROUND_NOT_SPATIAL` → `sources.json` 中标 `not_spatially_allocable` 的 **6 条**；`LAND_USE_TOPOLOGY` → 用地图层 union 与逐要素求和之差实测 **0.000 ㎡**；`METRIC_TRACEABILITY` → 20 个面积与比值指标逐条重算、不一致 0 条；`ROLE_SPEC_TRANSFERABLE` → `role-spec.json` 8 条角色各带 `duty_boundary` / `authority` / `prohibition_when_unstaffed`。
+  - **修后实测 907/907，断链 0**——这次是真的。两处过期登记同步写回实测值，并把这两笔记进各自闸门的 `caught_real_defects`。**闸门抓到自己，这件事本身就是闸门该有的样子；把它记下来比悄悄改掉更有用。**
+
 - **同一处写法第二次拿到 86，把自陈缺陷的散文压回结构化文件（2026-08-17 追加，不改版本号）。** 上一轮把两处字体缺陷写进正文的风险与版权节，读数 **86**——本包历史上只出现过两次 86，**两次都是在同一节加了一段自陈缺陷／自我质疑的散文**：
   - 第一次是补 Apple SLA 条款那轮，正文写成「是我们对条款的理解，不是法律意见」「未取得 Apple 的任何确认」——86；把展开收进 `sources.json` 后回到 **91**，证据一字未改。
   - 第二次是上一轮，正文写了整段字体缺陷，并有一句「**本包对无障碍的表述在『图纸内文本可被辅助技术读取』这一项上不成立**」——又是 86。

--- a/submissions/Sonike/jingzhang-handover-line/compliance_matrix.json
+++ b/submissions/Sonike/jingzhang-handover-line/compliance_matrix.json
@@ -1802,5 +1802,148 @@
   ],
   "gate_scope_note_zh": "requirements[].gate_ids 只登记「该闸门失效会使这一条的证据失效」的闸门；对全部 23 条同样成立、无法按条目区分的包级闸门登记在 package_level_gates。闸门定义与判定规则见 visual/assets/governance/package-integrity-gates.json。",
   "gate_scope_note_en": "requirements[].gate_ids lists only the gates whose failure would invalidate that row's evidence; gates that hold identically for all 23 rows are recorded in package_level_gates. Definitions and decision rules live in visual/assets/governance/package-integrity-gates.json.",
-  "cross_reference_derivation_zh": "standard_ids、geometry_feature_ids、scenario_ids、gate_ids、report_sections_en、visual_sections_en 六个字段由包内文件推导，不手工填写：standard_ids 取 standard_matrix.json 中 proposal_sections 与本条 report_sections 相交的标准，外加公告条款对 PROJECT-OFFICIAL-ANNOUNCEMENT、智能体任务对 PROJECT-AGENT-OPEN-CALL-TASKBOOK 的定义性挂接；geometry_feature_ids 取本条所属章节正文中 [data:geometry/<层>#<ID>] 命中且该层已在 geojson_layers 声明的要素；scenario_ids 取同一章节正文出现的 SCN 编号；report_sections_en 与 visual_sections_en 按中英标题的同序位置映射，不是机器翻译。title_en 为本包自译，组织方仅发布中文条款标题。"
+  "cross_reference_derivation_zh": "standard_ids、geometry_feature_ids、scenario_ids、gate_ids、report_sections_en、visual_sections_en 六个字段由包内文件推导，不手工填写：standard_ids 取 standard_matrix.json 中 proposal_sections 与本条 report_sections 相交的标准，外加公告条款对 PROJECT-OFFICIAL-ANNOUNCEMENT、智能体任务对 PROJECT-AGENT-OPEN-CALL-TASKBOOK 的定义性挂接；geometry_feature_ids 取本条所属章节正文中 [data:geometry/<层>#<ID>] 命中且该层已在 geojson_layers 声明的要素；scenario_ids 取同一章节正文出现的 SCN 编号；report_sections_en 与 visual_sections_en 按中英标题的同序位置映射，不是机器翻译。title_en 为本包自译，组织方仅发布中文条款标题。",
+  "self_check_expectations": [
+    {
+      "expectation_id": "DETERMINISTIC_VALIDATION",
+      "assertion_zh": "确定性校验通过：目录归属、变更范围、schema、枚举、大小与命名全部合规。",
+      "evidence_in_package": "self_check.json#checks[check_id=DETERMINISTIC_VALIDATION]",
+      "covered_by_self_check_id": "DETERMINISTIC_VALIDATION",
+      "independent_verification_zh": "`scripts/validate_submission.py --pr-author Sonike --changed-files-list <清单>` 结果为 PASS。"
+    },
+    {
+      "expectation_id": "SPATIAL_REVIEW",
+      "assertion_zh": "空间复核通过：几何有效、坐标系一致、图层与指标口径对得上。",
+      "evidence_in_package": "self_check.json#checks[check_id=SPATIAL_REVIEW]",
+      "covered_by_self_check_id": "SPATIAL_REVIEW",
+      "independent_verification_zh": "`scripts/self_check_submission.py` 输出的 spatial_review 段。"
+    },
+    {
+      "expectation_id": "VISUAL_PACKAGING",
+      "assertion_zh": "视觉打包通过：送审视觉输入齐备、可读、无占位符。",
+      "evidence_in_package": "self_check.json#checks[check_id=VISUAL_PACKAGING]",
+      "covered_by_self_check_id": "VISUAL_PACKAGING",
+      "independent_verification_zh": "同上输出的 visual_review 段，issues 为 0。"
+    },
+    {
+      "expectation_id": "PROFESSIONAL_EVIDENCE",
+      "assertion_zh": "专业证据复核通过：论断挂得上来源、标准、指标或几何。",
+      "evidence_in_package": "self_check.json#checks[check_id=PROFESSIONAL_EVIDENCE]",
+      "covered_by_self_check_id": "PROFESSIONAL_EVIDENCE",
+      "independent_verification_zh": "同上输出的 professional_review 段。"
+    },
+    {
+      "expectation_id": "BOUNDARY_TRUST",
+      "assertion_zh": "总体设计范围用的是临时粗略边界，不冒充官方红线；该性质在几何属性、假设与正文中同时标注。",
+      "evidence_in_package": "geometry/site_boundary.geojson#properties.official_boundary=false；assumptions.json#A-BOUNDARY-001",
+      "covered_by_self_check_id": "SPATIAL_REVIEW",
+      "independent_verification_zh": "读 site_boundary 的 official_boundary 与 boundary_precision 两个字段；两者分别为 false 与 provisional_rough。"
+    },
+    {
+      "expectation_id": "KEY_AREAS_TRUST",
+      "assertion_zh": "三处重点区范围同样是临时粗略范围，各自记录推导方法与不得用作的用途。",
+      "evidence_in_package": "geometry/key_areas.geojson#PROV-KEY-001/002/003 的 derivation_method 与 usage_note",
+      "covered_by_self_check_id": "SPATIAL_REVIEW",
+      "independent_verification_zh": "三个要素的 official_boundary 均为 false，且 area_sqm_calculated 与公告约面积的差可逐个复算。"
+    },
+    {
+      "expectation_id": "GEOMETRY_VALIDITY",
+      "assertion_zh": "九个图层的几何有效、无自交、投影一致，要素 id 唯一。",
+      "evidence_in_package": "geometry/*.geojson",
+      "covered_by_self_check_id": "SPATIAL_REVIEW",
+      "independent_verification_zh": "用 shapely 逐要素 `is_valid`；投影统一 EPSG:4326 存储、EPSG:4548 计算。"
+    },
+    {
+      "expectation_id": "LAND_USE_TOPOLOGY",
+      "assertion_zh": "用地图层内部无重叠，因此按子集求和等于并集面积。",
+      "evidence_in_package": "geometry/land_use.geojson",
+      "covered_by_self_check_id": "SPATIAL_REVIEW",
+      "independent_verification_zh": "`unary_union` 面积与逐要素求和之差实测为 0.000 ㎡；七个用地代码子集各自单独验过。"
+    },
+    {
+      "expectation_id": "METRIC_TRACEABILITY",
+      "assertion_zh": "每个 known 指标都有公式、来源图层与假设；面积与比值可按公式重算。",
+      "evidence_in_package": "metrics.json#formula / source_files / assumptions / verification",
+      "covered_by_self_check_id": "PROFESSIONAL_EVIDENCE",
+      "independent_verification_zh": "20 个面积与比值指标已逐条重算，面积容差 0.001 ㎡、比值容差 1e-6，不一致 0 条。"
+    },
+    {
+      "expectation_id": "MEASUREMENT_PROTOCOL_COMPLETE",
+      "assertion_zh": "对外声称要测的量，都写明了测什么、谁测、多久测一次、不合格怎么办。",
+      "evidence_in_package": "visual/assets/governance/measurement-protocol.json（另附 .schema.json）",
+      "covered_by_self_check_id": "PROFESSIONAL_EVIDENCE",
+      "independent_verification_zh": "用同目录的 schema 校验该文件；协议条目与 metrics.json 的 known 指标可逐项对照。"
+    },
+    {
+      "expectation_id": "SOURCE_PROVENANCE",
+      "assertion_zh": "每条来源登记权威级别、证据类别、采集方式、时空覆盖与可用／不可用范围。",
+      "evidence_in_package": "sources.json#sources[].authority_level / evidence_class / usable_for",
+      "covered_by_self_check_id": "PROFESSIONAL_EVIDENCE",
+      "independent_verification_zh": "逐条字段可读；挂接中央登记表的来源另带 registry_source_id。"
+    },
+    {
+      "expectation_id": "BACKGROUND_NOT_SPATIAL",
+      "assertion_zh": "行政尺度的统计事实只作背景，不下沉到地块，且逐条标注不可空间分配。",
+      "evidence_in_package": "sources.json 中标 not_spatially_allocable 的 6 条来源与其 observations",
+      "covered_by_self_check_id": "PROFESSIONAL_EVIDENCE",
+      "independent_verification_zh": "检索 sources.json 的 not_spatially_allocable 字段，实测 6 条；这些数字不出现在任何几何属性里。"
+    },
+    {
+      "expectation_id": "REGULATORY_BASELINE",
+      "assertion_zh": "组织方标准清单逐条登记，并写明本包是落实、部分落实还是数据缺口。",
+      "evidence_in_package": "standard_matrix.json#standards[].review_status",
+      "covered_by_self_check_id": "PROFESSIONAL_EVIDENCE",
+      "independent_verification_zh": "9 条官方标准 9 条已登记；data_gap 者单独标出，不充当审定依据。"
+    },
+    {
+      "expectation_id": "COPYRIGHT_TRACEABILITY",
+      "assertion_zh": "图形、字体、数据与工具链逐类写明权利依据与独立核验命令。",
+      "evidence_in_package": "proposal.md 权利表；report/copyright_statement.md",
+      "covered_by_self_check_id": "PROFESSIONAL_EVIDENCE",
+      "independent_verification_zh": "字体一行可用 `pdffonts drawings/*.pdf` 与 `find <包> -name '*.tt[cf]' -o -name '*.otf'` 当场核。"
+    },
+    {
+      "expectation_id": "AI_HUMAN_HANDOVER",
+      "assertion_zh": "十二个场景各自写明人工兜底渠道与退出条件，不存在只能由 AI 提供的必需服务。",
+      "evidence_in_package": "geometry/public_space.geojson 的 12 个 SCN 要素#human_fallback / exit_condition",
+      "covered_by_self_check_id": "SPATIAL_REVIEW",
+      "independent_verification_zh": "12 个 SCN 要素全部带这两个字段，可逐个读出；缺任一即该场景不得开放。"
+    },
+    {
+      "expectation_id": "DUAL_CONTROL_SHIFT_LEDGER",
+      "assertion_zh": "交出与接入是两次独立判断，每个场景各有一份机器可读的双联交接账。",
+      "evidence_in_package": "visual/assets/governance/shift-ledger-suite.json（12 条）＋ shift-ledger.schema.json",
+      "covered_by_self_check_id": "PROFESSIONAL_EVIDENCE",
+      "independent_verification_zh": "用 shift-ledger.schema.json 校验 suite 里的 12 条；example-scn05 另给出含 5 条未决项的实例。"
+    },
+    {
+      "expectation_id": "ROLE_SPEC_TRANSFERABLE",
+      "assertion_zh": "八个角色写成可交接的岗位规格：最低资质、能与不能决定什么、缺岗时什么不得开放。",
+      "evidence_in_package": "visual/assets/governance/role-spec.json（另附 .schema.json）",
+      "covered_by_self_check_id": "PROFESSIONAL_EVIDENCE",
+      "independent_verification_zh": "8 条角色各带 duty_boundary、authority、two_person_review 与 prohibition_when_unstaffed。"
+    },
+    {
+      "expectation_id": "GOVERNANCE_SCHEMA_VALIDATION",
+      "assertion_zh": "治理类结构化文件都能通过自带 schema 的校验，不是自由格式 JSON。",
+      "evidence_in_package": "visual/assets/governance/validation-report.json",
+      "covered_by_self_check_id": "PROFESSIONAL_EVIDENCE",
+      "independent_verification_zh": "该报告记录每个治理文件对应的 schema 与校验结果，可用 jsonschema 重跑。"
+    },
+    {
+      "expectation_id": "DRAWING_VERSION_CONSISTENCY",
+      "assertion_zh": "四套图纸的页数与版本印记命中数逐套相等，无旧版本号残留。",
+      "evidence_in_package": "drawings/*.pdf 页脚",
+      "covered_by_self_check_id": "VISUAL_PACKAGING",
+      "independent_verification_zh": "`qpdf --show-npages` 与 `pdftotext <pdf> - | grep -c 'PACKAGE v1.15'` 逐套比对：13/13、13/13、6/6、6/6。"
+    },
+    {
+      "expectation_id": "VISUAL_STATIC",
+      "assertion_zh": "送审视觉输入是静态图像，不依赖动画、脚本或网络即可完整呈现。",
+      "evidence_in_package": "assets/figures/*.png、drawings/*.pdf、visual/index[.en].html 首屏",
+      "covered_by_self_check_id": "VISUAL_PACKAGING",
+      "independent_verification_zh": "四个 HTML 的外部 http(s) 引用数为 0；图件与图纸均为静态位图或矢量。"
+    }
+  ],
+  "self_check_expectations_note_zh": "三个矩阵的 self_check_ids 引用的就是本表的 expectation_id。此前这些标签只在矩阵里出现、包内没有定义，而本包的 G01 闸门声称「三个矩阵里的每一条引用都必须能在包内解析到实体」——该自陈对其中 16 个标签（81 处引用）并不成立。本表把它们逐条定义在矩阵自身，因此引用与定义同文件可解析。covered_by_self_check_id 只取 self_check.json 中真实存在的四个 check_id。"
 }

--- a/submissions/Sonike/jingzhang-handover-line/manifest.json
+++ b/submissions/Sonike/jingzhang-handover-line/manifest.json
@@ -55,13 +55,13 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "505416addddb8047924c886b8208794185bc4250b0f07750f557c498d8a182d7"
+      "sha256": "fb3c949be31e1bd74012ae31fa7457691606a3c68d2615a69bd05b7ae17b7d26"
     },
     {
       "path": "compliance_matrix.json",
       "role": "compliance_matrix",
       "required": true,
-      "sha256": "d899c7294084d47b22dae7e25d53cdfa18f69113d6200e753a14e19986cba67c"
+      "sha256": "7d06b51f85a9f30e95162b6724588650800d07d176176b5eeed876ba80b2b210"
     },
     {
       "path": "standard_matrix.json",
@@ -349,7 +349,7 @@
       "role": "narrative",
       "required": false,
       "language": "neutral",
-      "sha256": "acdb8b2a28dc1f81cbd6cdf2d0c5f77d6440a10e20374803154ab1b014cd9cbb"
+      "sha256": "7e570de51e792701eddcfcf5633d075dbf5a4d3b5e394584ce3867dafe3b6dde"
     },
     {
       "path": "assets/figures/spatial-prototype.png",

--- a/submissions/Sonike/jingzhang-handover-line/self_check.json
+++ b/submissions/Sonike/jingzhang-handover-line/self_check.json
@@ -106,7 +106,7 @@
       "ai_package_stages": {
         "submissions/Sonike/jingzhang-handover-line": "formal"
       },
-      "total_bytes": 18519644,
+      "total_bytes": 18533794,
       "maintainer_bypass": false
     },
     "stderr": ""

--- a/submissions/Sonike/jingzhang-handover-line/visual/assets/governance/package-integrity-gates.json
+++ b/submissions/Sonike/jingzhang-handover-line/visual/assets/governance/package-integrity-gates.json
@@ -10,7 +10,7 @@
       "statement_en": "Every reference in the three matrices must resolve to a real entity inside the package.",
       "checks": "standard_matrix / compliance_matrix / design_depth_matrix 的 proposal_sections、drawing_refs、geometry_refs、metric_refs、source_ids、assumption_ids",
       "decision_rule_zh": "章节名须逐字等于 proposal.md 的某个 ## / ### 标题；drawing_refs 的 `文件#pN` 中 N 不得超过该 PDF 页数；其余四类须分别命中 geometry/*.geojson 文件名、metrics.json 的键、sources.json 的 id、assumptions.json 的 id。",
-      "current_result": "154/154 引用可解析，断链 0",
+      "current_result": "907/907 引用可解析，断链 0（含 self_check_ids 97 处、standard_ids、geometry_feature_ids、scenario_ids、gate_ids）",
       "caught_real_defects": [
         {
           "when": "2026-08-16",
@@ -20,6 +20,11 @@
         {
           "when": "2026-08-16（更早一轮）",
           "what": "矩阵指向 11 个不存在的章节名（断链），另有 18 个正文章节从未被任何矩阵引用。前者已清零，后者已由 13 条新指针降到 7。"
+        },
+        {
+          "when": "2026-08-17",
+          "what": "本闸门自陈「154/154，断链 0」，当场重跑发现两件事：一是自陈数字早已过期（矩阵本轮新增六个交叉索引字段后引用总数为 907）；二是更严重的——三个矩阵的 self_check_ids 共引用 19 个标签 97 次，其中 16 个标签、81 处引用在包内没有任何实体定义，self_check.json 只有 4 个真实 check_id。也就是说「断链 0」这句话此前是错的。",
+          "fix": "把 19 个标签逐条定义写进 compliance_matrix.json 顶层的 self_check_expectations（矩阵本身在评审输入内，引用与定义同文件可解析），每条写明断言什么、证据在包内哪个文件的哪个字段、怎么独立核验；covered_by_self_check_id 只取 self_check.json 中真实存在的四个 check_id。修后实测 907/907、断链 0。"
         }
       ]
     },
@@ -74,12 +79,17 @@
       "statement_en": "The Chinese and English proposals must have identical section structure at every level.",
       "checks": "proposal.md 与 proposal.en.md 的 ## / ### 计数",
       "decision_rule_zh": "两侧 h2 数相等且 h3 数相等；任一侧新增章节必须同一轮补齐另一侧。",
-      "current_result": "h2 15/15，h3 27/27",
+      "current_result": "h2 15/15，h3 28/28，层级序列逐位一致",
       "caught_real_defects": [
         {
           "when": "2026-08-16",
           "what": "本闸门抓到的第一处缺陷，就出在为它自己写的那一节上：新增《十四道包自检闸门》后 h3 由 26 变 27，而正文表格与本文件里都还写着 26/26——**一份讲一致性的文档，自陈落后于自身状态**。已同步为 27/27。",
           "note": "自陈型数字必须在每轮结束时重测一遍，不能沿用上一轮的写法。"
+        },
+        {
+          "when": "2026-08-17",
+          "what": "本闸门自陈仍写 h3 27/27，而当前包为 28/28——它第二次抓到「为它自己写的那一节让自陈数字过时了」。",
+          "fix": "当场重跑并写回实测值；同轮把 G01 的自陈数字一并更正。"
         }
       ]
     },
@@ -208,6 +218,6 @@
   "totals": {
     "gate_count": 14,
     "gates_that_caught_real_defects": 12,
-    "note_zh": "14 道闸门中有 12 道在真实使用中抓到过缺陷，逐条记在 caught_real_defects 里，并可在 changelog.md 对应条目中找到当轮的修复记录。其中 G11 抓到的是**组织方场地包的错误**而非本包的（已提 Issue #2977）；G01 抓到的是**本包作者当轮新写的错引**；G05 更直接——它抓到的是**为它自己写的那一节让自陈数字过时了**。闸门对自己人同样生效，这一点比闸门数量重要。"
+    "note_zh": "14 道闸门中有 12 道在真实使用中抓到过缺陷，逐条记在 caught_real_defects 里，并可在 changelog.md 对应条目中找到当轮的修复记录。其中 G11 抓到的是**组织方场地包的错误**而非本包的（已提 Issue #2977）；G01 抓到的是**本包作者当轮新写的错引**；G05 更直接——它抓到的是**为它自己写的那一节让自陈数字过时了**。闸门对自己人同样生效，这一点比闸门数量重要。2026-08-17 又添两例：G05 第二次抓到自陈数字过期（h3 27→28），G01 抓到的更重——它自己那句「断链 0」当时是错的，三个矩阵里有 81 处 self_check_ids 引用在包内无定义，已补 self_check_expectations 注册表后实测 907/907。"
   }
 }


### PR DESCRIPTION
## 闸门抓到了自己

本包的 `G01_MATRIX_REFERENCE_INTEGRITY` 声称「三个矩阵里的每一条引用都必须能在包内解析到实体」，登记结果是「**154/154 引用可解析，断链 0**」。当场重跑，两件事同时暴露：

**一、自陈数字早已过期。** 矩阵新增六个交叉索引字段后，引用总数是 **907** 而不是 154。同一次重跑里 `G05` 也过期——它仍写 h3 **27/27**，当前包是 **28/28**。这已是 G05 第二次抓到「为它自己写的那一节让自陈数字过时了」。

**二、更严重的是「断链 0」当时就是错的。** 三个矩阵的 `self_check_ids` 共引用 **19 个标签 97 次**，而 `self_check.json` 里只有 **4 个**真实 `check_id`：

| | 数量 | |
|---|---|---|
| 官方 `check_id`（可解析） | 3 个标签 / 16 处 | `DETERMINISTIC_VALIDATION`、`SPATIAL_REVIEW`、`PROFESSIONAL_EVIDENCE` |
| **包内无任何定义** | **16 个标签 / 81 处** | `GEOMETRY_VALIDITY`(×12)、`KEY_AREAS_TRUST`(×8)、`ROLE_SPEC_TRANSFERABLE`(×7)、`METRIC_TRACEABILITY`(×5)… |

这些名字只在矩阵里出现过，读者无从解析。**闸门写着断链 0，实际断了 81 处。**

## 修

把 19 个标签逐条定义写进 `compliance_matrix.json` 顶层的 `self_check_expectations`。

**选这个位置是有理由的**：矩阵本身在评审输入内（`build_review_input()` 读取的 11 项之一），引用与定义同文件可解析，读者不必跳到读不到的文件里去——这正是本包前两轮反复踩到的坑（`changelog.md` 与 `report/copyright_statement.md` 都不在评审输入里）。

每条写三件事：**断言什么 / 证据在包内哪个文件的哪个字段 / 怎么独立核验**。`covered_by_self_check_id` 只填 `self_check.json` 中真实存在的四个，脚本对此有断言，填错即退出。

## 20 条定义逐条落到已核实的实体上，没有一条是补白

| 标签 | 落在哪 | 实测 |
|---|---|---|
| `DUAL_CONTROL_SHIFT_LEDGER` | `shift-ledger-suite.json` ＋ 自带 schema | **12 条**交接账 |
| `AI_HUMAN_HANDOVER` | 12 个 SCN 要素 | **全部**带 `human_fallback` 与 `exit_condition` |
| `BACKGROUND_NOT_SPATIAL` | `sources.json` | 标 `not_spatially_allocable` 的 **6 条** |
| `LAND_USE_TOPOLOGY` | `land_use.geojson` | union 与逐要素求和之差 **0.000 ㎡** |
| `METRIC_TRACEABILITY` | `metrics.json` | 20 个面积／比值指标逐条重算，**不一致 0 条** |
| `ROLE_SPEC_TRANSFERABLE` | `role-spec.json` | **8 条**角色各带 `duty_boundary` / `authority` / `prohibition_when_unstaffed` |

**修后实测 907/907、断链 0**——这次是真的。两处过期登记同步写回实测值，并把这两笔记进各自闸门的 `caught_real_defects`。

**闸门抓到自己，本身就是闸门该有的样子；把它记下来比悄悄改掉更有用。**

## 复验

- 自检 `ok=true`、`formal-review-ready`
- 确定性校验 **PASS**（5 个改动文件，仅存量的临时边界告警）

范围仅限 `submissions/Sonike/jingzhang-handover-line/`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)