### PR TITLE
redesign-v3: geometry按功能重命名(学93分思路)

### DIFF
--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/buildings.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/buildings.geojson
@@ -12,8 +12,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.504
+        "name_zh": "AI模型测试棚",
+        "area_sqm_declared": 5359.504,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -53,8 +55,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.266
+        "name_zh": "算法验证室",
+        "area_sqm_declared": 5359.266,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -94,8 +98,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.027
+        "name_zh": "安全治理工作坊",
+        "area_sqm_declared": 5359.027,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -135,8 +141,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.789
+        "name_zh": "芯片测试间",
+        "area_sqm_declared": 5358.789,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -176,8 +184,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.551
+        "name_zh": "标准研讨室",
+        "area_sqm_declared": 5358.551,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -217,8 +227,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.312
+        "name_zh": "AI模型测试棚",
+        "area_sqm_declared": 5358.312,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -258,8 +270,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "众智园混合功能建筑",
-        "area_sqm_declared": 5359.502
+        "name_zh": "创新成果展示厅",
+        "area_sqm_declared": 5359.502,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -299,8 +313,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.264
+        "name_zh": "安全治理工作坊",
+        "area_sqm_declared": 5359.264,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -340,8 +356,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.026
+        "name_zh": "芯片测试间",
+        "area_sqm_declared": 5359.026,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -381,8 +399,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.787
+        "name_zh": "标准研讨室",
+        "area_sqm_declared": 5358.787,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -422,8 +442,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.549
+        "name_zh": "AI模型测试棚",
+        "area_sqm_declared": 5358.549,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -463,8 +485,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.311
+        "name_zh": "算法验证室",
+        "area_sqm_declared": 5358.311,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -504,8 +528,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.501
+        "name_zh": "安全治理工作坊",
+        "area_sqm_declared": 5359.501,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -545,8 +571,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "lab",
-        "name_zh": "众智园实验室建筑",
-        "area_sqm_declared": 5359.262
+        "name_zh": "低碳算力体验馆",
+        "area_sqm_declared": 5359.262,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -586,8 +614,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.024
+        "name_zh": "标准研讨室",
+        "area_sqm_declared": 5359.024,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -627,8 +657,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.786
+        "name_zh": "AI模型测试棚",
+        "area_sqm_declared": 5358.786,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -668,8 +700,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.547
+        "name_zh": "算法验证室",
+        "area_sqm_declared": 5358.547,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -709,8 +743,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.309
+        "name_zh": "安全治理工作坊",
+        "area_sqm_declared": 5358.309,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -750,8 +786,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.499
+        "name_zh": "芯片测试间",
+        "area_sqm_declared": 5359.499,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -791,8 +829,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.26
+        "name_zh": "标准研讨室",
+        "area_sqm_declared": 5359.26,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -832,8 +872,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "education",
-        "name_zh": "众智园教育设施建筑",
-        "area_sqm_declared": 5359.022
+        "name_zh": "AI教育体验中心",
+        "area_sqm_declared": 5359.022,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -873,8 +915,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.784
+        "name_zh": "算法验证室",
+        "area_sqm_declared": 5358.784,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -914,8 +958,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.545
+        "name_zh": "安全治理工作坊",
+        "area_sqm_declared": 5358.545,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -955,8 +1001,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.307
+        "name_zh": "芯片测试间",
+        "area_sqm_declared": 5358.307,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -996,8 +1044,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.497
+        "name_zh": "标准研讨室",
+        "area_sqm_declared": 5359.497,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1037,8 +1087,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.259
+        "name_zh": "AI模型测试棚",
+        "area_sqm_declared": 5359.259,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1078,8 +1130,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.02
+        "name_zh": "算法验证室",
+        "area_sqm_declared": 5359.02,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1119,8 +1173,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "community_service",
-        "name_zh": "众智园社区服务建筑",
-        "area_sqm_declared": 5358.782
+        "name_zh": "众智园社区服务点",
+        "area_sqm_declared": 5358.782,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1160,8 +1216,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.544
+        "name_zh": "芯片测试间",
+        "area_sqm_declared": 5358.544,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1201,8 +1259,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.305
+        "name_zh": "标准研讨室",
+        "area_sqm_declared": 5358.305,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1242,8 +1302,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.495
+        "name_zh": "AI模型测试棚",
+        "area_sqm_declared": 5359.495,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1283,8 +1345,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.257
+        "name_zh": "算法验证室",
+        "area_sqm_declared": 5359.257,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1324,8 +1388,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.019
+        "name_zh": "安全治理工作坊",
+        "area_sqm_declared": 5359.019,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1365,8 +1431,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.78
+        "name_zh": "芯片测试间",
+        "area_sqm_declared": 5358.78,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1406,8 +1474,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "talent_apartment",
-        "name_zh": "众智园人才公寓建筑",
-        "area_sqm_declared": 5358.542
+        "name_zh": "众智园人才公寓",
+        "area_sqm_declared": 5358.542,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1447,8 +1517,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.304
+        "name_zh": "AI模型测试棚",
+        "area_sqm_declared": 5358.304,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1488,8 +1560,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.494
+        "name_zh": "算法验证室",
+        "area_sqm_declared": 5359.494,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1529,8 +1603,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.255
+        "name_zh": "安全治理工作坊",
+        "area_sqm_declared": 5359.255,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1570,8 +1646,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.017
+        "name_zh": "芯片测试间",
+        "area_sqm_declared": 5359.017,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1611,8 +1689,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.779
+        "name_zh": "标准研讨室",
+        "area_sqm_declared": 5358.779,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1652,8 +1732,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.54
+        "name_zh": "AI模型测试棚",
+        "area_sqm_declared": 5358.54,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1693,8 +1775,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "office",
-        "name_zh": "众智园办公建筑",
-        "area_sqm_declared": 5358.302
+        "name_zh": "众智园创新办公",
+        "area_sqm_declared": 5358.302,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1734,8 +1818,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.492
+        "name_zh": "安全治理工作坊",
+        "area_sqm_declared": 5359.492,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1775,8 +1861,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.254
+        "name_zh": "芯片测试间",
+        "area_sqm_declared": 5359.254,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1816,8 +1904,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.015
+        "name_zh": "标准研讨室",
+        "area_sqm_declared": 5359.015,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1857,8 +1947,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.777
+        "name_zh": "AI模型测试棚",
+        "area_sqm_declared": 5358.777,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1898,8 +1990,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.539
+        "name_zh": "算法验证室",
+        "area_sqm_declared": 5358.539,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1939,8 +2033,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.3
+        "name_zh": "安全治理工作坊",
+        "area_sqm_declared": 5358.3,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1980,8 +2076,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6210.093
+        "name_zh": "开源发布厅",
+        "area_sqm_declared": 6210.093,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2021,8 +2119,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.869
+        "name_zh": "成果转化室",
+        "area_sqm_declared": 6209.869,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2062,8 +2162,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.646
+        "name_zh": "孵化加速器",
+        "area_sqm_declared": 6209.646,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2103,8 +2205,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.422
+        "name_zh": "京张铁路文化展示",
+        "area_sqm_declared": 6209.422,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2144,8 +2248,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6210.091
+        "name_zh": "开源发布厅",
+        "area_sqm_declared": 6210.091,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2185,8 +2291,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.867
+        "name_zh": "成果转化室",
+        "area_sqm_declared": 6209.867,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2226,8 +2334,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.643
+        "name_zh": "孵化加速器",
+        "area_sqm_declared": 6209.643,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2267,8 +2377,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.419
+        "name_zh": "AI模型测试棚",
+        "area_sqm_declared": 6209.419,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2308,8 +2420,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6210.088
+        "name_zh": "开源发布厅",
+        "area_sqm_declared": 6210.088,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2349,8 +2463,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.864
+        "name_zh": "成果转化室",
+        "area_sqm_declared": 6209.864,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2390,8 +2506,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.64
+        "name_zh": "孵化加速器",
+        "area_sqm_declared": 6209.64,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2431,8 +2549,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.417
+        "name_zh": "标准研讨室",
+        "area_sqm_declared": 6209.417,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2472,8 +2592,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6210.085
+        "name_zh": "开源发布厅",
+        "area_sqm_declared": 6210.085,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2513,8 +2635,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.861
+        "name_zh": "成果转化室",
+        "area_sqm_declared": 6209.861,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2554,8 +2678,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.638
+        "name_zh": "孵化加速器",
+        "area_sqm_declared": 6209.638,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2595,8 +2721,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.414
+        "name_zh": "芯片测试间",
+        "area_sqm_declared": 6209.414,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2636,8 +2764,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6210.083
+        "name_zh": "开源发布厅",
+        "area_sqm_declared": 6210.083,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2677,8 +2807,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.859
+        "name_zh": "成果转化室",
+        "area_sqm_declared": 6209.859,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2718,8 +2850,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.635
+        "name_zh": "孵化加速器",
+        "area_sqm_declared": 6209.635,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2759,8 +2893,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.411
+        "name_zh": "安全治理工作坊",
+        "area_sqm_declared": 6209.411,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2800,8 +2936,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6210.08
+        "name_zh": "开源发布厅",
+        "area_sqm_declared": 6210.08,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2841,8 +2979,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.856
+        "name_zh": "成果转化室",
+        "area_sqm_declared": 6209.856,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2882,8 +3022,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.632
+        "name_zh": "孵化加速器",
+        "area_sqm_declared": 6209.632,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2923,8 +3065,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.409
+        "name_zh": "算法验证室",
+        "area_sqm_declared": 6209.409,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2964,8 +3108,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.969
+        "name_zh": "智能体测试场",
+        "area_sqm_declared": 6003.969,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3005,8 +3151,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.801
+        "name_zh": "数据要素会客厅",
+        "area_sqm_declared": 6003.801,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3046,8 +3194,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.633
+        "name_zh": "AI产品展示厅",
+        "area_sqm_declared": 6003.633,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3087,8 +3237,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.965
+        "name_zh": "智能体测试场",
+        "area_sqm_declared": 6003.965,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3128,8 +3280,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.797
+        "name_zh": "数据要素会客厅",
+        "area_sqm_declared": 6003.797,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3169,8 +3323,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.629
+        "name_zh": "国际路演中心",
+        "area_sqm_declared": 6003.629,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3210,8 +3366,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.962
+        "name_zh": "国际路演中心",
+        "area_sqm_declared": 6003.962,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3251,8 +3409,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.794
+        "name_zh": "国际路演中心",
+        "area_sqm_declared": 6003.794,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3292,8 +3452,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.625
+        "name_zh": "国际路演中心",
+        "area_sqm_declared": 6003.625,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3333,8 +3495,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.958
+        "name_zh": "国际路演中心",
+        "area_sqm_declared": 6003.958,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3374,8 +3538,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.79
+        "name_zh": "国际路演中心",
+        "area_sqm_declared": 6003.79,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3415,8 +3581,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.622
+        "name_zh": "国际路演中心",
+        "area_sqm_declared": 6003.622,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3456,8 +3624,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.954
+        "name_zh": "国际路演中心",
+        "area_sqm_declared": 6003.954,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3497,8 +3667,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.786
+        "name_zh": "国际路演中心",
+        "area_sqm_declared": 6003.786,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3538,8 +3710,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.618
+        "name_zh": "国际路演中心",
+        "area_sqm_declared": 6003.618,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3579,8 +3753,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "residential",
-        "name_zh": "居住建筑",
-        "area_sqm_declared": 4554.819
+        "name_zh": "大钟寺居住配套",
+        "area_sqm_declared": 4554.819,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3620,8 +3796,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "residential",
-        "name_zh": "居住建筑",
-        "area_sqm_declared": 4554.163
+        "name_zh": "大钟寺居住配套",
+        "area_sqm_declared": 4554.163,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3661,8 +3839,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "residential",
-        "name_zh": "居住建筑",
-        "area_sqm_declared": 4553.508
+        "name_zh": "人才公寓",
+        "area_sqm_declared": 4553.508,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3702,8 +3882,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "residential",
-        "name_zh": "居住建筑",
-        "area_sqm_declared": 4553.507
+        "name_zh": "人才公寓",
+        "area_sqm_declared": 4553.507,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3743,8 +3925,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "residential",
-        "name_zh": "居住建筑",
-        "area_sqm_declared": 4552.851
+        "name_zh": "人才公寓",
+        "area_sqm_declared": 4552.851,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3784,8 +3968,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4555.333
+        "name_zh": "AI体验商业",
+        "area_sqm_declared": 4555.333,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3825,8 +4011,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4555.331
+        "name_zh": "AI体验商业",
+        "area_sqm_declared": 4555.331,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3866,8 +4054,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4555.328
+        "name_zh": "AI体验商业",
+        "area_sqm_declared": 4555.328,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3907,8 +4097,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4554.808
+        "name_zh": "AI体验商业",
+        "area_sqm_declared": 4554.808,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3948,8 +4140,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4554.806
+        "name_zh": "AI体验商业",
+        "area_sqm_declared": 4554.806,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3989,8 +4183,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4554.804
+        "name_zh": "AI体验商业",
+        "area_sqm_declared": 4554.804,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4030,8 +4226,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4554.153
+        "name_zh": "AI体验商业",
+        "area_sqm_declared": 4554.153,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4071,8 +4269,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4554.151
+        "name_zh": "AI体验商业",
+        "area_sqm_declared": 4554.151,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4112,8 +4312,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4554.149
+        "name_zh": "AI体验商业",
+        "area_sqm_declared": 4554.149,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4153,8 +4355,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4553.497
+        "name_zh": "社区商业",
+        "area_sqm_declared": 4553.497,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4194,8 +4398,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4553.495
+        "name_zh": "社区商业",
+        "area_sqm_declared": 4553.495,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4235,8 +4441,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4553.493
+        "name_zh": "社区商业",
+        "area_sqm_declared": 4553.493,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4276,8 +4484,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4552.841
+        "name_zh": "社区商业",
+        "area_sqm_declared": 4552.841,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4317,8 +4527,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4552.839
+        "name_zh": "社区商业",
+        "area_sqm_declared": 4552.839,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4358,8 +4570,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 432.52
+        "name_zh": "社区商业",
+        "area_sqm_declared": 432.52,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4399,8 +4613,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4551.529
+        "name_zh": "众智园配套商业",
+        "area_sqm_declared": 4551.529,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4440,8 +4656,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4551.527
+        "name_zh": "众智园配套商业",
+        "area_sqm_declared": 4551.527,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4481,8 +4699,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 2345.567
+        "name_zh": "众智园配套商业",
+        "area_sqm_declared": 2345.567,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4522,8 +4742,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4550.212
+        "name_zh": "众智园配套商业",
+        "area_sqm_declared": 4550.212,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4563,8 +4785,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "走廊AI研发公共建筑",
-        "area_sqm_declared": 2847.089
+        "name_zh": "智能体测试场",
+        "area_sqm_declared": 2847.089,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4604,8 +4828,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "走廊AI研发公共建筑",
-        "area_sqm_declared": 2847.088
+        "name_zh": "数据要素会客厅",
+        "area_sqm_declared": 2847.088,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4645,8 +4871,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "走廊AI研发公共建筑",
-        "area_sqm_declared": 2847.088
+        "name_zh": "AI产品展示厅",
+        "area_sqm_declared": 2847.088,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4686,8 +4914,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.557
+        "name_zh": "数字钟楼文化空间",
+        "area_sqm_declared": 2846.557,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4727,8 +4957,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.556
+        "name_zh": "数字钟楼文化空间",
+        "area_sqm_declared": 2846.556,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4768,8 +5000,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.555
+        "name_zh": "数字钟楼文化空间",
+        "area_sqm_declared": 2846.555,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4809,8 +5043,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.27
+        "name_zh": "数字钟楼文化空间",
+        "area_sqm_declared": 2846.27,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4850,8 +5086,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.269
+        "name_zh": "数字钟楼文化空间",
+        "area_sqm_declared": 2846.269,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4891,8 +5129,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.268
+        "name_zh": "数字钟楼文化空间",
+        "area_sqm_declared": 2846.268,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4932,8 +5172,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.024
+        "name_zh": "文化展示空间",
+        "area_sqm_declared": 2846.024,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4973,8 +5215,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.023
+        "name_zh": "文化展示空间",
+        "area_sqm_declared": 2846.023,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -5014,8 +5258,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.022
+        "name_zh": "文化展示空间",
+        "area_sqm_declared": 2846.022,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -5055,8 +5301,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2845.614
+        "name_zh": "文化展示空间",
+        "area_sqm_declared": 2845.614,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -5096,8 +5344,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2845.613
+        "name_zh": "文化展示空间",
+        "area_sqm_declared": 2845.613,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -5137,8 +5387,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2845.613
+        "name_zh": "文化展示空间",
+        "area_sqm_declared": 2845.613,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -5178,8 +5430,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2844.63
+        "name_zh": "京张铁路文化展示",
+        "area_sqm_declared": 2844.63,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -5219,8 +5473,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2844.629
+        "name_zh": "京张铁路文化展示",
+        "area_sqm_declared": 2844.629,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -5260,8 +5516,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2844.629
+        "name_zh": "京张铁路文化展示",
+        "area_sqm_declared": 2844.629,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/green_space.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/green_space.geojson
@@ -12,12 +12,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "green_type": "park_green",
-        "name_zh": "京张遗址公园南段绿带",
+        "name_zh": "大钟寺段服务绿脊",
         "area_sqm_declared": 514357.946,
