### PR TITLE
Improve evidence-first reviewer entry ladder

### DIFF
--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/changelog.md
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/changelog.md
@@ -1,5 +1,25 @@
 # 方案迭代记录 / Changelog
 
+## v41.0 - 2026-08-18
+
+**Evidence-first reviewer reading ladder / 证据优先的评审阅读梯**
+
+- 串行门：第 40 轮 PR #3204 已合并（head `d4d9f5dd86ed61a121ed716c964968ae7aaecd16`，merge `596ddd89ffd75edd59cc4f1afa70e6f0ec5e3d9a` 已包含于 canonical `main@5fb96256c5b756f2f7d1880b7594352aa0eb25e1`）；同一投稿包开放 PR 为 0，源工作树洁净。本轮只修复首屏阅读路径的可复现入口断点。
+- Serial gate: Round 40 PR #3204 is merged (head `d4d9f5dd86ed61a121ed716c964968ae7aaecd16`; merge `596ddd89ffd75edd59cc4f1afa70e6f0ec5e3d9a` is contained in canonical `main@5fb96256c5b756f2f7d1880b7594352aa0eb25e1`); the package has zero open PRs and the source worktree was clean. This round repairs only a reproducible first-screen reading-entry break.
+
+| 已具备 / Already present | 仍薄弱 / RED | 必须冻结 / Locked | 本轮实施 / Implemented |
+|---|---|---|---|
+| 双语 visual 已有 30 秒／3 分钟／15 分钟三张阅读卡、六项主导航、八问唯一答案与 D01—D08/H01—H07 证据入口 | 每版有 3 张阅读卡但卡内直接行动链接为 0；3 分钟和 15 分钟的起点只能从说明文字推断，读者必须自行滚动或猜测 | 双轨总纲、三原型、四态与 G0—G3 分离、JZ-AIOS、三载体、九份 geometry、`metrics.json`、12/8/3/36、G0/NO-GO/provisional/rights、媒体和 PDF 页数 | 三张卡各新增一个可键盘访问的静态起步链接：概念/边界 → `#cold-read-proof-boundary`，普通生活 → `#ordinary-life`，证据/交接 → `#review-handoff`；双语结构和六项主导航不变 |
+
+- 修复前 RED 可重放：统计 `visual/index.html` 与 `visual/index.en.html` 的 `.reading-lanes` 内 `<a>` 元素，两版均为 0，而每版均有 3 张卡。修复后每版有 3 个显式起步链接，目标一致且不依赖 JavaScript；`review-handoff-index.json#evidence_integrity.reading_ladder_r41` 保存前后计数与边界。
+- Reproducible RED: counting `<a>` elements inside `.reading-lanes` in both `visual/index.html` and `visual/index.en.html` returned 0 while each page contained three cards. After repair each page exposes three explicit, matching start links without JavaScript; `review-handoff-index.json#evidence_integrity.reading_ladder_r41` preserves the before/after counts and boundary.
+- 本轮无新媒体、来源、主张、场景、项目、重点区、治理合同或页面。修复只改变既有阅读入口，不把概念图、离线导航或验证通过写成现场证据、理解测量、专业意见、批准、G1、授权或清权。四份 PDF 因内容未受影响而保持原字节与页数。
+- This round adds no media, source, claim, scene, project, key area, governance contract or page. It changes only existing reading entry; it does not turn concept figures, offline navigation or a passing check into field evidence, measured comprehension, professional opinion, approval, G1, authorisation or clearance. The four PDFs keep their existing bytes and page counts because their content is unaffected.
+- 权利台账的逐字节核验保持 138 条普通文件，再加 manifest、`self_check.json`、ledger 三个明确例外：manifest 和 ledger 不能哈希自身；`self_check_submission.py` 在同一最终化步骤中重写 `self_check.json` 并把最终 SHA-256 写入 manifest，所以该记录只回链 manifest 的最终摘要。例外不改变 `not_fully_cleared`、独立逐文件清权 0 或任何可用性结论。
+- Rights-ledger byte verification covers 138 ordinary files plus three explicit exceptions: manifest and ledger cannot hash themselves; `self_check_submission.py` rewrites `self_check.json` and writes its final SHA-256 into manifest in the same finalization step, so that record back-links only to the final manifest digest. The exception does not change `not_fully_cleared`, zero independent file-level clearance audits or any use decision.
+- 八个长期真实性反问：修复更清楚而非更花哨；三处继续可由空间关系区分；非 AI 路径继续完整；故障只停验证叠层；恢复不等于授权、批准或 G1；既有图像继续明确为概念展示；中英文、visual、报告和 PDF 指向同一结论；本轮无新媒体，既有生成方法、来源、模型、权利和不可证明事项披露不变。geometry、`metrics.json`、12/8/3/36、G0、NO-GO、provisional、现实结果 0、`not_fully_cleared` 和独立逐文件清权 0 保持不变。
+- Eight long-running truth checks: the repair is clearer rather than more decorative; three places remain distinguishable by spatial relation; the non-AI path stays complete; failure stops only the proof overlay; recovery is not authorisation, approval or G1; existing imagery remains labelled as conceptual display; Chinese, English, visual, report and PDF state the same outcome; and this round adds no media, leaving generation-method, source, model, rights and non-provable-matter disclosures unchanged. Geometry, `metrics.json`, 12/8/3/36, G0, NO-GO, provisional status, zero real-world outcomes, `not_fully_cleared` and zero independent file-level clearance audits remain unchanged.
+
 ## v40.0 - 2026-08-18
 
 **Spatial-distinction cold-read repair / 空间差异冷读修复**

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/manifest.json
@@ -81,13 +81,13 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "81c1266fdd7c6eea36af9ca5510ea202ca415948ec293cf7b76289b579e83a7c"
+      "sha256": "bf258804cc2283ef3a8dbb07cd0e627bfa01ee6a144c79cb213d5d0bdb094c90"
     },
     {
       "path": "changelog.md",
       "role": "changelog",
       "required": true,
-      "sha256": "c0601b47dbad989b295b27ce792d99962a5c4f0d0a7b649adc7d760800157431"
+      "sha256": "b0389b9488eadc7348f4eeffc30aac89449c564a19732d0db2f9a49c8957094b"
     },
     {
       "path": "compliance_matrix.json",
@@ -202,7 +202,7 @@
       "path": "visual/assets/rights-clearance-ledger.json",
       "role": "copyright_statement",
       "required": true,
-      "sha256": "fc07076cf477472b064617c2ba5c6b685c9eb6c2a42aedc6739836dc5ea78ed7"
+      "sha256": "28c2a3e52c0b756eed00f391ff4c950a8dfb60f80b00ae70c87eef7ed99fc9bf"
     },
     {
       "path": "visual/assets/source-rights-evidence.schema.json",
@@ -236,7 +236,7 @@
       "path": "report/narrative.md",
       "role": "narrative",
       "required": false,
-      "sha256": "24398cb8df52d742d4e0677a0c20decee76b4adf1bf99f59750d127fd57335e0"
+      "sha256": "3bec39cb7b897e3b8309f036ef21ab87a5d5e811ee06f34e533cf7d1b567751d"
     },
     {
       "path": "report/copyright_statement.md",
@@ -263,7 +263,7 @@
       "role": "visualization",
       "required": true,
       "language": "zh",
-      "sha256": "451838b62d81fab43134f829e3da2a0d1b34c86920f29026b32a2855ff56ab04"
+      "sha256": "2a131a62605e5f20a6f3c8219f2350a4d908534902f32421da2d9d4a66c1fde1"
     },
     {
       "path": "assets/figures/key-areas.png",
@@ -419,7 +419,7 @@
       "required": true,
       "language": "en",
       "translation_of": "visual/index.html",
-      "sha256": "f467c2ccaa3206d18d35aa42e5f6b6273dfa31fe8524bbd9edf3c26010436559"
+      "sha256": "57bbf61c05dc28f31278ff74acb8ff76b99738dcbbe9c5a30b898609ed3ba51b"
     },
     {
       "path": "drawings/a3-booklet.en.pdf",
@@ -990,7 +990,7 @@
       "title_en": "Review handoff index and package navigation",
       "description_zh": "全部 141 个投稿包路径的评审定位索引：七条阅读路线、逐文件登记、冻结/临时/历史标记、三载体映射与权利回链；索引只负责定位，不生成证据、不改变成熟度或权利状态。",
       "description_en": "Review navigation for all 141 package paths: seven reading routes, a per-file registry, frozen/provisional/historical labels, three-carrier mapping and rights backlinks; the index only locates, creates no evidence and changes no maturity or rights state.",
-      "sha256": "f9ce24adcb3971b6cad24833200ba96b3d75f5b76d2929d2bca6543ffeed515f"
+      "sha256": "3a6927cc81f36e6f76f1293cde27b815688ba43394fe86f6b5ec6217dd7670af"
     },
     {
       "path": "visual/assets/round17-reading.css",

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/report/narrative.md
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/report/narrative.md
@@ -4,6 +4,24 @@
 >
 > This file applies only to `submissions/xyh202131/jingzhang-ai-pilgrimage-belt/`. It is a package-local copy reference, not a repository-level reusable template, public PR template, or maintainer policy. No `[x]` may be inherited when it is copied into another submission or later PR.
 
+## Round 41 Evidence-first reviewer reading ladder / 第 41 轮证据优先的评审阅读梯
+
+第 41 轮只在第 40 轮 PR #3204 合并（head `d4d9f5dd86ed61a121ed716c964968ae7aaecd16`，merge `596ddd89ffd75edd59cc4f1afa70e6f0ec5e3d9a` 已包含于 canonical `main@5fb96256c5b756f2f7d1880b7594352aa0eb25e1`）、同包无开放 PR、工作树洁净后开始。审计没有寻找新的方案方向，而是检查前台承诺的三档阅读是否能真正启动。RED 是可重复的 DOM 计数：中英文 `.reading-lanes` 各有三张卡，但各有 0 个 `<a>`，因此 3 分钟“从哪里开始”和 15 分钟“从哪里进入证据”只能靠说明文字推断。修复把三张既有卡变成三个原生、可键盘访问、无 JavaScript 的起步链接：30 秒回到一个概念与一个边界，3 分钟从普通生活开始，15 分钟从专业交接进入。链接只定位既有内容，既不展开或隐藏证据，也不制造一个新的阅读层。
+
+结构化索引 `review-handoff-index.json#evidence_integrity.reading_ladder_r41` 保存 3 卡／0 直接行动链接的修复前记录，以及修复后每语言 3 个目标一致的静态链接。这个记录只是编辑导航核验：不认证真实评审者的理解、公众反馈、专家意见或评审结论。它不改变“30 秒／3 分钟／15 分钟”所指的既有内容，也不让离线页面、机器检查或清晰表达变成现场证据、专业责任、批准、G1、授权或权利清除。
+
+权利台账对 138 个普通文件执行摘要核验，并明确三项狭义的字节核验例外。manifest 和 ledger 不能对自身哈希；`self_check_submission.py` 在同一最终化步骤中替换 `self_check.json` 并把其最终 SHA-256 写入 manifest，因此台账只回链该最终 manifest 摘要，不保留会立刻过期的重复摘要。这项机械例外不降低 manifest 校验、权利状态、独立审计数量或使用边界。
+
+本轮无新媒体；生成方法、来源、模型、权利和不可证明事项均未变化。图像继续是 G0 概念展示，不是现状、已建成状态、无障碍结果、人员承诺或现实恢复时间。geometry 九文件、`metrics.json`、12 个场景、8 个项目、3 个重点区、36 个概念用地单元、普通—验证—故障—恢复、非 AI 路径、G0、NO-GO、临时边界、现实结果 0、`not_fully_cleared` 和独立逐文件清权 0 全部保持冻结。正文和 PDF 没有事实改动；四份既有 PDF 因而保留原页数和字节。
+
+Round 41 began only after Round 40 PR #3204 merged (head `d4d9f5dd86ed61a121ed716c964968ae7aaecd16`; merge `596ddd89ffd75edd59cc4f1afa70e6f0ec5e3d9a` is contained in canonical `main@5fb96256c5b756f2f7d1880b7594352aa0eb25e1`), no PR remained open for this package, and the worktree was clean. The audit sought no new design direction; it tested whether the three promised front-stage reading depths could actually begin. The RED was a repeatable DOM count: each Chinese and English `.reading-lanes` contained three cards but zero `<a>` elements, so readers had to infer where the 3-minute path starts and where the 15-minute evidence path enters. The repair turns the existing cards into three native, keyboard-accessible, no-JavaScript start links: 30 seconds returns to one concept and one boundary, 3 minutes starts with ordinary life, and 15 minutes enters through professional handoff. The links locate existing content only; they neither reveal nor hide evidence and do not create another reading layer.
+
+`review-handoff-index.json#evidence_integrity.reading_ladder_r41` retains the 3-card/0-direct-action before record and the repaired three matching static targets per language. This is an editorial navigation check only: it does not certify real reviewer comprehension, public feedback, expert opinion or a jury conclusion. It does not alter the existing content signified by “30 seconds / 3 minutes / 15 minutes,” nor turn an offline page, machine check or clearer expression into field evidence, professional duty, approval, G1, authorisation or rights clearance.
+
+The rights ledger checks 138 ordinary file digests and names three narrow byte-verification exceptions. Manifest and ledger cannot hash themselves. `self_check_submission.py` replaces `self_check.json` and records its final SHA-256 in manifest during the same finalisation step, so the ledger records the final manifest reference instead of retaining a stale duplicate digest. This mechanical exception does not reduce the manifest check, rights status, independent audit count or use boundary.
+
+The round adds no media; generation method, source, model, rights and non-provable matters are unchanged. Imagery remains a G0 concept display, not an existing or built state, accessibility result, staffing commitment or real recovery time. The nine geometry files, `metrics.json`, 12 scenes, 8 projects, 3 key areas, 36 conceptual land-use units, ordinary–proof–failure–recovery, the non-AI path, G0, NO-GO, provisional boundary, zero real-world outcomes, `not_fully_cleared` and zero independent file-level clearance audits all remain frozen. Neither proposal prose nor PDFs change facts, so all four PDFs retain their existing page counts and bytes.
+
 ## Round 40 Spatial-distinction cold-read repair / 第 40 轮空间差异冷读修复
 
 第 40 轮在第 39 轮 PR #3109 已合并（head `1172b6ac6904b67bd7f9d41c0cfad4742d91ed8a`，merge 已进入 canonical `main@44ffc5bbad89245f76ea1eed4f36a38465cf9211`）、同一投稿包无开放 PR、工作树洁净后开始。基线复核确认八问已有唯一答案入口，但两张关键图仍有可复现的冷读问题：三处文字内容不同，平面却先被相同卡片边框读取；关系剖面也先被三条相似横排读取。因此本轮不增加方案内容，只把差异移入空间构图。众智园读作普通旁路与上方可停验证庭的平行分离，人工维护交接位于两者之间；原点社区读作一条居民街串联两院和四个可独立撤回节点；大钟寺读作四向通勤十字，发布厅、人工台和安静休憩均退到路线之外。三处的失败对象与恢复对象不可互换。

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/self_check.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/self_check.json
@@ -164,7 +164,7 @@
       "ai_package_stages": {
         "submissions/xyh202131/jingzhang-ai-pilgrimage-belt": "formal"
       },
-      "total_bytes": 34662590,
+      "total_bytes": 34675968,
       "maintainer_bypass": false
     },
     "stderr": ""

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/visual/assets/review-handoff-index.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/visual/assets/review-handoff-index.json
@@ -31,7 +31,7 @@
       "zh": "场景护照：12 个场景的门级与护照字段覆盖"
     }
   },
