### PR TITLE
urban-v2: 大钟寺增加8栋AI研发建筑

### DIFF
--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/buildings.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/buildings.geojson
@@ -2963,7 +2963,7 @@
         "source_type": "agent_generated_design",
         "confidence": "medium",
         "geometry_role": "design_proposal",
-        "building_type": "mixed_use",
+        "building_type": "ai_r_and_d",
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.969
       },
@@ -3004,7 +3004,7 @@
         "source_type": "agent_generated_design",
         "confidence": "medium",
         "geometry_role": "design_proposal",
-        "building_type": "mixed_use",
+        "building_type": "ai_r_and_d",
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.801
       },
@@ -3045,7 +3045,7 @@
         "source_type": "agent_generated_design",
         "confidence": "medium",
         "geometry_role": "design_proposal",
-        "building_type": "mixed_use",
+        "building_type": "ai_r_and_d",
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.633
       },
@@ -3086,7 +3086,7 @@
         "source_type": "agent_generated_design",
         "confidence": "medium",
         "geometry_role": "design_proposal",
-        "building_type": "mixed_use",
+        "building_type": "ai_r_and_d",
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.965
       },
@@ -3127,7 +3127,7 @@
         "source_type": "agent_generated_design",
         "confidence": "medium",
         "geometry_role": "design_proposal",
-        "building_type": "mixed_use",
+        "building_type": "ai_r_and_d",
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.797
       },
@@ -4562,8 +4562,8 @@
         "source_type": "agent_generated_design",
         "confidence": "medium",
         "geometry_role": "design_proposal",
-        "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "building_type": "ai_r_and_d",
+        "name_zh": "走廊AI研发公共建筑",
         "area_sqm_declared": 2847.089
       },
       "geometry": {
@@ -4603,8 +4603,8 @@
         "source_type": "agent_generated_design",
         "confidence": "medium",
         "geometry_role": "design_proposal",
-        "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "building_type": "ai_r_and_d",
+        "name_zh": "走廊AI研发公共建筑",
         "area_sqm_declared": 2847.088
       },
       "geometry": {
@@ -4644,8 +4644,8 @@
         "source_type": "agent_generated_design",
         "confidence": "medium",
         "geometry_role": "design_proposal",
-        "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "building_type": "ai_r_and_d",
+        "name_zh": "走廊AI研发公共建筑",
         "area_sqm_declared": 2847.088
       },
       "geometry": {

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
@@ -64,7 +64,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "289d9a0feb2fa436c3957a8a8d79886952d585576915a8d9e67506261298eda3"
+      "sha256": "4529354382d184fea6c2fd76f487196251fd63d29c245536fb312b1546b8a5b4"
     },
     {
       "path": "compliance_matrix.json",
@@ -235,7 +235,7 @@
       "path": "geometry/buildings.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "ddf27a1f684539345757d022247d3af122c5ef764dbd802695b8bb8ca527490a"
+      "sha256": "230d48d60b728a91e42d2e46c6c40fc3412218dc04c075c4736a0dd1737b7ca3"
     },
     {
       "path": "geometry/constraints.geojson",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
@@ -78,7 +78,7 @@
       "ai_package_stages": {
         "submissions/565431hzhang/jingzhang-ai-heritage-halo": "formal"
       },
-      "total_bytes": 4175250,
+      "total_bytes": 4175267,
       "maintainer_bypass": false
     },
     "stderr": ""


### PR DESCRIPTION
城市设计优化：

大钟寺作为AI产业聚集区，但原来没有ai_r_and_d建筑。
改8栋(mixed_use→5栋+cultural→3栋)为ai_r_and_d。

大钟寺建筑分布: mixed_use:10, ai_r_and_d:8, retail:9, cultural:6, residential:2
众智园建筑分布: ai_r_and_d:47, mixed_use:1, lab:1, education:1, community_service:1, talent_apartment:1, office:1, cultural:4, retail:4