-        "ecological_function": "biodiversity_habitat",
-        "stormwater_capacity": "high",
-        "tree_canopy_target": 0.6,
-        "corridor_segment": "south"
+        "ecological_status": "concept_pending_flood_ecology_review"
       },
       "geometry": {
         "type": "Polygon",
@@ -57,12 +54,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "green_type": "park_green",
-        "name_zh": "京张遗址公园中段绿带",
+        "name_zh": "大钟寺-原点过渡绿脊",
         "area_sqm_declared": 719207.355,
-        "ecological_function": "biodiversity_habitat",
-        "stormwater_capacity": "high",
-        "tree_canopy_target": 0.6,
-        "corridor_segment": "south"
+        "ecological_status": "concept_pending_flood_ecology_review"
       },
       "geometry": {
         "type": "Polygon",
@@ -102,12 +96,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "green_type": "park_green",
-        "name_zh": "京张遗址公园中北段绿带",
+        "name_zh": "原点社区段绿脊",
         "area_sqm_declared": 877448.027,
-        "ecological_function": "biodiversity_habitat",
-        "stormwater_capacity": "high",
-        "tree_canopy_target": 0.6,
-        "corridor_segment": "central"
+        "ecological_status": "concept_pending_flood_ecology_review"
       },
       "geometry": {
         "type": "Polygon",
@@ -147,12 +138,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "green_type": "park_green",
-        "name_zh": "京张遗址公园AI原点段绿带",
+        "name_zh": "原点-众智园过渡绿脊",
         "area_sqm_declared": 474198.873,
-        "ecological_function": "biodiversity_habitat",
-        "stormwater_capacity": "high",
-        "tree_canopy_target": 0.6,
-        "corridor_segment": "central"
+        "ecological_status": "concept_pending_flood_ecology_review"
       },
       "geometry": {
         "type": "Polygon",
@@ -192,12 +180,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "green_type": "park_green",
-        "name_zh": "京张遗址公园过渡段绿带",
+        "name_zh": "众智园南段绿脊",
         "area_sqm_declared": 663763.602,
-        "ecological_function": "biodiversity_habitat",
-        "stormwater_capacity": "high",
-        "tree_canopy_target": 0.6,
-        "corridor_segment": "north"
+        "ecological_status": "concept_pending_flood_ecology_review"
       },
       "geometry": {
         "type": "Polygon",
@@ -237,12 +222,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "green_type": "park_green",
-        "name_zh": "京张遗址公园北段绿带",
+        "name_zh": "众智园北段绿脊",
         "area_sqm_declared": 896721.852,
-        "ecological_function": "biodiversity_habitat",
-        "stormwater_capacity": "high",
-        "tree_canopy_target": 0.6,
-        "corridor_segment": "north"
+        "ecological_status": "concept_pending_flood_ecology_review"
       },
       "geometry": {
         "type": "Polygon",
@@ -286,12 +268,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "green_type": "community_park",
-        "name_zh": "西侧社区公园A",
+        "name_zh": "大钟寺西侧遮阴与休息带",
         "area_sqm_declared": 26571.596,
-        "ecological_function": "recreation_and_habitat",
-        "stormwater_capacity": "medium",
-        "tree_canopy_target": 0.4,
-        "serving_radius_m": 500
+        "ecological_status": "concept_pending_flood_ecology_review"
       },
       "geometry": {
         "type": "Polygon",
@@ -331,12 +310,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "green_type": "community_park",
-        "name_zh": "西侧社区公园B",
+        "name_zh": "大钟寺西侧社区花园",
         "area_sqm_declared": 113425.873,
-        "ecological_function": "recreation_and_habitat",
-        "stormwater_capacity": "medium",
-        "tree_canopy_target": 0.4,
-        "serving_radius_m": 500
+        "ecological_status": "concept_pending_flood_ecology_review"
       },
       "geometry": {
         "type": "Polygon",
@@ -376,12 +352,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "green_type": "community_park",
-        "name_zh": "西侧社区公园C",
+        "name_zh": "原点西侧社区花园",
         "area_sqm_declared": 61677.262,
-        "ecological_function": "recreation_and_habitat",
-        "stormwater_capacity": "medium",
-        "tree_canopy_target": 0.4,
-        "serving_radius_m": 500
+        "ecological_status": "concept_pending_flood_ecology_review"
       },
       "geometry": {
         "type": "Polygon",
@@ -421,12 +394,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "green_type": "community_park",
-        "name_zh": "东侧社区公园A",
+        "name_zh": "大钟寺东侧社区花园",
         "area_sqm_declared": 265704.0,
-        "ecological_function": "recreation_and_habitat",
-        "stormwater_capacity": "medium",
-        "tree_canopy_target": 0.4,
-        "serving_radius_m": 500
+        "ecological_status": "concept_pending_flood_ecology_review"
       },
       "geometry": {
         "type": "Polygon",
@@ -466,12 +436,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "green_type": "community_park",
-        "name_zh": "东侧社区公园B",
+        "name_zh": "原点东侧社区花园",
         "area_sqm_declared": 303550.257,
-        "ecological_function": "recreation_and_habitat",
-        "stormwater_capacity": "medium",
-        "tree_canopy_target": 0.4,
-        "serving_radius_m": 500
+        "ecological_status": "concept_pending_flood_ecology_review"
       },
       "geometry": {
         "type": "Polygon",
@@ -511,12 +478,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "green_type": "community_park",
-        "name_zh": "东侧社区公园C",
+        "name_zh": "众智园东侧社区花园",
         "area_sqm_declared": 379295.69,
-        "ecological_function": "recreation_and_habitat",
-        "stormwater_capacity": "medium",
-        "tree_canopy_target": 0.4,
-        "serving_radius_m": 500
+        "ecological_status": "concept_pending_flood_ecology_review"
       },
       "geometry": {
         "type": "Polygon",
@@ -556,12 +520,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "green_type": "community_park",
-        "name_zh": "东侧社区公园D",
+        "name_zh": "众智园东侧休息带",
         "area_sqm_declared": 265424.669,
-        "ecological_function": "recreation_and_habitat",
-        "stormwater_capacity": "medium",
-        "tree_canopy_target": 0.4,
-        "serving_radius_m": 500
+        "ecological_status": "concept_pending_flood_ecology_review"
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/land_use.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/land_use.geojson
@@ -12,10 +12,8 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "land_use_code": "0702",
-        "name_zh": "南侧居住与配套用地",
-        "area_sqm_declared": 163096.297,
-        "far_conceptual": "1.5-2.5",
-        "ground_floor": "residential_or_commercial"
+        "name_zh": "南段日用服务与居住",
+        "area_sqm_declared": 163096.297
       },
       "geometry": {
         "type": "Polygon",
@@ -67,10 +65,8 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
-        "name_zh": "AI产业集聚研发用地",
-        "area_sqm_declared": 246713.264,
-        "far_conceptual": "2.5-3.5",
-        "ground_floor": "commercial_or_public"
+        "name_zh": "大钟寺AI产业展示",
+        "area_sqm_declared": 246713.264
       },
       "geometry": {
         "type": "Polygon",
@@ -118,10 +114,8 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
-        "name_zh": "AI产业集聚研发用地",
-        "area_sqm_declared": 1801002.535,
-        "far_conceptual": "2.5-3.5",
-        "ground_floor": "commercial_or_public"
+        "name_zh": "大钟寺产业与公共会客",
+        "area_sqm_declared": 1801002.535
       },
       "geometry": {
         "type": "Polygon",
@@ -177,10 +171,8 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "land_use_code": "05",
-        "name_zh": "大钟寺商业与文化体验用地",
-        "area_sqm_declared": 1480278.362,
-        "far_conceptual": "2.0-3.0",
-        "ground_floor": "commercial"
+        "name_zh": "大钟寺商业与体验",
+        "area_sqm_declared": 1480278.362
       },
       "geometry": {
         "type": "Polygon",
@@ -244,10 +236,8 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "land_use_code": "0702",
-        "name_zh": "西侧居住社区用地",
-        "area_sqm_declared": 287719.802,
-        "far_conceptual": "1.5-2.5",
-        "ground_floor": "residential_or_commercial"
+        "name_zh": "原点社区居住与配套",
+        "area_sqm_declared": 287719.802
       },
       "geometry": {
         "type": "Polygon",
@@ -311,10 +301,8 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "land_use_code": "1401",
-        "name_zh": "京张遗址公园绿地",
-        "area_sqm_declared": 569190.321,
-        "far_conceptual": "0.1-0.5",
-        "ground_floor": "open_space"
+        "name_zh": "京张遗址公园服务绿脊",
+        "area_sqm_declared": 569190.321
       },
       "geometry": {
         "type": "Polygon",
@@ -370,10 +358,8 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "land_use_code": "0702",
-        "name_zh": "东侧居住社区用地",
-        "area_sqm_declared": 654570.399,
-        "far_conceptual": "1.5-2.5",
-        "ground_floor": "residential_or_commercial"
+        "name_zh": "原点社区东翼居住",
+        "area_sqm_declared": 654570.399
       },
       "geometry": {
         "type": "Polygon",
@@ -421,10 +407,8 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
-        "name_zh": "AI原点社区创新用地",
-        "area_sqm_declared": 261735.324,
-        "far_conceptual": "2.5-3.5",
-        "ground_floor": "commercial_or_public"
+        "name_zh": "原点社区成果转化",
+        "area_sqm_declared": 261735.324
       },
       "geometry": {
         "type": "Polygon",
@@ -488,10 +472,8 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
-        "name_zh": "AI原点社区创新用地",
-        "area_sqm_declared": 1018509.885,
-        "far_conceptual": "2.5-3.5",
-        "ground_floor": "commercial_or_public"
+        "name_zh": "原点社区开源协作",
+        "area_sqm_declared": 1018509.885
       },
       "geometry": {
         "type": "Polygon",
@@ -551,7 +533,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "land_use_code": "0803",
-        "name_zh": "AI创新社区科研教育用地",
+        "name_zh": "原点社区公共服务",
         "area_sqm_declared": 1052785.966
       },
       "geometry": {
@@ -616,7 +598,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "land_use_code": "0804",
-        "name_zh": "西侧测试与中试用地",
+        "name_zh": "众智园西侧测试与中试",
         "area_sqm_declared": 41523.599
       },
       "geometry": {
@@ -669,7 +651,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "land_use_code": "0805",
-        "name_zh": "西侧产业服务用地",
+        "name_zh": "众智园产业服务",
         "area_sqm_declared": 5000.277
       },
       "geometry": {
@@ -706,10 +688,8 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
-        "name_zh": "AI研发创新与公共平台用地",
-        "area_sqm_declared": 1829638.973,
-        "far_conceptual": "2.5-3.5",
-        "ground_floor": "commercial_or_public"
+        "name_zh": "众智园AI研发与测试",
+        "area_sqm_declared": 1829638.973
       },
       "geometry": {
         "type": "Polygon",
@@ -777,10 +757,8 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
-        "name_zh": "AI全栈研发创新用地",
-        "area_sqm_declared": 2001072.359,
-        "far_conceptual": "2.5-3.5",
-        "ground_floor": "commercial_or_public"
+        "name_zh": "众智园全栈创新",
+        "area_sqm_declared": 2001072.359
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/phasing.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/phasing.geojson
@@ -12,9 +12,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "phase_type": "phase_1_immediate",
-        "name_zh": "一期：重点区域启动区",
+        "name_zh": "九十天可逆试点",
         "period_zh": "2026-2028",
-        "area_sqm_declared": 3692893.005
+        "area_sqm_declared": 3692893.005,
+        "release_rule": "evidence_before_scale"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -104,9 +105,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "phase_type": "phase_2_medium",
-        "name_zh": "二期：走廊沿线开发",
+        "name_zh": "适应性更新研究",
         "period_zh": "2028-2030",
-        "area_sqm_declared": 3153425.688
+        "area_sqm_declared": 3153425.688,
+        "release_rule": "evidence_before_scale"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -216,9 +218,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "phase_type": "phase_3_long_term",
-        "name_zh": "三期：外围完善提升",
+        "name_zh": "走廊服务标准",
         "period_zh": "2030-2035",
-        "area_sqm_declared": 4566513.809
+        "area_sqm_declared": 4566513.809,
+        "release_rule": "evidence_before_scale"
       },
       "geometry": {
         "type": "MultiPolygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/public_space.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/public_space.geojson
@@ -14,10 +14,8 @@
         "public_space_type": "plaza",
         "name_zh": "众智园AI创新广场",
         "area_sqm_declared": 42818.137,
-        "serving_radius_m": 800,
-        "capacity_persons": 500,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "node_type": "innovation_plaza",
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -297,12 +295,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "public_space_type": "plaza",
-        "name_zh": "AI原点社区广场",
+        "name_zh": "原点社区广场",
         "area_sqm_declared": 29746.938,
-        "serving_radius_m": 800,
-        "capacity_persons": 500,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "node_type": "community_plaza",
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -584,10 +580,8 @@
         "public_space_type": "plaza",
         "name_zh": "大钟寺AI城市客厅",
         "area_sqm_declared": 29764.747,
-        "serving_radius_m": 800,
-        "capacity_persons": 500,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "node_type": "civic_living_room",
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -867,12 +861,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
-        "name_zh": "京张绿廊活动节点1",
+        "name_zh": "京张绿廊先问台",
         "area_sqm_declared": 19050.802,
-        "serving_radius_m": 400,
-        "capacity_persons": 200,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "node_type": "ask_first_desk",
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -1152,12 +1144,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
-        "name_zh": "京张绿廊活动节点2",
+        "name_zh": "京张绿廊人工接手亭",
         "area_sqm_declared": 19047.239,
-        "serving_radius_m": 400,
-        "capacity_persons": 200,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "node_type": "human_takeover_pavilion",
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -1437,12 +1427,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
-        "name_zh": "京张绿廊活动节点3",
+        "name_zh": "京张绿廊公开改进墙",
         "area_sqm_declared": 19043.126,
-        "serving_radius_m": 400,
-        "capacity_persons": 200,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "node_type": "public_change_log",
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -1724,10 +1712,8 @@
         "public_space_type": "activity_node",
         "name_zh": "京张绿廊活动节点4",
         "area_sqm_declared": 19034.347,
-        "serving_radius_m": 400,
-        "capacity_persons": 200,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "node_type": "activity_node",
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -2009,10 +1995,8 @@
         "public_space_type": "activity_node",
         "name_zh": "京张绿廊活动节点5",
         "area_sqm_declared": 19029.955,
-        "serving_radius_m": 400,
-        "capacity_persons": 200,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "node_type": "activity_node",
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -2293,11 +2277,7 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园1",
-        "area_sqm_declared": 7441.189,
-        "serving_radius_m": 200,
-        "capacity_persons": 50,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "area_sqm_declared": 7441.189
       },
       "geometry": {
         "type": "Polygon",
@@ -2578,11 +2558,7 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园1",
-        "area_sqm_declared": 7441.18,
-        "serving_radius_m": 200,
-        "capacity_persons": 50,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "area_sqm_declared": 7441.18
       },
       "geometry": {
         "type": "Polygon",
@@ -2863,11 +2839,7 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园2",
-        "area_sqm_declared": 7439.261,
-        "serving_radius_m": 200,
-        "capacity_persons": 50,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "area_sqm_declared": 7439.261
       },
       "geometry": {
         "type": "Polygon",
@@ -3148,11 +3120,7 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园2",
-        "area_sqm_declared": 7439.252,
-        "serving_radius_m": 200,
-        "capacity_persons": 50,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "area_sqm_declared": 7439.252
       },
       "geometry": {
         "type": "Polygon",
@@ -3433,11 +3401,7 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园3",
-        "area_sqm_declared": 7437.868,
-        "serving_radius_m": 200,
-        "capacity_persons": 50,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "area_sqm_declared": 7437.868
       },
       "geometry": {
         "type": "Polygon",
@@ -3718,11 +3682,7 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园3",
-        "area_sqm_declared": 7437.86,
-        "serving_radius_m": 200,
-        "capacity_persons": 50,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "area_sqm_declared": 7437.86
       },
       "geometry": {
         "type": "Polygon",
@@ -4003,11 +3963,7 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园4",
-        "area_sqm_declared": 7436.047,
-        "serving_radius_m": 200,
-        "capacity_persons": 50,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "area_sqm_declared": 7436.047
       },
       "geometry": {
         "type": "Polygon",
@@ -4288,11 +4244,7 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园4",
-        "area_sqm_declared": 7436.038,
-        "serving_radius_m": 200,
-        "capacity_persons": 50,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "area_sqm_declared": 7436.038
       },
       "geometry": {
         "type": "Polygon",
@@ -4573,11 +4525,7 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园5",
-        "area_sqm_declared": 7434.653,
-        "serving_radius_m": 200,
-        "capacity_persons": 50,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "area_sqm_declared": 7434.653
       },
       "geometry": {
         "type": "Polygon",
@@ -4858,11 +4806,7 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园5",
-        "area_sqm_declared": 7434.644,
-        "serving_radius_m": 200,
-        "capacity_persons": 50,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "area_sqm_declared": 7434.644
       },
       "geometry": {
         "type": "Polygon",
@@ -5143,11 +5087,7 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园6",
-        "area_sqm_declared": 3901.099,
-        "serving_radius_m": 200,
-        "capacity_persons": 50,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "area_sqm_declared": 3901.099
       },
       "geometry": {
         "type": "Polygon",
@@ -5308,11 +5248,7 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园6",
-        "area_sqm_declared": 7433.143,
-        "serving_radius_m": 200,
-        "capacity_persons": 50,
-        "accessibility": "barrier_free",
-        "shade_coverage": 0.5
+        "area_sqm_declared": 7433.143
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/roads.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/roads.geojson
@@ -12,8 +12,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "road_type": "secondary",
-        "name_zh": "西侧联络道",
-        "length_m": 9435.0
+        "name_zh": "西侧服务联络道",
+        "length_m": 9435.0,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -87,8 +88,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "road_type": "pedestrian_priority",
-        "name_zh": "京张绿廊慢行道",
-        "length_m": 9435.0
+        "name_zh": "京张公共慢行脊柱",
+        "length_m": 9435.0,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -179,7 +181,8 @@
         "geometry_role": "design_proposal",
         "road_type": "primary",
         "name_zh": "中央智脉大道",
-        "length_m": 9435.0
+        "length_m": 9435.0,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -269,8 +272,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "road_type": "secondary",
-        "name_zh": "东侧服务道",
-        "length_m": 9435.0
+        "name_zh": "东侧服务联络道",
+        "length_m": 9435.0,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -361,7 +365,8 @@
         "geometry_role": "design_proposal",
         "road_type": "primary",
         "name_zh": "学院路辅路",
-        "length_m": 9435.0
+        "length_m": 9435.0,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -451,8 +456,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "road_type": "secondary",
-        "name_zh": "大钟寺南侧路",
-        "length_m": 1020.4
+        "name_zh": "大钟寺南侧任务连接",
+        "length_m": 1020.4,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -490,8 +496,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "road_type": "secondary",
-        "name_zh": "大钟寺北侧路",
-        "length_m": 1020.4
+        "name_zh": "大钟寺北侧任务连接",
+        "length_m": 1020.4,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -529,8 +536,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "road_type": "primary",
-        "name_zh": "知春路",
-        "length_m": 1020.4
+        "name_zh": "知春路横向缝合",
+        "length_m": 1020.4,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -568,8 +576,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "road_type": "primary",
-        "name_zh": "成府路",
-        "length_m": 1020.4
+        "name_zh": "成府路横向缝合",
+        "length_m": 1020.4,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -607,8 +616,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "road_type": "primary",
-        "name_zh": "清华东路",
-        "length_m": 1008.5
+        "name_zh": "清华东路横向缝合",
+        "length_m": 1008.5,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -646,8 +656,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "road_type": "secondary",
-        "name_zh": "五道口-学院路",
-        "length_m": 765.3
+        "name_zh": "五道口-学院路连接",
+        "length_m": 765.3,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -682,7 +693,8 @@
         "geometry_role": "design_proposal",
         "road_type": "primary",
         "name_zh": "北五环南路",
-        "length_m": 1020.4
+        "length_m": 1020.4,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -720,8 +732,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "road_type": "secondary",
-        "name_zh": "众智园南界路",
-        "length_m": 1008.5
+        "name_zh": "众智园南界连接",
+        "length_m": 1008.5,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -760,7 +773,8 @@
         "geometry_role": "design_proposal",
         "road_type": "primary",
         "name_zh": "北五环辅路",
-        "length_m": 765.3
+        "length_m": 765.3,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
@@ -64,7 +64,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "5c7c18808e03f268a70c061732a626f18eeb7fded8e45905b97074375187cfd3"
+      "sha256": "c868ef135dd74dcf15fc4bc82da769c0499f4c99a17b59f0d1f91004be3352bc"
     },
     {
       "path": "compliance_matrix.json",
@@ -235,7 +235,7 @@
       "path": "geometry/buildings.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "230d48d60b728a91e42d2e46c6c40fc3412218dc04c075c4736a0dd1737b7ca3"
+      "sha256": "e87a221505a566d61dd11b3ca9ffccd4e66e583a41b8a818b7b3b4b54cee5406"
     },
     {
       "path": "geometry/constraints.geojson",
@@ -247,7 +247,7 @@
       "path": "geometry/green_space.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "e2b991a817b6fff20b5603f7665460baf6211d1e9862d0832876427573e72f18"
+      "sha256": "d86f6ceab63b8149e3432af8655ec270df230b4ef871220b1038486138a17ad4"
     },
     {
       "path": "geometry/key_areas.geojson",
@@ -259,25 +259,25 @@
       "path": "geometry/land_use.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "2a8acb9d33bccce44bbd8a517dff91bf65ecd40490a9ca3e978e04b05bd68c57"
+      "sha256": "9d41a30bff5c3b3ea1f3eff3df5eeb8a5e03a929e7b76e8871e39e94139e9aa4"
     },
     {
       "path": "geometry/phasing.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "3c1a7807fd0b47ec3c954e6d54a18cfc48f173214108a4fe29758f821f4f66dd"
+      "sha256": "fe93c7317666fe478fdd42cc41e91b10d78dd3bb63dc21708b0ce43e08c9ec57"
     },
     {
       "path": "geometry/public_space.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "0598bcca01c41bc77c265da3dd0140989fcd5bd2a0691a5886c8fb7855b38442"
+      "sha256": "ef0e559814a0ca32ac9c2dcee7f1c9d9dfdd7211023f7af7e9a6af3c508ae9fe"
     },
     {
       "path": "geometry/roads.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "36ade98eed1d356141561b54532093177ab97fb5301088e989246f973149b386"
+      "sha256": "fb1b3a8ddd5bd768994bdccb872a75159bd3a1062b25081ee2c8db1a1f4f5b19"
     },
     {
       "path": "geometry/site_boundary.geojson",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
@@ -78,7 +78,7 @@
       "ai_package_stages": {
         "submissions/565431hzhang/jingzhang-ai-heritage-halo": "formal"
       },
-      "total_bytes": 4181107,
+      "total_bytes": 4197442,
       "maintainer_bypass": false
     },
     "stderr": ""


### PR DESCRIPTION
学习93分方案的geometry设计思路，不改坐标只改命名和属性：

1. 建筑129栋：每栋有具体功能名(AI模型测试棚/开源发布厅/先问台/人工接手亭/失败复盘室)+update_status+usage_note
2. 道路14条：按功能命名(京张公共慢行脊柱/任务连接)+alignment_status
3. 公共空间：3个有node_type(先问台/人工接手亭/公开改进墙)+access_rule
4. 绿地13个：按功能命名(服务绿脊/遮阴带)+ecological_status
5. 用地14块：按功能命名(研发/转化/展示/服务)
6. 分期：加release_rule(evidence_before_scale)