-  "contract_id": "JZ-REVIEW-HANDOFF-INDEX-R40",
+  "contract_id": "JZ-REVIEW-HANDOFF-INDEX-R41",
   "evidence_integrity": {
     "cold_read_answer_map": {
       "answers_checked": 8,
@@ -41,6 +41,25 @@
       "unique_answer_ids": true,
       "unique_primary_anchors": true
     },
+    "reading_ladder_r41": {
+      "audit_type": "editorial_navigation_check",
+      "post_repair": {
+        "bilingual_targets_resolved": 3,
+        "direct_start_actions_per_language": 3,
+        "targets": [
+          "#cold-read-proof-boundary",
+          "#ordinary-life",
+          "#review-handoff"
+        ]
+      },
+      "red_before": {
+        "reading_depth_cards_per_language": 3,
+        "direct_start_actions_per_language": 0,
+        "reproduction": "Count <a> elements inside visual/index(.en).html .reading-lanes; both pages returned 0 before repair, so the stated 3-minute and 15-minute paths required inferred scrolling rather than a declared start."
+      },
+      "scope_en": "This records only front-stage navigation repair. It does not create evidence, alter the 30-second/3-minute/15-minute claims, certify comprehension, or change maturity, rights or real-world status.",
+      "scope_zh": "本记录只说明前台导航修复；不生成证据、不改变 30 秒／3 分钟／15 分钟主张、不认证理解效果，也不改变成熟度、权利或现实状态。"
+    },
     "generator_enforced": true,
     "heading_parity": {
       "en": 87,
@@ -48,7 +67,12 @@
       "zh": 87
     },
     "ledger_digest_coherence": {
-      "checked": 139,
+      "checked": 138,
+      "excluded": {
+        "manifest.json": "manifest cannot hash itself",
+        "self_check.json": "the self-check writer replaces this file and refreshes its final manifest digest in one step; verify it against manifest.json rather than duplicating a stale ledger digest",
+        "visual/assets/rights-clearance-ledger.json": "ledger cannot hash itself"
+      },
       "mismatched": 0
     },
     "marker_target_resolution": {

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/visual/assets/rights-clearance-ledger.json
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/visual/assets/rights-clearance-ledger.json
@@ -605,10 +605,10 @@
       "asset_class": "structured_package_record",
       "origin_status": "self_declared_origin_pending_independent_review",
       "content_identity": {
-        "algorithm": "sha256",
-        "digest": "81c1266fdd7c6eea36af9ca5510ea202ca415948ec293cf7b76289b579e83a7c",
-        "digest_status": "matches_final_manifest_after_refresh",
-        "reason": "SHA-256 is computed from final Round 40 bytes and will be refreshed into manifest.json after the ledger is finalized."
+        "algorithm": "manifest_declared_sha256",
+        "digest": null,
+        "digest_status": "manifest_authoritative_self_rewriting_record",
+        "reason": "self_check_submission.py writes self_check.json and then refreshes its manifest SHA-256 in the same finalization step. The ledger therefore cites the final manifest entry rather than duplicating a digest that its own finalization rewrites; this is a byte-verification exception, not a rights, evidence or readiness exception."
       },
       "source_lineage": {
         "source_ids": [],
@@ -653,7 +653,7 @@
       "origin_status": "self_declared_origin_pending_independent_review",
       "content_identity": {
         "algorithm": "sha256",
-        "digest": "c0601b47dbad989b295b27ce792d99962a5c4f0d0a7b649adc7d760800157431",
+      "digest": "b0389b9488eadc7348f4eeffc30aac89449c564a19732d0db2f9a49c8957094b",
         "digest_status": "matches_final_manifest_after_refresh",
         "reason": "SHA-256 is computed from final Round 40 bytes and will be refreshed into manifest.json after the ledger is finalized."
       },
@@ -1908,7 +1908,7 @@
       "origin_status": "self_declared_origin_pending_independent_review",
       "content_identity": {
         "algorithm": "sha256",
-        "digest": "24398cb8df52d742d4e0677a0c20decee76b4adf1bf99f59750d127fd57335e0",
+      "digest": "3bec39cb7b897e3b8309f036ef21ab87a5d5e811ee06f34e533cf7d1b567751d",
         "digest_status": "matches_final_manifest_after_refresh",
         "reason": "SHA-256 is computed from final Round 40 bytes and will be refreshed into manifest.json after the ledger is finalized."
       },
@@ -2169,7 +2169,7 @@
       "origin_status": "generated_derivative_pending_embedded_asset_audit",
       "content_identity": {
         "algorithm": "sha256",
-        "digest": "451838b62d81fab43134f829e3da2a0d1b34c86920f29026b32a2855ff56ab04",
+      "digest": "2a131a62605e5f20a6f3c8219f2350a4d908534902f32421da2d9d4a66c1fde1",
         "digest_status": "matches_final_manifest_after_refresh",
         "reason": "SHA-256 is computed from final Round 40 bytes and will be refreshed into manifest.json after the ledger is finalized."
       },
@@ -3399,7 +3399,7 @@
       "origin_status": "generated_derivative_pending_embedded_asset_audit",
       "content_identity": {
         "algorithm": "sha256",
-        "digest": "f467c2ccaa3206d18d35aa42e5f6b6273dfa31fe8524bbd9edf3c26010436559",
+      "digest": "57bbf61c05dc28f31278ff74acb8ff76b99738dcbbe9c5a30b898609ed3ba51b",
         "digest_status": "matches_final_manifest_after_refresh",
         "reason": "SHA-256 is computed from final Round 40 bytes and will be refreshed into manifest.json after the ledger is finalized."
       },
@@ -7805,7 +7805,7 @@
       "origin_status": "package_authored_pending_independent_review",
       "content_identity": {
         "algorithm": "sha256",
-        "digest": "f9ce24adcb3971b6cad24833200ba96b3d75f5b76d2929d2bca6543ffeed515f",
+      "digest": "3a6927cc81f36e6f76f1293cde27b815688ba43394fe86f6b5ec6217dd7670af",
         "digest_status": "matches_final_manifest_after_refresh",
         "reason": "SHA-256 is computed from final Round 40 bytes and will be refreshed into manifest.json after the ledger is finalized."
       },

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/visual/index.en.html
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/visual/index.en.html
@@ -165,6 +165,33 @@
         background: #e4eceb;
         margin: 3px;
       }
+      .reading-lanes {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+        gap: 14px;
+        margin: 22px 0;
+      }
+      .reading-lane {
+        background: #fff;
+        border: 1px solid #d8dbd4;
+        border-radius: 14px;
+        padding: 16px;
+      }
+      .reading-lane strong {
+        color: var(--green);
+        font-size: 20px;
+      }
+      .reading-lane p {
+        margin: 6px 0 0;
+      }
+      .reading-lane-action {
+        display: inline-block;
+        margin-top: 10px;
+        color: var(--ink);
+        font-weight: 700;
+        text-decoration-thickness: 2px;
+        text-underline-offset: 3px;
+      }
       footer {
         background: var(--ink);
         color: #dce5e9;
@@ -212,9 +239,9 @@
         </figure>
         <p id="cold-read-proof-boundary" class="entry-lead"><strong>One concept:</strong> the continuous ordinary track keeps the ordinary task complete, while the intermittent proof track is a voluntary, bounded and stoppable side overlay: Zhongzhiyuan VERIFY, Origin Community CO-CREATE, Dazhongsi PUBLISH. <strong>One boundary:</strong> the proposal remains G0 with provisional geometry; clarity is not site precision.</p>
         <div class="reading-lanes" aria-label="Three reading depths">
-          <article class="reading-lane"><strong>30 seconds</strong><p>Read Figure 01: twin tracks, three prototypes, failure siding, six signals, and the provisional boundary.</p></article>
-          <article class="reading-lane"><strong>3 minutes</strong><p>Follow the six front-stage sections: cover—ordinary life—four-state journey—three places—public signals—professional handoff.</p></article>
-          <article class="reading-lane"><strong>15 minutes</strong><p>Open the evidence library and audit D01–D08, H01–H07, rights, sources, and recalculation triggers.</p></article>
+          <article class="reading-lane"><strong>30 seconds</strong><p>Recognize one concept and one boundary first: twin tracks, three prototypes, failure siding and provisional geometry.</p><a class="reading-lane-action" href="#cold-read-proof-boundary">Check concept and boundary here →</a></article>
+          <article class="reading-lane"><strong>3 minutes</strong><p>Start with ordinary life, then follow the four-state journey, three places, public signals and professional handoff.</p><a class="reading-lane-action" href="#ordinary-life">Start with ordinary life →</a></article>
+          <article class="reading-lane"><strong>15 minutes</strong><p>Enter through professional handoff, then trace each object to D01–D08, H01–H07, rights, sources and recalculation triggers.</p><a class="reading-lane-action" href="#review-handoff">Start with evidence and handoff →</a></article>
         </div>
         <details class="entry-evidence">
           <summary>Open the three-frame site evidence and provisional-boundary note</summary>

--- a/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/visual/index.html
+++ b/submissions/xyh202131/jingzhang-ai-pilgrimage-belt/visual/index.html
@@ -159,6 +159,33 @@
         background: #e4eceb;
         margin: 3px;
       }
+      .reading-lanes {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+        gap: 14px;
+        margin: 22px 0;
+      }
+      .reading-lane {
+        background: #fff;
+        border: 1px solid #d8dbd4;
+        border-radius: 14px;
+        padding: 16px;
+      }
+      .reading-lane strong {
+        color: var(--green);
+        font-size: 20px;
+      }
+      .reading-lane p {
+        margin: 6px 0 0;
+      }
+      .reading-lane-action {
+        display: inline-block;
+        margin-top: 10px;
+        color: var(--ink);
+        font-weight: 700;
+        text-decoration-thickness: 2px;
+        text-underline-offset: 3px;
+      }
     </style>
     <link rel="stylesheet" href="assets/review-walkthrough.css">
     <link rel="stylesheet" href="assets/round17-reading.css">
@@ -186,9 +213,9 @@
         </figure>
         <p id="cold-read-proof-boundary" class="entry-lead"><strong>一个概念：</strong>连续日常轨让普通任务始终可完成，间歇验证轨只作自愿、限域、可停止的旁侧叠层；众智园 VERIFY、原点社区 CO-CREATE、大钟寺 PUBLISH。<strong>一个边界：</strong>全案仍为 G0、provisional geometry，图面清楚不等于场地准确。</p>
         <div class="reading-lanes" aria-label="三档阅读路径">
-          <article class="reading-lane"><strong>30 秒</strong><p>看图 01：双轨、三处原型、失败侧线、六类信号，以及临时边界。</p></article>
-          <article class="reading-lane"><strong>3 分钟</strong><p>沿前台六段依次阅读：封面—普通生活—四态旅程—三处空间—公共信号—专业交接。</p></article>
-          <article class="reading-lane"><strong>15 分钟</strong><p>展开证据库，逐项核查 D01—D08、H01—H07、权利、来源与重算触发。</p></article>
+          <article class="reading-lane"><strong>30 秒</strong><p>先认一个概念与一个边界：双轨、三处原型、失败侧线与临时几何。</p><a class="reading-lane-action" href="#cold-read-proof-boundary">在此核对概念与边界 →</a></article>
+          <article class="reading-lane"><strong>3 分钟</strong><p>从普通生活开始，依次读四态旅程、三处空间、公共信号与专业交接。</p><a class="reading-lane-action" href="#ordinary-life">从普通生活开始 →</a></article>
+          <article class="reading-lane"><strong>15 分钟</strong><p>从专业交接进入，逐对象追到 D01—D08、H01—H07、权利、来源与复算触发。</p><a class="reading-lane-action" href="#review-handoff">从证据与交接开始 →</a></article>
         </div>
         <details class="entry-evidence">
           <summary>展开三框场地依据与临时边界说明</summary>


### PR DESCRIPTION
## Summary

- Adds direct, native links from the Chinese and English 30-second / 3-minute / 15-minute reading lanes to their unique concept-and-boundary, ordinary-life, and evidence-handoff anchors.
- Records the reproducible pre-fix finding: three reading-lane cards existed, but none exposed an action link; the repair adds no new proposal claim, site fact, media, page, scenario, project, or maturity assertion.
- Keeps the manifest as the final hash authority for the self-rewriting `self_check.json` record; this transparent ledger exception does not advance clearance, evidence, or readiness.

## Verification

- Four-gate self-check: pass; formal review ready (the three existing provisional-key-area notices remain).
- T-02 replay: 10/10 exact fixtures, 4/4 stop events, zero real service interactions.
- Strict proposal score: 8/8 pass.
- Manifest hashes: 140/140 matched; rights ledger: 138 ordinary file identities matched; frozen metrics, nine geometry files, and four PDFs unchanged from current `main`.
- Offline visual review, no-JavaScript fallback checks, participant preflight with push dry-run, and `git diff --check`: pass.

## Boundaries retained

The submission remains G0 with provisional geometry. No real-world results are claimed; `not_fully_cleared` remains in force, with zero completed independent file-level clearance audits and public/professional reuse still blocked pending terms and audit.
