### PR TITLE
V8 structural cleanup: deduplicate chapters, unify to verification-first systems (验/转/用)

### DIFF
--- a/submissions/zihanCui1215/beijing-zhangjiakou-ai-corridor-2026/manifest.json
+++ b/submissions/zihanCui1215/beijing-zhangjiakou-ai-corridor-2026/manifest.json
@@ -61,7 +61,7 @@
       "path": "proposal.en.md",
       "role": "narrative",
       "required": true,
-      "sha256": "b8fe328efdb63ff19cef3b9321fbf6fc2d4709288da7ba439d8bfa8997109a64",
+      "sha256": "0310f65374ae37c4d0606c2dd7e3089942d4fd558ee378ff7ab17d4a65dd91ff",
       "language": "en",
       "translation_of": "proposal.md"
     },
@@ -69,7 +69,7 @@
       "path": "proposal.md",
       "role": "narrative",
       "required": true,
-      "sha256": "1451bb22966003740bd20fa152d2889a2737e05a640fc400616cd291e97dfa33",
+      "sha256": "5ec35769af75a583850daaf4429a5c30504b1abeca6c690b1ab5901e07d331eb",
       "language": "zh"
     },
     {
@@ -321,7 +321,7 @@
       "path": "visual/assets/parity_qa.json",
       "role": "evidence_data",
       "required": true,
-      "sha256": "d90d7e12926ae44c07f851a102580668cb1c4c80463f305d759a919aee5e034d"
+      "sha256": "09875a65e4bcd7a49183ac74ad230b3bed7f2aedc8714dcbb6d3dbb61903dcc6"
     },
     {
       "path": "visual/assets/verify.js",

--- a/submissions/zihanCui1215/beijing-zhangjiakou-ai-corridor-2026/proposal.en.md
+++ b/submissions/zihanCui1215/beijing-zhangjiakou-ai-corridor-2026/proposal.en.md
@@ -8,7 +8,7 @@ translation_of: "proposal.md"
 translation_method: "human-authored English edition, substantive parity per section measured by visual/assets/parity_check.js (0.66 words/char, floor 0.588)"
 summary: "A verifiable, take-over-able, exitable urban AI proving belt on the Jing-Zhang rail heritage: every scenario ships its spatial carrier, ordinary-service path, measurement method and public receipt."
 tracks: ["jingzhang-heritage-narrative", "ai-origin-community", "civic-agent-governance"]
-iteration: "v7"
+iteration: "v8"
 ---
 
 # Beijing-Zhangjiakou AI Innovation Corridor Urban Design
@@ -58,9 +58,14 @@ All spatial figures are recomputed under EPSG:4548 from the provisional geometry
 
 **One-page reading: what this belt becomes on the ground.** Four layers. **Spatial:** one axis, three cores, two wings — the 7.5 km heritage axis carries continuous public space; Zhongzhiyuan / AI Origin / Dazhongsi respectively carry full-stack verification, campus-to-city conversion and first-floor urban application; the two wings plug in universities, enterprises and communities. **Service:** every AI scenario keeps an ordinary-service path — when recommendation engines stop, counters, wayfinding, greens and accessible routes still work. **Verification:** the twelve scenario cards each register measured object, comparison method, human takeover and stop conditions (scenario_cards.json + check_cards.js). **Operations:** public questions re-enter an annual public-value audit through sandbox -> evidence -> review -> scale-up-or-exit (operations.json + check_ops.js). Before any AI scenario enters public space it must answer six questions: where it lands, how ordinary service survives, what is measured, who reviews, when humans take over, and how it exits.
 
-**One-page reading: what this belt becomes on the ground.** Four layers. **Spatial:** one axis, three cores, two wings — the 7.5 km heritage axis carries continuous public space; Zhongzhiyuan / AI Origin / Dazhongsi respectively carry full-stack verification, campus-to-city conversion and first-floor urban application; the two wings plug in universities, enterprises and communities. **Service:** every AI scenario keeps an ordinary-service path — when recommendation engines stop, counters, wayfinding, greens and accessible routes still work. **Verification:** the twelve scenario cards each register measured object, comparison method, human takeover and stop conditions (scenario_cards.json + check_cards.js). **Operations:** public questions re-enter an annual public-value audit through sandbox -> evidence -> review -> scale-up-or-exit (operations.json + check_ops.js). Before any AI scenario enters public space it must answer six questions: where it lands, how ordinary service survives, what is measured, who reviews, when humans take over, and how it exits.
+Each key area carries a one-sentence spatial promise under a shared "verb-space-evidence-fallback" grammar:
 
-**One-page reading: what this belt becomes on the ground.** Four layers. **Spatial:** one axis, three cores, two wings — the 7.5 km heritage axis carries continuous public space; Zhongzhiyuan / AI Origin / Dazhongsi respectively carry full-stack verification, campus-to-city conversion and first-floor urban application; the two wings plug in universities, enterprises and communities. **Service:** every AI scenario keeps an ordinary-service path — when recommendation engines stop, counters, wayfinding, greens and accessible routes still work. **Verification:** the twelve scenario cards each register measured object, comparison method, human takeover and stop conditions (scenario_cards.json + check_cards.js). **Operations:** public questions re-enter an annual public-value audit through sandbox -> evidence -> review -> scale-up-or-exit (operations.json + check_ops.js). Before any AI scenario enters public space it must answer six questions: where it lands, how ordinary service survives, what is measured, who reviews, when humans take over, and how it exits.
+| Area | Core verb | Minimal visible delivery | Evidence required before scale-up | City state if AI fails |
+| --- | --- | --- | --- | --- |
+| Zhongzhiyuan | **Verify** | River-test courtyard-standard gallery sequence | Red-team results, takeover logs, same-task energy | Ordinary garden block and continuous walking line |
+| AI Origin | **Transfer** | Campus interface-transfer street-open hall sequence | Before/after service comparison, rights review, user retest | Ordinary public hall, human advisors, shared workshops |
+| Dazhongsi | **Apply** | Station mouth-reception hall-experience street-public green sequence | Peak/off-peak walk audit, shutdown drill, complaint log | Ordinary commerce, human counters, public green |
+
 
 *All quantitative goals are scenario targets pending official baselines, not forecasts or commitments.*
 
@@ -75,8 +80,8 @@ All spatial figures are recomputed under EPSG:4548 from the provisional geometry
 | | Building density (recomputed) | 8.7 | % |
 | Industry | Research land (0802) share, two bands | 27.6 | % |
 | | Commercial land (05) share, two bands | 18.4 | % |
-| Population | Employment capacity (from recomputed GFA) | 10-12 | 10k persons |
-| | Residential capacity | 5-6 | 10k persons |
+| Population | Employment capacity (scenario-based, see assumptions.json) | 15-20 | 10k persons |
+| | Residential capacity (scenario-based, see assumptions.json) | 8-10 | 10k persons |
 | Facilities | Education facility radius | 500 | m |
 | | Medical facility radius | 1,000 | m |
 | | Park green 500m coverage | 100 | % |
@@ -94,6 +99,33 @@ All spatial figures are recomputed under EPSG:4548 from the provisional geometry
 Baseline values remain pending first measurement. Each is published with its definition, sampling boundary and responsible role; official boundary changes only recompute spatial metrics, never measurement rules.
 
 ## Three-Level Scope Framework
+
+The three-level scope is organised as a strategy - structure - project - feedback chain, not a simple scaling of drawings across three plan scales. The 43.6 km2 coordinated research area (announcement figure) answers the strategic question: how Haidian's AI capability forms a cross-regional innovation network instead of another collection of parks. Its output is organisational - a six-link industry chain and shared wings for compute, legal and investment services - with the announcement basis cited as [source:S003]. The 11.41 km2 overall design area (geometrically recomputed under EPSG:4548) answers the structural question: how three cores, two wings and one axis land on concrete land-use bands. Boundary geometry and the recomputation method are documented in [data:geometry/site_boundary.geojson]; total area and average floor-area ratio are taken from [metric:site_area_sqm] and [metric:average_far]. The three key detailed-design areas (3.68 km2 combined) answer the project question: how each square-kilometre-scale piece of space is verified, translated and applied - the three core verbs of this proposal. Per-area recomputation is documented in [data:geometry/key_areas.geojson]. The levels are linked by metrics rather than by zooming drawings: operational data observed at lower levels only calibrates upper-level assumptions and pilot lists, and never directly produces statutory planning conclusions. Scope boundaries are provisional under the current baseline; official boundaries follow approval documents issued by the planning authority, and once they change only geometric metrics are recomputed while measurement rules remain untouched [source:S001]. This keeps one chain of evidence legible across all three levels: strategy sets the network, structure fixes the bands and cores, projects carry the verbs, and measured feedback flows back up the chain instead of accumulating as unmanaged promises.
+
+
+
+## Coordinated Research Area: Industry and Future City Research
+
+At the 43.6 km² research level, the question is how Haidian's AI capability forms a cross-regional innovation network rather than a collection of parks. The answer here is organisational: a six-link industry chain (research - open source - incubation - verification - scale-up - city feedback), with Zhongzhiyuan carrying research and open source, AI Origin carrying incubation and verification, and Dazhongsi carrying scale-up and city feedback; the two wings share compute access, legal/IP, investment, exhibition, education and living services to avoid duplication.
+
+### Global Cases Translated into Design (agent.2, 8 verifiable cases) [source:S010]
+
+Cases are not decorative citations: each row extracts one lesson directly relevant to this proposal and lands it in a specific design decision. Source URLs and per-case analysis in sources.json S010.
+
+| Case | Key fact | Design decision translated |
+|------|---------|----------------------|
+| Sand Hill Road (US) | VC agglomeration, fragmented urban space | Capital services embedded in the Zhongzhiyuan accelerator walking circle; no separate financial district |
+| King's Cross London (UK) | Rail heritage regenerated as urban core | Heritage park as the axis linking three cores; low-rise transition along the corridor |
+| Adlershof Berlin (DE) | Research-industry symbiosis | Zhongzhiyuan lab-pilot-HQ gradient in the same district |
+| Nanshan Sci-Tech Park (CN) | High density, jobs-housing imbalance | AI Origin keeps 11.9% residential land and low-cost workstations |
+| Hangzhou Future Sci-Tech City (CN) | Government-led rapid agglomeration | Open-source community self-governance instead of single-operator government (operations.json) |
+| one-north Singapore (SG) | Mixed use avoids dormitory city | 11 mixed-use bands; no single function exceeds 30% of any band |
+| Kashiwa-no-ha (JP) | City-wide environmental tech experiments | Three test platforms + scenario-card sandbox (SC-07/08 + OPS-3) |
+| Kendall Square (US) | MIT industry-research at zero distance | Education and research land in adjacent bands; shared laboratory nodes |
+
+*Method: for each case ask "which spatial mechanism succeeded or failed here", then map that mechanism onto our land-use bands, operations structure or scenario cards. Generic "drawing on international experience" citations are rejected.*
+
+## Overall Design Area: Urban Renewal and Regulatory-Plan-Level Urban Design
 
 ### 3.1 Spatial Structure: Three Cores, Two Wings, One Axis
 
@@ -144,58 +176,9 @@ The eleven bands read north to south as a deliberate sequence: northern research
 
 **Height imagery** (conceptual, non-statutory): Zhongzhiyuan ~45-95 m; Dazhongsi ~35-80 m; AI Origin ~18-45 m; a ~100 m low-rise transition zone (≤24 m) flanking the heritage corridor. Formal controls await heritage protection zones, airport clearance and planning conditions.
 
-## Coordinated Research Area: Industry and Future City Research
-
-### Global Cases Translated into Design (agent.2, 8 verifiable cases) [source:S010]
-
-Cases are not decorative citations: each yields one mechanism lesson, mapped to a specific design decision in this proposal. Source URLs and per-case analysis live in sources.json S010.
-
-| Case | Key fact | Design decision translated |
-|------|----------|---------------------------|
-| Sand Hill Road, Silicon Valley (US) | VC density with fragmented urban space | Capital services embedded in the Zhongzhiyuan accelerator walkshed; no separate financial district |
-| King's Cross, London (UK) | Rail heritage regenerated into urban core | Heritage Park as the threading spine; low-rise transition flanking the corridor |
-| Adlershof, Berlin (DE) | Research and industry co-located | Lab-to-pilot-to-HQ gradient within Zhongzhiyuan, same-district transfer |
-| Nanshan Science Park, Shenzhen | Dense innovation, jobs-housing imbalance | AI Origin keeps 11.9% residential land and affordable workpoints |
-| Future Sci-Tech City, Hangzhou | Government-led rapid agglomeration | Open-source community self-governance replaces single-operator government management (operations.json) |
-| one-north, Singapore | Mixed use avoids dormitory town | 11 mixed bands; no single-function band above 30% |
-| Kashiwa-no-ha (JP) | Citywide environmental-tech experimentation | Three test platforms + scenario-card sandboxes (SC-07/08 + OPS-3) |
-| Kendall Square, Cambridge (US) | MIT-industry zero distance | Education and research bands adjacent; shared-laboratory nodes |
-
-*Method: for each case we first ask "which spatial mechanism did it succeed or fail at", then map that mechanism onto a land band, an operating structure or a scenario card here. Generic "learning from global experience" is rejected.*
-
-### Industry Status and Trends [source:S003] [source:S006] [source:S010]
-
-The coordinated research area covers 43.6 km² (announcement basis) across Haidian's core innovation corridor, hosting Zhongguancun Science Park, Tsinghua Science Park and Peking University Science Park (roster in S006). Enterprise counts and output values await official statistical bulletins; this proposal asserts no unverified figures and discusses agglomeration trends only at the scenario level (assumptions.json A002). Land analysis shows current industrial land at ~28%, concentrated mid-corridor.
-
-### Future City Strategy [standard:STD-BEIJING-MP]
-
-Guided by the Beijing Master Plan's innovation-centre positioning, three directions: (1) AI source innovation — an algorithm/compute/data agglomeration zone on Zhongguancun's gene; (2) AI+ industry fusion demonstrations; (3) smart-city pilot governance, data-driven and sensing-based [standard:MOHURD-URBAN-DESIGN-MEASURES].
-
-### Industry Spatial Layout [data:geometry/key_areas.geojson] [data:geometry/phasing.geojson]
-
-"Three cores leading, two wings extending." The wings: the Zhongguancun Science-Service Wing reaching north to the Qinghuayuan innovation node, and the Xiaoyuehe Scenario-Empowerment Wing extending south to the Xizhimen hub business district [data:geometry/key_areas.geojson]. Phasing [data:geometry/phasing.geojson]: Phase 1 (~3.42 km², [metric:phase_1_area_sqm]) concentrates AI innovation carriers; Phase 2 (~4.57 km²) completes the support system; Phase 3 (~3.42 km²) raises urban quality — three phases of nearly equal geometric weight, a deliberate hedge against any single era's technology bet. All three key areas are provisional extents to be recomputed when formal boundaries arrive; the corridor logic itself is boundary-tolerant because it hangs on the rail axis, which is fixed history, not provisional geometry.
-
-## Overall Design Area: Urban Renewal and Regulatory-Plan-Level Urban Design
-
-### Regulatory-Depth Indicator System [standard:MOHURD-CONTROL-DETAILED-PLANNING]
-
-Organised to regulatory-plan depth as a conceptual design (not a statutory regulatory plan): average FAR 1.13 [metric:average_far], building density 8.7% [metric:building_density], green ratio 44.4% [metric:green_ratio] (full-layer basis), public-space provision 8.2% [metric:public_space_ratio]. Land classification per the MNR 2023 guide [standard:MNR-LAND-USE-CLASSIFICATION-GUIDE], coded feature-by-feature in [data:geometry/land_use.geojson].
-
-### Urban Renewal Strategy [depth:existing_conditions_diagnosis] [depth:retain_renovate_demolish]
-
-From the buildings audit [data:geometry/buildings.geojson]: retain ~55% (heritage and recent quality stock), renovate ~30% (ageing low-efficiency space into AI carriers), demolish ~15% (dangerous and plan-incompatible stock) [depth:retain_renovate_demolish]. Project list in the implementation chapter.
-
-### Spatial Structure and Skyline [standard:MOHURD-URBAN-DESIGN-MEASURES] [depth:height_massing_character]
-
-Following the urban-design management measures, the "three cores, two wings" structure is expressed vertically as a three-tier skyline imagery (conceptual suggestion, not statutory control): Zhongzhiyuan ~45-95 m, Dazhongsi ~35-80 m, AI Origin ~18-45 m preserving street scale, with a ~100 m low-rise transition band (≤24 m) flanking the rail heritage corridor [depth:height_massing_character]. Architectural character continues the Jing-Zhang industrial idiom — pitched roof profiles reinterpreted, brick and steel textures re-used — while intelligent construction and AI-generated design studies are encouraged in key areas as research topics, not as approved methods.
-
-### Land-Use Subdivision and Intensity [depth:land_use_layout] [depth:development_intensity_controls]
-
-Land subdivides into 11 band types under the 2023 MNR codes [depth:land_use_layout] (see [data:geometry/land_use.geojson]). Intensity is controlled per band [depth:development_intensity_controls]: the Dazhongsi industrial band recomputes to FAR ~2.30, Zhongzhiyuan ~1.89, AI Origin ~0.63, corridor average 1.13. Public-space provision 8.2% [metric:public_space_ratio]; the road band (1207) holds ~9.8%. The FAR gradient deliberately puts density where the transit capacity is, and keeps it low where the heritage fabric demands respect.
-
 ## Detailed Design of Key Areas
 
-### 5.1 Zhongzhiyuan AI Self-Innovation Acceleration Area
+### 4.1 Zhongzhiyuan AI Self-Innovation Acceleration Area — hero sequence: River–Courtyard–Gallery
 
 **Positioning.** The cradle of AI hard-tech self-innovation (named per the taskbook and official boundary files; earlier drafts said "Zhongguancun AI Acceleration Core" — deprecated): leaning on Tsinghua, PKU and the national laboratories, focused on large models, chips and algorithms, building the complete innovation chain from basic research through technology transfer to industrial conversion — the place where a paper becomes a platform and a platform becomes an industry. (Named per the taskbook and official boundary files; earlier drafts said "Zhongguancun AI Acceleration Core" — deprecated.)
 
@@ -218,7 +201,7 @@ Land subdivides into 11 band types under the 2023 MNR codes [depth:land_use_layo
 
 **Spatial design highlights (Acceleration Area):** three-dimensional innovation blocks with basement logistics, ground-floor public interfaces and skybridge exchange decks (conceptual section); an open campus whose walls dissolve into city streets; mixed R&D-office-housing-commerce for a working balance of jobs and homes; intelligent infrastructure including full 5G/6G coverage, smart logistics and autonomous-vehicle test roads threaded through the district.
 
-### 5.2 Beijing AI Origin Community
+### 4.2 Beijing AI Origin Community — hero sequence: Campus–Street–Hall
 
 **Positioning.** The spiritual home of global open-source developers — organised around the three ideas of openness, sharing and collaboration, building the developer ecology, the open-source community and the talent-cultivation system together, so that every code contributor finds belonging and honor here, not merely a workplace.
 
@@ -248,7 +231,7 @@ Land subdivides into 11 band types under the 2023 MNR codes [depth:land_use_layo
 | Annual developer visits (target) | ≥100,000 |
 | Training capacity | ≥5,000 persons/yr |
 
-### 5.3 Dazhongsi AI Industry Cluster
+### 4.3 Dazhongsi AI Industry Cluster — hero sequence: Station–Hall–Street–Green
 
 **Positioning.** The highland where AI technology reaches industrial application — focused on AI+healthcare, AI+education and AI+commerce, constructing the complete chain of industrial application, scenario verification and commercial conversion, so that AI genuinely serves urban development and livelihood improvement rather than remaining in demonstration rooms. It is also the corridor's commercial gateway.
 
@@ -366,66 +349,6 @@ All synergy items are conceptual suggestions for the respective authorities to c
 
 ## Land Use, Building Scale, and Retain-Renovate-Demolish Strategy
 
-### 5.1 Ecological Chain Design
-
-The innovation ecology is a four-layer chain, each layer feeding the next:
-
-**Layer one — fundamental research:** universities and institutes → national laboratories → large-scale research installations; outputs are original theory, core technology and algorithmic breakthroughs, moving down through technology-transfer platforms. **Layer two — applied R&D:** start-ups → growth companies → unicorns; outputs are applied technology, product prototypes and solutions, moving down through incubators and accelerators. **Layer three — industrial application:** industry clusters → industry testing → scenario validation; outputs are deployed applications, commercial products and market value, moving down through investment-and-financing services. **Layer four — capital markets:** venture capital → industry funds → listing channels; outputs are capital support, market recognition and sustained development feeding back into layer one.
-
-**Four support elements run through all layers:** open-source community support (code, data and models lowering the entry threshold); talent supply (universities, enterprise training, international recruitment); infrastructure (compute, data and testing platforms); and policy instruments (talent, industry and innovation policy optimising the institutional environment).
-
-The complete innovation ecosystem runs through four layers, each feeding the next:
-
-```
-Layer 1: Basic research — universities, national laboratories, large-scale
-         compute installations → theories, core technologies, algorithmic
-         breakthroughs; handed down through technology-transfer platforms.
-Layer 2: Applied R&D — start-ups, growth firms, unicorns → application
-         technologies, prototypes, solutions; handed down through
-         incubators and accelerators.
-Layer 3: Industrial application — clusters, industrial testing, scenario
-         verification → products, commercial value; financed by
-Layer 4: Capital markets — venture capital, industrial funds, IPO
-         financing → sustained development.
-```
-
-**Key support elements:** (1) open-source community — code, data and models lowering the innovation threshold; (2) talent supply — university programmes, enterprise practice, international recruitment; (3) infrastructure — compute, data and test platforms; (4) policy instruments — talent, industry and innovation policies.
-
-### 5.2 User Personas and Scenario Cards
-
-**Persona 1 — AI researcher, Li Ming (35).** Associate professor at a university AI school; research in large models and multimodal learning. Needs: high-performance compute, large datasets, collaboration spaces. Trajectory: laboratory → conferences → industry engagement. Cares about research transfer, academic impact, student mentoring.
-
-**Persona 2 — Open-source developer, Zhang Xue (28).** Independent developer and active community contributor; Python/PyTorch/distributed systems. Needs: community belonging, peer exchange, honor recognition. Trajectory: remote work → developer conferences → hackathons. Cares about contribution records, community standing, career growth.
-
-**Persona 3 — Start-up founder, Wang Qiang (32).** Founder of an AI-medical company; product: AI-assisted diagnosis. Needs: office space, investor access, clinical validation, policy support. Trajectory: office → roadshows → hospital partnerships → team building. Cares about growth, market share, funding progress.
-
-**Persona 4 — Venture capitalist, Zhao Lin (40).** VC partner focused on AI: large-model applications, AI infrastructure, AI healthcare. Needs: quality deal flow, industry research, post-investment services. Trajectory: due diligence → investment decisions → portfolio management. Cares about returns, trends, deal quality.
-
-**Persona 5 — AI user-professional, Dr Chen (45).** Chief physician applying AI diagnosis and imaging analysis. Needs: reliable products, clinical evidence, training. Trajectory: clinic → surgery → training → feedback. Cares about diagnostic efficiency, patient satisfaction, safety.
-
-The five industry personas above are the compressed narrative of the nine-type persona table in the Chinese edition (researcher, open-source developer, founder, investor, physician, teacher, student, elder and service worker) — the four added types carry the inclusion agenda: the elder and the service worker test whether the corridor works for people who never write code, and the teacher and student carry the AI-literacy programme. Each persona's daily trajectory is traceable to specific anchors: the researcher's lab-to-conference path runs through the Zhongzhiyuan seminar commons; the developer's remote-work-to-hackathon path ends at the Exchange Centre; the physician's clinic loop closes at the clinical-validation platform; the service worker's day is anchored by the 800 m service stations.
-
-**Scenario details (ten flagship scenes):**
-
-1. **AI Diagnosis Centre** (Dazhongsi healthcare park, 2 ha): three functions — AI-assisted diagnosis (imaging recognition, pathology analysis, record interpretation), telemedicine linking grassroots hospitals to expert-level care, and personalised treatment grounded in de-identified histories and genomic data. Users: physicians, patients, medical-AI developers. Validation: clinical trials with tertiary hospitals, diagnostic accuracy target ≥95% (SC-01).
-2. **Adaptive Learning Lab** (education base, 1.5 ha): personalised learning paths adjusted to each student's demonstrated ability; a 24/7 intelligent tutoring system with instant feedback; learning-outcome prediction enabling early intervention. Users: students, teachers, education-AI developers. Validation: five-school pilot with tracked outcomes, learning-efficiency gain ≥30%, no individual profiling (SC-02).
-3. **Smart Retail Street** (500 m, commerce zone): scan-based checkout, shelf recommendations — no biometric recognition by default, staffed counters always retained (SC-03); personalised marketing on anonymous aggregates only.
-4. **Autonomous Driving Test Road** (5 km, Dazhongsi test platform): full-scenario testing across urban roads, expressway links, night and adverse weather; V2X infrastructure (roadside units, on-board units), adaptive signal control with priority passage, and high-precision mapping at ≤10 cm refresh accuracy; a safety-supervision regime of 24-hour monitoring, emergency response and black-box liability tracing. Users: AV enterprises, transport authorities, passengers. Validation: cumulative ≥1,000,000 test-km with zero major safety incidents (SC-08).
-5. **Open-source Code Review Station** (0.5 ha, Origin community): AI-assisted code quality and vulnerability detection; contribution-value assessment; code provenance tracing. Accuracy target ≥90%, efficiency gain ≥50%.
-6. **AI Art Creation Studio** (0.8 ha, heritage park): generative painting, music and literature; human-machine co-creation; immersive digital exhibition.
-7. **Smart Eldercare Community** (within residential bands): opt-in wearable health monitoring, emergency response covering fall detection, cardiac-event warning and automatic alerting, and companion robots offering emotional support and health management. Users: elders, chronic-disease patients, families. Validation: pilot-community satisfaction ≥90%, emergency response ≤5 minutes — all under SC-04 boundaries: no health profiling, unconditional opt-out.
-8. **Robot Service Streets** (district-wide): delivery, cleaning and guidance robots on designated lanes (SC-07), with remote human operators and takeover protocols.
-9. **Data Labelling Factory** (1 ha, Dazhongsi): image/speech/text labelling services with AI-assisted quality control and human verification; labelling accuracy target ≥98%.
-10. **AI Ethics Review Centre** (0.3 ha): ethics review of AI applications (privacy, bias, safety); standards development; public education. Beyond these ten flagship scenes, the full set runs to twelve structured cards (SC-01 to SC-12, machine-readable in scenario_cards.json) adding the transit hub (SC-09) and the city digital twin (SC-12); each card binds the same eight fields — anchor layer and feature, personas served, data sources, model boundary, human review, failure degradation, KPI and exit condition — so that every scene is an auditable commitment rather than an illustration.
-
-### 5.3 Industry Test and Verification Platforms (detail)
-
-**Platform 1 — Medical AI clinical validation** (Dazhongsi): five-hospital consortium; pipeline of application → ethics committee review → 100-500-case trial → 1,000-5,000-case expansion → published validation report; standards: diagnostic accuracy ≥95%, response ≤5 s, physician acceptance ≥85%; ≥10 products validated annually.
-
-**Platform 2 — Autonomous-driving open test roads**: 3 km urban + 2 km expressway link; normal / complex / extreme scenario suites; roadside units and on-board units; adaptive signal priority; high-precision maps refreshed to ≤10 cm; a 24-hour monitoring centre, remote-takeover contingency and black-box liability tracing; cumulative target ≥1 M test-km with zero major incidents.
-
-**Platform 3 — Smart-campus pilot zone** (five schools around the Origin community): AI-assisted teaching, personalised assignments and intelligent assessment; campus safety with card-based (non-biometric) access, AI-assisted anomaly alerts and emergency alarms — explicitly no facial recognition or behavioural profiling of students (see privacy_review_matrix.json); health management with nutrition analysis and counselling. Targets: learning efficiency +30%, teacher workload −20%, parent satisfaction ≥90%.
-
 ### Land Use Layout
 
 The layout optimises the 11.41 km² overall design area [metric:site_area_sqm] under the MNR 2023 classification (the 43.6 km² research area stays at strategy level with no land balance). Recomputed from [data:geometry/land_use.geojson]: research (0802) totals 315.0 ha / 27.6%; commercial (05) 209.4 ha / 18.4%; park green (1401) 153.7 ha / 13.5%; residential (0701) 135.5 ha / 11.9%; culture (0803) 62.3 ha / 5.5%; education (0804) 63.2 ha / 5.5%; sports (0805) 38.0 ha / 3.3%; roads (1207) 112.1 ha / 9.8%; strategic reserve (16) 51.8 ha / 4.5% — summing to exactly 100%.
@@ -440,17 +363,10 @@ Corridor-wide recomputed average FAR 1.13 [metric:average_far], building density
 
 Retain historic buildings and cultural relics (the Qinghuayuan Station ruins and peers); renovate ageing industrial workshops into AI innovation space; demolish illegal construction and inefficient buildings. Corridor-average split aligned with the renewal strategy: retain ~55% (historic and quality stock), renovate ~30% (ageing low-efficiency space), demolish ~15% (unsafe and illegal stock), per [depth:retain_renovate_demolish].
 
-### Ecological Chain Design (context)
-
-The eleven-band plan (3.2) is a complete partition, not scattered zoning: bands tile the site with zero gap and total 100.0%. Research bands (0802) total 315.0 ha / 27.6%; commercial bands (05) total 209.4 ha / 18.4%; road band (1207) 112.1 ha / 9.8% — each recomputable via verify.js.
-
-Building scale: 593 generated building masses, footprint 99.1 ha (density 8.7% [metric:building_density]), GFA 12.89 M m², average FAR 1.13 [metric:average_far]. Heights follow the three-tier imagery with the heritage-corridor transition band; all massing is conceptual and awaits formal controls.
-
-Retain-renovate-demolish: 55/30/15 as a corridor-average scenario band, declared per-project in the renewal list, gated by heritage constraints and existing-community continuity. The retained 55% concentrates in the heritage fabric and recent quality stock; the renovated 30% targets ageing low-efficiency space whose structure can carry new AI uses (workshops into labs, dormitories into studios); the demolished 15% is confined to structurally unsafe or plan-incompatible buildings, replaced at no net loss of affordable community services. Every demolition-adjacent household gets the pre-assessment and resettlement options described in the Inclusive Design chapter.
-
-**Land-use discipline:** the eleven bands are a partition, not a collage — they tile the 11.41 km² site with zero gap, total exactly 100.0%, and every band's area is recomputable from land_use.geojson via verify.js. No band exceeds 30% of the site, implementing the one-north lesson against single-function superblocks; research (27.6%) and commerce (18.4%) together carry the innovation-belt program while residential (11.9%) and green (13.5%) keep the district livable at night, avoiding the Nanshan jobs-housing trap.
 
 ## 6. Transportation and Infrastructure
+
+## Transport, Rail, Municipal Infrastructure, and Public Services
 
 ### 6.1 Integrated Transport
 
@@ -483,7 +399,6 @@ Retain-renovate-demolish: 55/30/15 as a corridor-average scenario band, declared
 **Community services:** one-stop convenience centres in every community handling government, life and consultation services; eldercare stations in every residential quarter for day care and health management; childcare centres resolving the dual-earner family's hardest constraint — all configured to the 15-minute life circle and retaining full non-digital channels per the inclusion indicators.
 
 
-
 Five-tier road hierarchy: expressways (Jingzang, North 4th Ring), arterials (Zhongguancun Street, Xueyuan Road), secondaries, branches and slow-traffic paths. Rail: Line 13, Changping Line and the planned corridor express, with eight station-access nodes. Eight schematic road features ship in [data:geometry/roads.geojson].
 
 Municipal: smart utility networks, utility tunnels, 5G/6G base stations, distributed energy — all as conceptual provisioning; capacity figures await official utility baselines.
@@ -491,12 +406,6 @@ Municipal: smart utility networks, utility tunnels, 5G/6G base stations, distrib
 Rail detail: Line 13 serves Wudaokou, Zhichunlu and Xizhimen; the Changping Line interchanges at Xi'erqi; Line 4 serves Haidian Huangzhuang and Zhongguancun. Eight station-access nodes turn these interchanges into corridor gateways — each node bundles bike docks, shuttle stops, wayfinding and robot kerb zones so that the last 500 m between rail and workplace is designed space, not leftover space.
 
 Public services to the 15-minute life-circle standard: education (500 m radius), medical (1,000 m), culture and sports facilities, community services with eldercare stations and childcare centres.
-
-## Transport, Rail, Municipal Infrastructure, and Public Services
-
-![Transport and blue-green systems](assets/figures/mobility-bluegreen.en.png)
-
-This chapter consolidates the corridor's mobility and utility frame. The five-tier road hierarchy (expressways — Jingzang and the North Fourth Ring; arterials — Zhongguancun Street, Xueyuan Road; secondaries; branches; slow-traffic paths) is carried in [data:geometry/roads.geojson] as eight schematic features. Rail transit rests on Line 13, the Changping Line and a planned corridor express, with eight station-access nodes converting interchanges into designed gateways. Municipal infrastructure — smart water and drainage networks, utility tunnels, 5G/6G base stations, distributed energy — is provisioned conceptually, with all capacity figures awaiting official utility baselines. Public services follow the 15-minute life-circle standard at full coverage: education at 500 m, medical at 1,000 m, culture and sports facilities, and community services with eldercare stations and childcare centres in every residential quarter.
 
 ## Inclusive Design and Social Impact
 
@@ -667,17 +576,19 @@ All four are standard-library-only, offline and deterministic. Current results: 
 
 **Industry:** research land (0802, two bands) 315.0 ha / 27.6%; commercial land (05, two bands) 209.4 ha / 18.4%; combined 46.0% carrying the innovation-belt program. Scenario targets: ≥500 AI enterprises by Phase 2; high-tech share ≥60%; Phase-2 output scenario 500+ billion yuan (assumptions.json).
 
-**Population (scenario, not forecast):** employment capacity 15-20万 on the recomputed GFA with density assumptions; residential capacity 8-10万; daily activity 25-30万 including visitors.
+**Population (scenario, not forecast):** employment capacity 15-20 (10k persons) on the recomputed GFA with density assumptions; residential capacity 8-10 (10k persons); daily activity 25-30 (10k persons) including visitors.
 
 **Metric discipline in one paragraph:** geometric metrics are recomputed from shipped GeoJSON under EPSG:4548 and are reproducible by verify.js; scenario metrics (enterprises, output, population) live in assumptions.json and are never mixed into the geometric set; aspirational service metrics (coverage rates) are labelled targets with phase gates. The three types are visually and syntactically distinct throughout — a reviewer can tell within one line which class of number a sentence carries.
 
 **Facilities:** education 500 m / medical 1,000 m / park green 500 m coverage all targeted at 100%; rail-station 800 m coverage ≥80% in core areas.
 
+**First-year baseline plan (B01-B05):** facility coverage figures are static accessibility computations; operational performance is judged against five measured baselines — B01 axis walking-break inventory, B02 accessibility continuity (AI / paper map / human escort, three paths compared), B03 non-commercial availability of public space, B04 complaint and takeover logs, B05 AI-closed-day drills per scenario each half-year. Baseline values stay pending-first-measurement: each first publication carries its definition, sampling boundary, missing-data handling and responsible role, and a formal boundary change recomputes only the spatial metrics, never the measurement rules.
+
 **Coverage targets behind the table:** education facilities at a 500 m radius and medical facilities at a 1,000 m radius both target 100% coverage; park green within 500 m targets full coverage; rail stations cover ≥80% of the core areas at an 800 m radius. All are aspirational service targets with phase gates, distinct in kind from the recomputed geometric set.
 
 ### 9.2 Compliance Matrix (detail)
 
-Spatial: site 11.41 km²; GFA 12.89 M m²; average FAR 1.13; density 8.7%; green 506.9 ha / 44.4% (full-layer basis); roads 112.1 ha / 9.8%. Industry: research 315.0 ha (27.6%), commercial 209.4 ha (18.4%). Population (scenario): employment 15-20k-capacity basis in assumptions.json; residential 8-10万 scenario; facilities coverage per the 2.3 table. Full table with sources: metrics.json; every figure recomputable via verify.js.
+Spatial: site 11.41 km²; GFA 12.89 M m²; average FAR 1.13; density 8.7%; green 506.9 ha / 44.4% (full-layer basis); roads 112.1 ha / 9.8%. Industry: research 315.0 ha (27.6%), commercial 209.4 ha (18.4%). Population (scenario): employment 15-20 (10k persons) scenario basis in assumptions.json; residential 8-10 (10k persons) scenario; facilities coverage per the 2.3 table. Full table with sources: metrics.json; every figure recomputable via verify.js.
 
 ### Compliance Matrix (summary)
 
@@ -763,26 +674,18 @@ May those who walk the Heritage Park a century from now, reading the names on th
 
 ---
 
-**END OF DOCUMENT**
-
-![Site overview](assets/figures/site-overview.en.png)
-
-![Key areas](assets/figures/key-areas.en.png)
-
-![Metrics evidence](assets/figures/metrics-evidence.en.png)
-
 ## References
 
-1. Overall-design-area provisional boundary (organiser, provisional use only) [source:S001] [data:geometry/site_boundary.geojson]
-2. Key-area provisional boundaries (organiser, provisional use only) [source:S002] [data:geometry/key_areas.geojson]
-3. Call announcement (scope figures) [source:S003]
+1. Overall design area provisional boundary (organiser) [source:S001] [data:geometry/site_boundary.geojson]
+2. Three key-area provisional boundaries (organiser) [source:S002] [data:geometry/key_areas.geojson]
+3. Open-call announcement (scope and key-area figures) [source:S003]
 4. Beijing Master Plan 2016-2035 [source:S004] [standard:STD-BEIJING-MP]
 5. Haidian 14th Five-Year Plan [source:S005]
-6. Zhongguancun innovation carriers (public common knowledge) [source:S006]
-7. GB 50180-2018 Residential planning standard [source:S007] [standard:STD-GB50180]
-8. GB 50220-95 Urban road transport planning [source:S008] [standard:STD-GB50220]
-9. GB 50420-2007 Urban green space design [source:S009] [standard:STD-GB50420]
-10. Global AI-innovation-district case comparison (8 cases, linked) [source:S010]
+6. Zhongguancun national innovation-zone carriers (public facts) [source:S006]
+7. GB 50180-2018 residential planning standard [source:S007] [standard:STD-GB50180]
+8. GB 50220-95 urban road traffic planning [source:S008] [standard:STD-GB50220]
+9. GB 50420-2007 urban green space design [source:S009] [standard:STD-GB50420]
+10. Global AI innovation-district case comparison (8 cases, linked) [source:S010]
 11. Noto Sans SC font licence (SIL OFL 1.1) [source:S011]
 
-Reference discipline: items 1-2 are provisional geometries for generation, visualisation and self-checks only; items 4-5 are public policy documents cited for context; items 7-9 are engaged as design references, not claims of statutory compliance; item 10 is a case-comparison table with per-case links. Where the call shipped no verifiable dataset, this proposal asserts no figures — the discipline is stated once here and kept everywhere in the text.
+Each numbered source is registered in sources.json with its licence, access date and usage scope; standards carry their standard-matrix anchors; geometry files are provisional-organiser data awaiting formal release. Scenario-card, operations and metrics evidence files live under visual/assets/ and are verified by the four shipped scripts.

--- a/submissions/zihanCui1215/beijing-zhangjiakou-ai-corridor-2026/proposal.md
+++ b/submissions/zihanCui1215/beijing-zhangjiakou-ai-corridor-2026/proposal.md
@@ -7,7 +7,7 @@ proposal_format_version: "2"
 translation_file: "proposal.en.md"
 summary: "以京张铁路遗址公园为空间载体，把三核两翼组织成可验证、可接管、可退出的城市AI试验带；每个场景同时交付空间载体、普通服务路径、测量方法和公开回执。"
 tracks: ["jingzhang-heritage-narrative", "ai-origin-community", "civic-agent-governance"]
-iteration: "v7"
+iteration: "v8"
 ---
 
 # 百年京张AI创新带城市设计方案
@@ -21,6 +21,16 @@ iteration: "v7"
 百年京张AI创新带是以京张铁路遗址公园为空间载体，融合百年铁路文化、中关村创新基因与AI技术革命的未来城市创新带。本方案统筹研究范围覆盖43.6平方公里（公告口径），总体设计范围（几何复算）为11.41平方公里 [metric:site_area_sqm]，从北五环到北京北站，构建三条带叠加的空间格局：百年京张文化带、都市AI生活体验带、AI融合创新带。
 
 **一页判读：这条带子在地上变成什么。** 方案可按四层理解：**空间层**是一轴三核两翼——7.5 km 遗产主轴承担连续公共空间，众智园/原点/大钟寺三核分别承担全栈验证、近校转化与城市首层应用，两翼接入高校、企业与社区；**服务层**规定每个 AI 场景都保留普通服务路径——推荐关闭后，柜台、导视、绿地与无障碍通行继续成立；**验证层**为 12 张场景卡逐项登记测量对象、对照方式、人工接管与停止条件（scenario_cards.json + check_cards.js）；**运营层**把公开问题经"沙盒—证据—复核—扩点/退出"回到年度公共价值审计（operations.json + check_ops.js）。任何 AI 场景进入公共空间前都要回答六件事：落在哪里、普通服务如何保留、测什么、谁复核、何时接管、怎样退出。
+
+![总体范围、关键片区与证据状态](assets/figures/site-overview.png)
+
+三核各有一句空间承诺，同一套“动词—空间—证据—回退”交付语法，让品牌识别与实施判断共用最短表达：
+
+| 片区 | 核心动词 | 最小可见交付 | 扩展前必须拿出的证据 | AI失效后的城市状态 |
+| --- | --- | --- | --- | --- |
+| 众智园 | **验** | 河岸—测试庭院—标准展廊连续序列 | 红队结果、人工接管记录、同任务能耗 | 普通花园街区与连续步行线 |
+| AI原点 | **转** | 校园接口—转化街—开放大厅连续序列 | 服务前后对照、权利审核、使用者复测 | 普通公共大厅、人工顾问与共享工坊 |
+| 大钟寺 | **用** | 站口—会客厅—体验街—公共绿地连续序列 | 高峰/平峰步行审计、停机演练、投诉记录 | 普通商业服务、人工柜台与公共绿地 |
 
 The Beijing-Zhangjiakou AI Innovation Corridor is a future-oriented urban innovation belt that integrates century-old railway culture, Zhongguancun's innovation DNA, and AI technology revolution, using the Beijing-Zhangjiakou Railway Heritage Park as its spatial carrier. This proposal covers 43.6 km², from North Fifth Ring Road to Beijing North Railway Station, building a three-layered spatial pattern: the Century-Old Beijing-Zhangjiakou Cultural Belt, the Urban AI Life Experience Belt, and the AI Integration Innovation Belt.
 
@@ -123,8 +133,8 @@ The Beijing-Zhangjiakou AI Innovation Corridor is a future-oriented urban innova
 | | 建筑密度（平均，复算） | 8.7 | % |
 | 产业指标 | 科研用地（0802）占比（两带合计，几何复算） | 27.6 | % |
 | | 商业服务业用地（05）占比（两带合计，几何复算） | 18.4 | % |
-| 人口指标 | 就业人口容量（按复算GFA测算） | 10-12 | 万人 |
-| | 居住人口容量（按复算GFA测算） | 5-6 | 万人 |
+| 人口指标 | 就业人口容量（情景测算，见 assumptions.json） | 15-20 | 万人 |
+| | 居住人口容量（情景测算，见 assumptions.json） | 8-10 | 万人 |
 | 设施指标 | 教育设施覆盖半径 | 500 | m |
 | | 医疗设施覆盖半径 | 1000 | m |
 | | 公园绿地500m覆盖 | 100 | % |
@@ -133,7 +143,13 @@ The Beijing-Zhangjiakou AI Innovation Corridor is a future-oriented urban innova
 
 ## 三层范围工作框架 / Three-Level Scope Framework
 
-### 统筹研究范围产业与未来城市研究 / Coordinated Research Area: Industry and Future City Research
+三层范围采用“战略—结构—项目—反馈”链路组织，而不是图面比例的简单缩放。统筹研究范围（43.6 km²，公告口径）回答战略问题：海淀的AI能力如何形成跨区域创新网络，研究结论以组织结构与产业生态链呈现 [source:S003]。总体设计范围（11.41 km²，EPSG:4548 几何复算）回答结构问题：三核、两翼、一轴如何在用地条带上落位，边界与复算方法见 [data:geometry/site_boundary.geojson]，总面积与平均容积率取自 [metric:site_area_sqm] 与 [metric:average_far]。三处重点区（合计3.68 km²）回答项目问题：每平方公里级的空间如何被验证（验）、转化（转）、应用（用），分区面积复算见 [data:geometry/key_areas.geojson]。三层之间以指标联动衔接：下层运营数据只用于校正上层假设与试点清单，不直接生成法定规划结论；范围边界当前为临时口径，正式边界以规划主管部门批复文件为准，届时仅重算几何指标，不改动测量规则 [source:S001]。
+
+
+
+## 统筹研究范围产业与未来城市研究 / Coordinated Research Area: Industry and Future City Research
+
+在43.6平方公里的统筹研究层面，核心问题不是再建几个园区，而是让海淀的AI能力形成跨区域创新网络。本章以组织问题为主线：六环创新链（研究—开源—孵化—验证—规模化—城市反馈）把三类主体接入同一条价值链，两翼共享算力入口、法务知识产权、投融资、会展、教育和生活服务，避免重复建设。
 
 ### 全球案例→设计转译（agent.2，8例可核验）[source:S010]
 
@@ -152,7 +168,7 @@ The Beijing-Zhangjiakou AI Innovation Corridor is a future-oriented urban innova
 
 *转译方法：每例先问"它失败/成功在哪个空间机制"，再把该机制映射到本方案的用地条带、运营结构或场景卡。拒绝"借鉴国际经验"式的泛化引用。*
 
-### 总体设计范围城市更新与控规深度城市设计 / Overall Design Area: Urban Renewal and Regulatory-Plan-Level Urban Design
+## 总体设计范围城市更新与控规深度城市设计 / Overall Design Area: Urban Renewal and Regulatory-Plan-Level Urban Design
 
 ### 3.1 空间结构 / Spatial Structure
 
@@ -234,41 +250,9 @@ The Beijing-Zhangjiakou AI Innovation Corridor is a future-oriented urban innova
 
 > 证据索引：[source:S003] [standard:MOHURD-CONTROL-DETAILED-PLANNING] [data:geometry/key_areas.geojson]
 
-## 统筹研究范围产业与未来城市研究 / Coordinated Research Area: Industry and Future City Research
-
-### 产业现状与发展趋势 [source:S003] [source:S006] [source:S010]
-
-统筹研究范围覆盖43.6平方公里（公告口径 [source:S003]），横跨海淀区核心创新走廊。区域内现有中关村科技园区、清华科技园、北京大学科技园等国家级创新载体（名单见来源清单 S006）。企业数量与产值等产业统计口径需以官方年度统计公报为准，本方案不作未经核验的具体数值断言，仅在情景假设层面讨论产业集聚趋势（见 assumptions.json A002）。基于 [data:geometry/land_use.geojson] 的用地分析，现状产业用地占比约28%，主要集中在区域中段和中关村片区。
-
-### 未来城市发展策略 [standard:STD-BEIJING-MP] [standard:MOHURD-URBAN-DESIGN-MEASURES]
-
-以北京城市总体规划为纲 [standard:STD-BEIJING-MP]，落实科技创新中心核心定位。未来城市发展聚焦三大方向：一是AI技术创新策源，依托中关村创新基因建设AI算法、算力、数据三要素集聚区；二是AI+产业融合示范，推动AI与传统制造业、服务业、文化创意产业深度融合；三是智慧城市先行实验，构建数据驱动、智能感知的城市治理新范式 [standard:MOHURD-URBAN-DESIGN-MEASURES]。
-
-### 产业空间布局优化 [data:geometry/key_areas.geojson] [data:geometry/phasing.geojson]
-
-基于 [data:geometry/key_areas.geojson] 的三核空间分析，产业布局形成"三核引领、两翼拓展"的空间格局。三核即众智园AI自主创新加速区（几何复算约1.93 km² [metric:key_area_zhongzhiyuan_sqm]）、北京AI原点社区（约1.04 km² [metric:key_area_ai_origin_sqm]）、大钟寺AI产业聚集区（约0.72 km² [metric:key_area_dazhongsi_sqm]）——三处范围均为依据公告面积约数形成的临时粗略范围（provisional），待组织方发布正式边界后重算。两翼为中关村科技服务翼（向北对接清华园创新节点）与小月河场景赋能翼（向南延伸至西直门枢纽商圈）。分期实施策略详见 [data:geometry/phasing.geojson]，一期约3.42 km² [metric:phase_1_area_sqm] 重点建设AI创新载体，二期约4.57 km² [metric:phase_2_area_sqm] 完善配套体系，三期约3.42 km² [metric:phase_3_area_sqm] 提升城市品质。
-
-## 总体设计范围城市更新与控规深度城市设计 / Overall Design Area: Urban Renewal and Regulatory-Plan-Level Urban Design
-
-### 控规深度指标体系 [standard:MOHURD-CONTROL-DETAILED-PLANNING] [metric:average_far] [metric:building_density]
-
-总体设计范围参照控规深度城市设计方法组织指标体系 [standard:MOHURD-CONTROL-DETAILED-PLANNING]（本方案为概念性城市设计建议，非法定控规成果）。核心指标均按 EPSG:4548 投影对几何数据复算：平均容积率 1.13（详见 [metric:average_far]），建筑密度 8.7%（[metric:building_density]），绿地率 44.4%（[metric:green_ratio]，去重叠union口径（与官方校验器一致）），公共空间配建率 8.2%（[metric:public_space_ratio]）。用地分类参照2023自然资源部标准 [standard:MNR-LAND-USE-CLASSIFICATION-GUIDE]，在 [data:geometry/land_use.geojson] 中以标准化代码标注每一地块用途。
-
-### 城市更新策略 [depth:existing_conditions_diagnosis] [depth:retain_renovate_demolish]
-
-基于 [data:geometry/buildings.geojson] 的建筑质量摸底分析 [depth:existing_conditions_diagnosis]，制定"留、改、拆"三类更新策略：保留历史文化建筑及近年新建品质建筑，改造老旧低效空间为AI创新载体，拆除危房及严重不符合规划的建筑。拆改留比例约为保留55%、改造30%、拆除15% [depth:retain_renovate_demolish]。更新项目清单详见后续章节。
-
-### 空间结构与天际线管控 [standard:MOHURD-URBAN-DESIGN-MEASURES] [depth:height_massing_character]
-
-遵循城市设计管理办法 [standard:MOHURD-URBAN-DESIGN-MEASURES]，构建"三核两翼"空间结构（三核：众智园AI自主创新加速区、北京AI原点社区、大钟寺AI产业聚集区；两翼：中关村科技服务翼、小月河场景赋能翼）。天际线形成三级意象分区（概念性建议，非法定管控）：众智园区约45-95米、大钟寺区约35-80米、AI原点社区约18-45米，铁路遗产廊道两侧建议约100米宽低层过渡带（≤24米）[depth:height_massing_character]。建筑风貌延续京张铁路工业文化特色，在重点区域鼓励采用智能建造技术和AI生成设计方案。
-
-### 用地细分与强度控制 [depth:land_use_layout] [depth:development_intensity_controls]
-
-用地按2023自然资源部标准代码划分 [depth:land_use_layout]，共11类条带分区（见 [data:geometry/land_use.geojson]）。开发强度分区控制 [depth:development_intensity_controls]：大钟寺产业带复算容积率约2.30，众智园约1.89，AI原点社区约0.63，全域平均1.13。公共空间配建率8.2%（[metric:public_space_ratio]），道路用地（1207）占比约9.8%。
-
 ## 重点区域详细设计 / Detailed Design of Key Areas
 
-### 4.1 众智园AI自主创新加速区 / Zhongzhiyuan AI Self-Innovation Acceleration Area
+### 4.1 众智园AI自主创新加速区——英雄序列：河—庭—廊 / Zhongzhiyuan: River–Courtyard–Gallery
 
 **定位陈述 / Positioning Statement**：
 众智园AI自主创新加速区（原正文称"中关村AI加速核心区"，现按任务书与官方边界文件统一命名为"众智园AI自主创新加速区"）是AI硬科技创新的策源地，依托清华、北大等顶尖高校和国家实验室，聚焦大模型、芯片、算法等硬核技术突破，打造从基础研究到产业转化的完整创新链。
@@ -313,7 +297,7 @@ The Beijing-Zhangjiakou AI Innovation Corridor is a future-oriented urban innova
 | 就业人口容量（情景测算） | 3-4 万人 |
 | 高新技术企业占比 | ≥70% |
 
-### 4.2 北京AI原点社区 / Beijing AI Origin Community
+### 4.2 北京AI原点社区——英雄序列：校—街—厅 / Origin: Campus–Street–Hall
 
 **定位陈述 / Positioning Statement**：
 北京AI原点社区是全球开源开发者的精神家园，以开放、共享、协作为核心理念，构建开发者生态、开源社区和人才培养体系，让每一个代码贡献者都能在这里找到归属感和荣誉感。
@@ -363,7 +347,7 @@ The Beijing-Zhangjiakou AI Innovation Corridor is a future-oriented urban innova
 | 培训人才容量 | ≥5000 人/年 |
 | 开源贡献记录 | ≥1000 项/年 |
 
-### 4.3 大钟寺AI产业聚集区 / Dazhongsi AI Industry Cluster
+### 4.3 大钟寺AI产业聚集区——英雄序列：站—厅—街—绿 / Dazhongsi: Station–Hall–Street–Green
 
 **定位陈述 / Positioning Statement**：
 大钟寺AI产业聚集区是AI技术走向产业应用的高地，聚焦AI+医疗、AI+教育、AI+商业等重点领域，构建产业应用、场景验证和商业转化的完整链条，让AI技术真正服务于城市发展和民生改善。
@@ -525,271 +509,9 @@ The Beijing-Zhangjiakou AI Innovation Corridor is a future-oriented urban innova
 保留历史建筑及文化遗存（清华园车站遗址等），改造更新老旧工业厂房为AI创新空间，拆除违法建设及低效利用建筑。总体拆改留比例与总体设计范围更新策略一致：保留约55%（历史建筑及品质建筑）、改造约30%（老旧低效空间）、拆除约15%（危房及违法建设），详见 [depth:retain_renovate_demolish]。
 
 
-
-### 5.1 生态链路设计 / Ecological Chain Design
-
-构建从基础研究到产业孵化到资本服务的完整创新生态链：
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│ 第一层：基础研究层                                            │
-│ 高校院所 → 国家实验室 → 大科学装置                            │
-│ 产出：原创理论、核心技术、算法突破                             │
-└─────────────────────────────────────────────────────────────┘
-                         ↓ 技术转化平台
-┌─────────────────────────────────────────────────────────────┐
-│ 第二层：应用研发层                                            │
-│ 初创企业 → 成长企业 → 独角兽企业                              │
-│ 产出：应用技术、产品原型、解决方案                             │
-└─────────────────────────────────────────────────────────────┘
-                         ↓ 孵化加速器
-┌─────────────────────────────────────────────────────────────┐
-│ 第三层：产业应用层                                            │
-│ 产业集群 → 产业测试 → 场景验证                                │
-│ 产出：产业应用、商业产品、市场价值                             │
-└─────────────────────────────────────────────────────────────┘
-                         ↓ 投融资服务
-┌─────────────────────────────────────────────────────────────┐
-│ 第四层：资本市场层                                            │
-│ 风险投资 → 产业基金 → 上市融资                                │
-│ 产出：资本支持、市场认可、持续发展                             │
-└─────────────────────────────────────────────────────────────┘
-```
-
-**关键支撑要素 / Key Support Elements**：
-
-1. **开源社区支撑**：开源代码、开源数据、开源模型，降低创新门槛
-2. **人才供给支撑**：高校培养、企业实训、国际引进，保障人才供给
-3. **基础设施支撑**：算力平台、数据平台、测试平台，提供硬件支撑
-4. **政策制度支撑**：人才政策、产业政策、创新政策，优化制度环境
-
-### 5.2 用户画像与场景卡片 / User Personas and Scenario Cards
-
-#### 用户画像 / User Personas
-
-**画像1：AI研究员 - 李明**
-
-- 年龄：35岁
-- 身份：清华大学AI学院副教授
-- 研究方向：大模型、多模态学习
-- 需求：高性能算力、大规模数据、合作交流空间
-- 活动轨迹：实验室 → 学术会议 → 产业对接
-- 关注点：研究成果转化、学术影响力、学生培养
-
-**画像2：开源开发者 - 张雪**
-
-- 年龄：28岁
-- 身份：独立开发者，开源社区活跃贡献者
-- 技术栈：Python、PyTorch、分布式系统
-- 需求：开源社区归属感、技术交流平台、荣誉认可
-- 活动轨迹：远程办公 → 开发者大会 → 代码马拉松
-- 关注点：开源贡献记录、社区影响力、职业发展
-
-**画像3：创业企业家 - 王强**
-
-- 年龄：32岁
-- 身份：AI医疗创业公司创始人
-- 产品：AI辅助诊断系统
-- 需求：办公空间、投资对接、临床验证、政策支持
-- 活动轨迹：办公室 → 融资路演 → 医院合作 → 团队建设
-- 关注点：公司成长、市场份额、融资进度
-
-**画像4：风险投资人 - 赵琳**
-
-- 年龄：40岁
-- 身份：专注AI领域的VC合伙人
-- 关注领域：大模型应用、AI基础设施、AI+医疗
-- 需求：优质项目发现、行业研究支持、投后服务
-- 活动轨迹：项目考察 → 投资决策 → 投后管理 → 行业会议
-- 关注点：投资回报、行业趋势、项目质量
-
-**画像5：AI应用者 - 陈医生**
-
-- 年龄：45岁
-- 身份：三甲医院主任医师，AI医疗应用者
-- 应用场景：AI辅助诊断、智能影像分析
-- 需求：可靠的AI产品、临床验证数据、培训支持
-- 活动轨迹：门诊 → 手术 → 学习培训 → 应用反馈
-- 关注点：诊疗效率、患者满意度、医疗安全
-
-#### 场景卡片 / Scenario Cards
-
-**场景1：AI诊疗中心 / AI Diagnosis Center**
-
-- **类型**：AI+医疗
-- **位置**：大钟寺AI+医疗产业园
-- **面积**：2 ha
-- **功能**：
-  - AI辅助诊断：影像识别、病理分析、病历解读
-  - 远程医疗：连接基层医院，提供专家级诊疗服务
-  - 个性化治疗：基于基因数据和病史的精准治疗方案
-- **用户**：医生、患者、医疗AI开发者
-- **验证机制**：与三甲医院合作，开展临床验证，确保AI诊断准确率≥95%
-
-**场景2：自适应学习实验室 / Adaptive Learning Lab**
-
-- **类型**：AI+教育
-- **位置**：大钟寺AI+教育创新基地
-- **面积**：1.5 ha
-- **功能**：
-  - 个性化学习路径：根据学生能力动态调整学习内容
-  - 智能辅导系统：24/7在线答疑，提供即时反馈
-  - 学习效果预测：预测学习成果，提前干预
-- **用户**：学生、教师、教育AI开发者
-- **验证机制**：5所学校试点，跟踪学习效果，确保学习效率提升≥30%
-
-**场景3：智能零售体验街 / Smart Retail Street**
-
-- **类型**：AI+商业
-- **位置**：大钟寺AI+商业体验区
-- **长度**：500m
-- **功能**：
-  - 无人商店：手机扫码/APP自动结算、智能货架推荐（不使用生物识别，保留人工收银通道）
-  - 智能导购：基于用户画像的个性化导购服务
-  - 精准营销：实时分析消费行为，推送个性化优惠
-- **用户**：消费者、零售商、商业AI开发者
-- **验证机制**：对比传统零售，验证转化率提升、运营成本降低
-
-**场景4：自动驾驶测试道路 / Autonomous Driving Test Road**
-
-- **类型**：AI+交通
-- **位置**：大钟寺产业测试平台
-- **长度**：5 km
-- **功能**：
-  - 全场景测试：城市道路、高速、夜间、恶劣天气
-  - 智能基础设施：车路协同、智能信号灯、高精地图
-  - 安全监管：实时监控、应急预案、责任追溯
-- **用户**：自动驾驶企业、交通管理部门、乘客
-- **验证机制**：累计测试里程≥100万公里，零重大安全事故
-
-**场景5：开源代码审查站 / Open Source Code Review Station**
-
-- **类型**：AI+研发
-- **位置**：北京AI原点社区
-- **面积**：0.5 ha
-- **功能**：
-  - AI辅助代码审查：自动检测代码质量、安全漏洞、性能问题
-  - 贡献评估：量化评估代码贡献的价值和影响力
-  - 代码溯源：追踪代码演进历程，识别原创性
-- **用户**：开源开发者、项目维护者、企业技术团队
-- **验证机制**：审查准确率≥90%，审查效率提升≥50%
-
-**场景6：AI艺术创作工坊 / AI Art Creation Studio**
-
-- **类型**：AI+文化
-- **位置**：京张铁路遗址公园沿线
-- **面积**：0.8 ha
-- **功能**：
-  - AI生成艺术：绘画、音乐、文学创作
-  - 人机协作：艺术家与AI共同创作
-  - 数字展览：AI艺术作品的沉浸式展示
-- **用户**：艺术家、设计师、文化爱好者
-- **验证机制**：举办AI艺术展览，收集观众反馈，探索AI艺术边界
-
-**场景7：智能康养社区 / Smart Health Community**
-
-- **类型**：AI+康养
-- **位置**：居住社区
-- **面积**：与居住用地结合
-- **功能**：
-  - 健康监测：可穿戴设备实时监测健康数据
-  - 紧急响应：跌倒检测、心脏病发作预警、自动呼救
-  - 智能陪伴：AI陪伴机器人，提供情感支持和健康管理
-- **用户**：老年人、慢性病患者、家属
-- **验证机制**：试点社区满意度≥90%，紧急事件响应时间≤5分钟
-
-**场景8：机器人服务街区 / Robot Service Street**
-
-- **类型**：AI+服务
-- **位置**：公共空间
-- **覆盖范围**：全域
-- **功能**：
-  - 配送机器人：快递、外卖、药品配送
-  - 清洁机器人：道路清扫、垃圾分类
-  - 服务机器人：导览、咨询、翻译
-- **用户**：市民、游客、服务提供商
-- **验证机制**：服务覆盖率100%，服务满意度≥85%
-
-**场景9：数据标注工厂 / Data Labeling Factory**
-
-- **类型**：AI+生产
-- **位置**：大钟寺AI产业聚集区
-- **面积**：1 ha
-- **功能**：
-  - 数据标注：图像、语音、文本标注服务
-  - 质量控制：AI辅助标注，人工审核
-  - 人才培养：标注员培训，提升标注质量和效率
-- **用户**：数据标注员、AI企业、数据服务商
-- **验证机制**：标注准确率≥98%，交付周期缩短≥30%
-
-**场景10：AI伦理审查中心 / AI Ethics Review Center**
-
-- **类型**：AI+治理
-- **位置**：公共服务设施
-- **面积**：0.3 ha
-- **功能**：
-  - 伦理审查：审查AI应用的伦理风险（隐私、偏见、安全）
-  - 标准制定：制定AI伦理标准和行业规范
-  - 公众教育：开展AI伦理公众教育活动
-- **用户**：AI企业、政府部门、公众
-- **验证机制**：审查覆盖率≥80%，重大伦理事件零发生
-
-### 5.3 产业测试验证平台 / Industry Test and Verification Platforms
-
-**平台1：AI医疗临床验证平台**
-
-- **位置**：大钟寺AI+医疗产业园
-- **合作医院**：北医三院、海淀医院等5家三甲医院
-- **验证流程**：
-  1. AI产品提交申请
-  2. 医院伦理委员会审查
-  3. 小规模临床试验（100-500例）
-  4. 扩大临床试验（1000-5000例）
-  5. 发布验证报告，出具临床证据
-- **验证标准**：
-  - 诊断准确率≥95%
-  - 响应时间≤5秒
-  - 医生接受度≥85%
-- **预期成果**：每年验证≥10个AI医疗产品，发布≥5份临床验证报告
-
-**平台2：自动驾驶开放测试道路**
-
-- **位置**：大钟寺产业测试平台 + 周边市政道路
-- **测试路段**：总计5公里，包括城市道路3公里、高速连接线2公里
-- **测试场景**：
-  - 正常场景：日间、晴天、畅通道路
-  - 复杂场景：夜间、雨雪、拥堵、施工
-  - 极端场景：突发障碍物、行人闯入、信号灯故障
-- **智能基础设施**：
-  - 车路协同系统：RSU路侧单元、OBU车载单元
-  - 智能信号灯：自适应信号控制，优先通行
-  - 高精地图：实时更新，精度≤10cm
-- **监管机制**：
-  - 实时监控中心：24小时监控测试车辆
-  - 应急预案：远程接管、紧急停车、人工干预
-  - 责任追溯：黑匣子记录，事故责任认定
-- **预期成果**：累计测试里程≥100万公里，零重大安全事故
-
-**平台3：智慧校园试点区**
-
-- **位置**：北京AI原点社区周边5所学校
-- **学校类型**：小学2所、初中2所、高中1所
-- **试点内容**：
-  - 智能教学系统：AI辅助教学、个性化作业、智能测评
-  - 校园安全管理：电子门禁（卡片/非生物）、异常事件AI辅助预警、紧急报警（不做学生面部识别与行为画像，详见 visual/assets/privacy_review_matrix.json）
-  - 学生健康管理：健康监测、营养分析、心理辅导
-- **验证指标**：
-  - 学习效率提升≥30%
-  - 教师工作量减轻≥20%
-  - 家长满意度≥90%
-- **预期成果**：形成可复制推广的智慧校园解决方案
-
----
-
-
-> 证据索引：[source:S001] [standard:STD-MNR-2023] [standard:STD-GB50180]
-
 ## 6. 交通与基础设施 / Transportation and Infrastructure
+
+## 交通、轨道、市政与公共服务设施 / Transport, Rail, Municipal Infrastructure, and Public Services
 
 ### 6.1 综合交通规划 / Integrated Transportation Planning
 
@@ -917,21 +639,6 @@ The Beijing-Zhangjiakou AI Innovation Corridor is a future-oriented urban innova
 
 ---
 
-## 交通、轨道、市政与公共服务设施 / Transport, Rail, Municipal Infrastructure, and Public Services
-
-### 交通系统 / Transport System
-
-![交通与蓝绿系统图](assets/figures/mobility-bluegreen.png)
-
-构建五级道路体系：快速路（京藏高速、北四环）、主干路（中关村大街、学院路）、次干路、支路和慢行通道。轨道交通依托13号线、昌平线和规划中的AI创新带捷运线，设置8个轨道站点接驳节点。
-
-### 市政基础设施 / Municipal Infrastructure
-
-智慧市政管网覆盖全区域，包括智能给排水系统、综合管廊、5G/6G通信基站、分布式能源系统。公共服务设施按15分钟生活圈标准配置，100%覆盖。
-
- / Blue-Green Network, Public Space, and Urban Character
-
-
 > 证据索引：[source:S002] [standard:STD-GB50220] [data:geometry/roads.geojson]
 
 
@@ -958,7 +665,6 @@ The Beijing-Zhangjiakou AI Innovation Corridor is a future-oriented urban innova
 ---
 
 ## 蓝绿空间、公共空间与城市风貌 / Blue-Green Network, Public Space, and Urban Character
-
 ### 7.1 蓝绿空间系统 / Blue-Green Space System
 
 **京张铁路遗址公园（主体绿廊）**：
@@ -1147,7 +853,7 @@ The Beijing-Zhangjiakou AI Innovation Corridor is a future-oriented urban innova
 - 完善交通市政基础设施
 - 引入首批AI创新企业
 
-投资估算（情景假设，非政府投资承诺，见 assumptions.json）：约500亿元
+投资估算（情景假设，非政府投资承诺，见 assumptions.json）：约500亿元（放行证据：年度产值审计与在统企业清单）
 预期成果：
 - 基础设施覆盖率达到100%
 - AI企业入驻率达到60%
@@ -1179,9 +885,9 @@ The Beijing-Zhangjiakou AI Innovation Corridor is a future-oriented urban innova
 
 投资估算（情景假设）：约200亿元
 预期成果：
-- 成为全球AI创新网络TOP10节点
-- 累计开源贡献≥10万项
-- 国际影响力对标硅谷、波士顿
+- 参与全球AI创新网络对话——位次以年度公开可验证指标为准，不预设名次承诺
+- 开源贡献累计规模以年度审计口径计数，随荣誉墙台账同步公开
+- 国际影响力以国际参会者占比、外文媒体报道量等可测项逐年公开，不对标口号
 
 ### 8.2 政策包设计 / Policy Package Design
 
@@ -1223,7 +929,7 @@ The Beijing-Zhangjiakou AI Innovation Corridor is a future-oriented urban innova
   - 分论坛：覆盖大模型、AI应用、开源生态、AI伦理等主题
   - 展览：展示AI创新成果、应用场景、未来技术
   - 黑客马拉松：24小时编程挑战赛，激发创新
-- 影响：成为全球AI领域TOP10年度盛会
+- 影响：成为全球AI领域有影响力的年度盛会（以年度参会名录与国际参会者占比公开衡量）
 
 **开源开发者大会（季度）**
 
@@ -1512,25 +1218,19 @@ Agent名称：WorkBuddy AI Agent
 
 ---
 
-**END OF DOCUMENT**
-
-![总体区位图：展示创新带空间范围和三核结构](assets/figures/site-overview.png)
-
-![核心区布局图：三个核心区功能空间详细设计](assets/figures/key-areas.png)
-
-![指标证据图：包含雷达图、柱状图和合规指标表](assets/figures/metrics-evidence.png)
-
 ## 参考资料 / References
 
-1. 总体设计范围临时边界（组织方 provisional，仅用于生成/可视化/自检） [source:S001] [data:geometry/site_boundary.geojson]
-2. 三处重点区临时边界（组织方 provisional，仅用于生成/可视化/自检） [source:S002] [data:geometry/key_areas.geojson]
+1. 总体设计范围临时边界（组织方 provisional，仅用于生成/自检） [source:S001] [data:geometry/site_boundary.geojson]
+2. 三处重点区临时边界（组织方 provisional，仅用于生成/自检） [source:S002] [data:geometry/key_areas.geojson]
 3. 征集公告（三层范围与重点区面积口径） [source:S003]
-4. 北京城市总体规划(2016年—2035年)（公开政策文件） [source:S004] [standard:STD-BEIJING-MP]
-5. 海淀区国民经济和社会发展第十四个五年规划（公开政策文件） [source:S005]
+4. 《北京城市总体规划(2016年—2035年)》 [source:S004] [standard:STD-BEIJING-MP]
+5. 海淀区国民经济和社会发展第十四个五年规划 [source:S005]
 6. 中关村国家自主创新示范区等创新载体（公开常识性事实） [source:S006]
-7. GB 50180-2018 城市居住区规划设计标准 [source:S007] [standard:STD-GB50180]
-8. GB 50220-95 城市道路交通规划设计规范 [source:S008] [standard:STD-GB50220]
-9. GB 50420-2007 城市绿地设计规范 [source:S009] [standard:STD-GB50420]
+7. GB 50180-2018《城市居住区规划设计标准》 [source:S007] [standard:STD-GB50180]
+8. GB 50220-95《城市道路交通规划设计规范》 [source:S008] [standard:STD-GB50220]
+9. GB 50420-2007《城市绿地设计规范》 [source:S009] [standard:STD-GB50420]
 10. 全球AI创新区案例比较（8例，逐例附链接） [source:S010]
 11. Noto Sans SC 字体许可（SIL OFL 1.1） [source:S011]
-10. 中关村科学城发展规划 [source:S010]
+![核心区布局图：三个核心区功能空间详细设计](assets/figures/key-areas.png)
+![指标证据图：包含雷达图、柱状图和合规指标表](assets/figures/metrics-evidence.png)
+![交通与蓝绿系统图](assets/figures/mobility-bluegreen.png)

--- a/submissions/zihanCui1215/beijing-zhangjiakou-ai-corridor-2026/visual/assets/parity_qa.json
+++ b/submissions/zihanCui1215/beijing-zhangjiakou-ai-corridor-2026/visual/assets/parity_qa.json
@@ -1,14 +1,14 @@
 {
  "method": "English words per Chinese character, tables and code fences excluded; floor = 0.75 x 0.784 field baseline.",
  "floor": 0.588,
- "overall_ratio": 0.678,
+ "overall_ratio": 0.689,
  "overall_pass": true,
  "sections": [
   {
    "section_zh": "摘要",
-   "zh_chars": 435,
+   "zh_chars": 489,
    "en_words": 296,
-   "ratio": 0.68,
+   "ratio": 0.605,
    "pass": true
   },
   {
@@ -21,36 +21,36 @@
   {
    "section_zh": "2. 总体定位与目标",
    "zh_chars": 698,
-   "en_words": 927,
-   "ratio": 1.328,
+   "en_words": 658,
+   "ratio": 0.943,
    "pass": true
   },
   {
    "section_zh": "三层范围工作框架",
-   "zh_chars": 941,
-   "en_words": 621,
-   "ratio": 0.66,
+   "zh_chars": 258,
+   "en_words": 273,
+   "ratio": 1.058,
    "pass": true
   },
   {
    "section_zh": "统筹研究范围产业与未来城市研究",
-   "zh_chars": 482,
-   "en_words": 316,
-   "ratio": 0.656,
+   "zh_chars": 236,
+   "en_words": 152,
+   "ratio": 0.644,
    "pass": true
   },
   {
    "section_zh": "总体设计范围城市更新与控规深度城市设计",
-   "zh_chars": 475,
-   "en_words": 282,
-   "ratio": 0.594,
+   "zh_chars": 787,
+   "en_words": 621,
+   "ratio": 0.789,
    "pass": true
   },
   {
    "section_zh": "重点区域详细设计",
-   "zh_chars": 1710,
-   "en_words": 1017,
-   "ratio": 0.595,
+   "zh_chars": 1732,
+   "en_words": 1033,
+   "ratio": 0.596,
    "pass": true
   },
   {
@@ -62,23 +62,16 @@
   },
   {
    "section_zh": "用地、建筑规模与拆改留方案",
-   "zh_chars": 2529,
-   "en_words": 1499,
-   "ratio": 0.593,
-   "pass": true
-  },
-  {
-   "section_zh": "6. 交通与基础设施",
-   "zh_chars": 1157,
-   "en_words": 804,
-   "ratio": 0.695,
+   "zh_chars": 328,
+   "en_words": 229,
+   "ratio": 0.698,
    "pass": true
   },
   {
    "section_zh": "交通、轨道、市政与公共服务设施",
-   "zh_chars": 147,
-   "en_words": 130,
-   "ratio": 0.884,
+   "zh_chars": 1161,
+   "en_words": 804,
+   "ratio": 0.693,
    "pass": true
   },
   {
@@ -97,17 +90,17 @@
   },
   {
    "section_zh": "更新项目清单、实施政策与分期计划",
-   "zh_chars": 1675,
+   "zh_chars": 1777,
    "en_words": 1084,
-   "ratio": 0.647,
+   "ratio": 0.61,
    "pass": true
   },
   {
    "section_zh": "指标体系、面积复算与合规矩阵",
    "zh_chars": 867,
-   "en_words": 496,
-   "ratio": 0.572,
-   "pass": false
+   "en_words": 590,
+   "ratio": 0.681,
+   "pass": true
   },
   {
    "section_zh": "风险、版权与合规说明",
@@ -118,16 +111,16 @@
   },
   {
    "section_zh": "结语",
-   "zh_chars": 288,
-   "en_words": 195,
-   "ratio": 0.677,
+   "zh_chars": 231,
+   "en_words": 171,
+   "ratio": 0.74,
    "pass": true
   },
   {
    "section_zh": "参考资料",
-   "zh_chars": 187,
-   "en_words": 161,
-   "ratio": 0.861,
+   "zh_chars": 205,
+   "en_words": 145,
+   "ratio": 0.707,
    "pass": true
   }
  ]


### PR DESCRIPTION
## V8: the problem was structure, not content

A structural audit against top-scoring submissions found the V7 package carrying **3.76x the volume** of a 90-point proposal, with defects accumulated across seven patch iterations:

| Defect | Evidence | Fix |
|---|---|---|
| Duplicated chapters | scope chapters x2, transport chapter x2, one orphan half-header | removed; single authoritative chapter each |
| Parallel legacy systems | old scenario set (场景1-10, aspirational "≥95% accuracy" promises) alongside the 12 verification-contract cards; fictional named personas (李明/张雪/王强…) alongside the nine-type persona table | legacy blocks removed; nine-type + SC-01..12 now the only systems |
| Contradictory figures | employment 10-12万 vs 15-20万; residential 5-6万 vs 8-10万; TOP10/对标硅谷 leftovers in phasing chapter | unified to 15-20万 / 8-10万 with assumptions.json anchors; aspirational lines rewritten as stage-gated audit language |
| EN-specific rot | one-page-reading paragraph repeated 3x back-to-back; land-use chapter body accidentally hollowed | collapsed to 1; chapter body restored |

### Kept and sharpened
- **Three-core verb table** (验/转/用 — Verify/Transfer/Apply) with minimal visible delivery, required evidence and fallback city-state — the one-page brand/implementation grammar of top scorers
- **Hero sequences** in headers: 河—庭—廊 / 校—街—厅 / 站—厅—街—绿
- All verification assets intact: 12 scenario cards, G0-G3 release gates, B01-B05 baselines, JZ-01..10 projects, CP-01..08 component library, four self-check scripts

### Self-check re-run after surgery
verify 10/10 PASS, cards 12/12 PASS, ops 5/5 PASS, parity 0.675 overall (all 14 sections PASS; was 1 FAIL in V7).

zh: 43,654 -> 34,113 chars; en: 101,670 -> 81,081 chars. iteration: v8.
