### PR TITLE
fix-road-lengths: 修复道路长度声明与实际坐标不一致(30.5%误差)

### DIFF
--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/roads.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/roads.geojson
@@ -13,7 +13,7 @@
         "geometry_role": "design_proposal",
         "road_type": "secondary",
         "name_zh": "西侧联络道",
-        "length_m": 4774.5
+        "length_m": 6232.6
       },
       "geometry": {
         "type": "LineString",
@@ -84,7 +84,7 @@
         "geometry_role": "design_proposal",
         "road_type": "pedestrian_priority",
         "name_zh": "京张绿廊慢行道",
-        "length_m": 7227.6
+        "length_m": 9435.0
       },
       "geometry": {
         "type": "LineString",
@@ -175,7 +175,7 @@
         "geometry_role": "design_proposal",
         "road_type": "primary",
         "name_zh": "中央智脉大道",
-        "length_m": 7227.6
+        "length_m": 9435.0
       },
       "geometry": {
         "type": "LineString",
@@ -266,7 +266,7 @@
         "geometry_role": "design_proposal",
         "road_type": "secondary",
         "name_zh": "东侧服务道",
-        "length_m": 7227.6
+        "length_m": 9435.0
       },
       "geometry": {
         "type": "LineString",
@@ -357,7 +357,7 @@
         "geometry_role": "design_proposal",
         "road_type": "primary",
         "name_zh": "学院路辅路",
-        "length_m": 7227.6
+        "length_m": 9435.0
       },
       "geometry": {
         "type": "LineString",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
@@ -46,7 +46,7 @@
       "path": "metrics.json",
       "role": "metrics",
       "required": true,
-      "sha256": "44c321384ec80126c01003ca41529f3ac6bef3e2189ee1c3c75d6f9f4e5526df"
+      "sha256": "9ffc62fe26568efe359fdc4e441434ad8bc20a1c6b974127902eafb1c179b8cc"
     },
     {
       "path": "assumptions.json",
@@ -64,7 +64,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "607a5db04756995757d0176fb2f297cd65cf28323444693eac376b010d9395c5"
+      "sha256": "d6113702c390723a20a0d0e67bf7c9ca7d527009b1fe8fcf0960798cb560d3dc"
     },
     {
       "path": "compliance_matrix.json",
@@ -277,7 +277,7 @@
       "path": "geometry/roads.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "914ab84da17d7b5d1b2ba391e382ff28a5de2da1533954cefda297bbe33b7c85"
+      "sha256": "fa667e6fab4cb4ef5c32d2721f9bd4e5fdf11dca41fad7cd2d5dfaa9caf23ba0"
     },
     {
       "path": "geometry/site_boundary.geojson",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/metrics.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/metrics.json
@@ -178,7 +178,7 @@
     },
     "road_network_total_length_m": {
       "status": "known",
-      "value": 42334.5,
+      "value": 52622.20000000001,
       "unit": "m",
       "source_files": [
         "geometry/roads.geojson"

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
@@ -78,7 +78,7 @@
       "ai_package_stages": {
         "submissions/565431hzhang/jingzhang-ai-heritage-halo": "formal"
       },
-      "total_bytes": 4175165,
+      "total_bytes": 4175175,
       "maintainer_bypass": false
     },
     "stderr": ""


### PR DESCRIPTION
城市设计数据修复：

5条南北道路的声明长度(length_m)与实际坐标计算不一致，误差30.5%。

修复：
- ROAD-NS-1: 4774m → 6233m
- ROAD-NS-2: 7228m → 9435m
- ROAD-NS-3: 7228m → 9435m
- ROAD-NS-4: 7228m → 9435m
- ROAD-NS-5: 7228m → 9435m
- 总道路网络: 42334m → 52622m
- metrics.json同步更新

这是实际的城市设计数据错误，不是属性标签。