### PR TITLE
fix: reject corrupt PNG submission assets

### DIFF
--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -13,7 +13,9 @@ import json
 import math
 import os
 import re
+import struct
 import sys
+import zlib
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Iterable
@@ -301,6 +303,8 @@ MAX_AUDIO_BYTES = 8 * 1024 * 1024
 MAX_DRAWING_BYTES = 10 * 1024 * 1024
 MAX_HTML_BYTES = 2 * 1024 * 1024
 MAX_VISUAL_ASSET_BYTES = 5 * 1024 * 1024
+MAX_PNG_INFLATED_BYTES = 128 * 1024 * 1024
+MAX_TOTAL_PNG_INFLATED_BYTES = 1024 * 1024 * 1024
 MAX_SINGLE_FILE_BYTES = max(
     MAX_MARKDOWN_BYTES,
     MAX_JSON_BYTES,
@@ -380,6 +384,7 @@ class ValidationReport:
     changed_files: list[str] = field(default_factory=list)
     ai_package_stages: dict[str, str] = field(default_factory=dict)
     total_bytes: int = 0
+    png_inflated_bytes: int = 0
     maintainer_bypass: bool = False
     strict_manifest_paths: set[str] = field(default_factory=set)
 
@@ -719,6 +724,232 @@ def media_signature_is_valid(path: Path) -> bool:
     if extension == ".ogg":
         return data.startswith(b"OggS")
     return True
+
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+PNG_VALID_BIT_DEPTHS = {
+    0: {1, 2, 4, 8, 16},
+    2: {8, 16},
+    3: {1, 2, 4, 8},
+    4: {8, 16},
+    6: {8, 16},
+}
+PNG_CHANNELS = {0: 1, 2: 3, 3: 1, 4: 2, 6: 4}
+PNG_ADAM7_PASSES = (
+    (0, 0, 8, 8),
+    (4, 0, 8, 8),
+    (0, 4, 4, 8),
+    (2, 0, 4, 4),
+    (0, 2, 2, 4),
+    (1, 0, 2, 2),
+    (0, 1, 1, 2),
+)
+
+
+def _png_row_payload_sizes(
+    width: int, height: int, bit_depth: int, color_type: int, interlace: int
+) -> Iterable[int]:
+    channels = PNG_CHANNELS[color_type]
+    if interlace == 0:
+        row_bytes = (width * channels * bit_depth + 7) // 8
+        for _ in range(height):
+            yield row_bytes
+        return
+    for x_start, y_start, x_step, y_step in PNG_ADAM7_PASSES:
+        if width <= x_start or height <= y_start:
+            continue
+        pass_width = (width - x_start + x_step - 1) // x_step
+        pass_height = (height - y_start + y_step - 1) // y_step
+        row_bytes = (pass_width * channels * bit_depth + 7) // 8
+        for _ in range(pass_height):
+            yield row_bytes
+
+
+def png_integrity_result(
+    path: Path, *, max_inflated_bytes: int = MAX_PNG_INFLATED_BYTES
+) -> tuple[str | None, int]:
+    """Return an integrity error and decoded byte count for a PNG."""
+    try:
+        if path.stat().st_size > MAX_ASSET_BYTES:
+            return f"file exceeds the {MAX_ASSET_BYTES}-byte PNG validation limit", 0
+        raw = path.read_bytes()
+    except OSError as exc:
+        return f"cannot read file: {exc}", 0
+    if not raw.startswith(PNG_SIGNATURE):
+        return "signature is invalid", 0
+
+    offset = len(PNG_SIGNATURE)
+    ihdr: tuple[int, int, int, int, int] | None = None
+    idat_parts: list[bytes] = []
+    seen_plte = False
+    seen_iend = False
+    idat_ended = False
+    while offset < len(raw):
+        if len(raw) - offset < 12:
+            return "chunk header or checksum is truncated", 0
+        length = struct.unpack(">I", raw[offset : offset + 4])[0]
+        chunk_type = raw[offset + 4 : offset + 8]
+        if not all(65 <= byte <= 90 or 97 <= byte <= 122 for byte in chunk_type) or not (
+            65 <= chunk_type[2] <= 90
+        ):
+            return "chunk type is invalid", 0
+        chunk_end = offset + 12 + length
+        if chunk_end > len(raw):
+            return f"{chunk_type.decode('ascii')} chunk is truncated", 0
+        payload = raw[offset + 8 : offset + 8 + length]
+        declared_crc = struct.unpack(">I", raw[offset + 8 + length : chunk_end])[0]
+        actual_crc = zlib.crc32(chunk_type)
+        actual_crc = zlib.crc32(payload, actual_crc) & 0xFFFFFFFF
+        if declared_crc != actual_crc:
+            return f"{chunk_type.decode('ascii')} chunk checksum is invalid", 0
+
+        if offset == len(PNG_SIGNATURE) and chunk_type != b"IHDR":
+            return "IHDR is not the first chunk", 0
+        if 65 <= chunk_type[0] <= 90 and chunk_type not in {b"IHDR", b"PLTE", b"IDAT", b"IEND"}:
+            return f"unknown critical chunk {chunk_type.decode('ascii')}", 0
+        if chunk_type == b"IHDR":
+            if ihdr is not None:
+                return "contains more than one IHDR chunk", 0
+            if length != 13:
+                return "IHDR chunk has an invalid length", 0
+            width, height, bit_depth, color_type, compression, filtering, interlace = struct.unpack(
+                ">IIBBBBB", payload
+            )
+            if width == 0 or height == 0:
+                return "IHDR declares a zero dimension", 0
+            if bit_depth not in PNG_VALID_BIT_DEPTHS.get(color_type, set()):
+                return "IHDR declares an invalid color type or bit depth", 0
+            if compression != 0 or filtering != 0 or interlace not in {0, 1}:
+                return "IHDR declares an unsupported compression, filter, or interlace method", 0
+            ihdr = (width, height, bit_depth, color_type, interlace)
+        elif chunk_type == b"PLTE":
+            if ihdr is None:
+                return "PLTE appears before IHDR", 0
+            if seen_plte:
+                return "contains more than one PLTE chunk", 0
+            if idat_parts:
+                return "PLTE appears after IDAT", 0
+            if ihdr[3] in {0, 4}:
+                return "PLTE is not allowed for grayscale color types", 0
+            if length == 0 or length % 3 != 0 or length > 768:
+                return "PLTE chunk has an invalid length", 0
+            if ihdr[3] == 3 and length // 3 > 2 ** ihdr[2]:
+                return "PLTE has more entries than the indexed bit depth permits", 0
+            seen_plte = True
+        elif chunk_type == b"IDAT":
+            if ihdr is None:
+                return "IDAT appears before IHDR", 0
+            if idat_ended:
+                return "IDAT chunks are not consecutive", 0
+            idat_parts.append(payload)
+        elif chunk_type == b"IEND":
+            if length != 0:
+                return "IEND chunk has an invalid length", 0
+            if not idat_parts:
+                return "IEND appears before IDAT", 0
+            seen_iend = True
+            offset = chunk_end
+            if offset != len(raw):
+                return "contains bytes after IEND", 0
+            break
+        elif idat_parts:
+            idat_ended = True
+        offset = chunk_end
+
+    if ihdr is None:
+        return "IHDR chunk is missing", 0
+    if not idat_parts:
+        return "IDAT chunk is missing", 0
+    if not seen_iend:
+        return "IEND chunk is missing", 0
+    if ihdr[3] == 3 and not seen_plte:
+        return "indexed-color PNG is missing PLTE", 0
+
+    width, height, bit_depth, color_type, interlace = ihdr
+    channels = PNG_CHANNELS[color_type]
+    if interlace == 0:
+        expected_bytes = height * (1 + ((width * channels * bit_depth + 7) // 8))
+    else:
+        expected_bytes = 0
+        for x_start, y_start, x_step, y_step in PNG_ADAM7_PASSES:
+            if width <= x_start or height <= y_start:
+                continue
+            pass_width = (width - x_start + x_step - 1) // x_step
+            pass_height = (height - y_start + y_step - 1) // y_step
+            row_bytes = (pass_width * channels * bit_depth + 7) // 8
+            expected_bytes += pass_height * (1 + row_bytes)
+    if expected_bytes > max_inflated_bytes:
+        return (
+            "IHDR dimensions exceed the safe decoding limit "
+            f"({expected_bytes} > {max_inflated_bytes} bytes)",
+            0,
+        )
+
+    decompressor = zlib.decompressobj()
+    inflated_bytes = 0
+    rows = iter(_png_row_payload_sizes(width, height, bit_depth, color_type, interlace))
+    row_remaining = -1
+
+    def consume_scanlines(output: bytes) -> str | None:
+        nonlocal row_remaining
+        cursor = 0
+        while cursor < len(output):
+            if row_remaining < 0:
+                try:
+                    row_remaining = next(rows)
+                except StopIteration:
+                    return "IDAT stream contains more scanlines than IHDR declares"
+                if output[cursor] > 4:
+                    return f"scanline uses invalid filter type {output[cursor]}"
+                cursor += 1
+            consumed = min(row_remaining, len(output) - cursor)
+            cursor += consumed
+            row_remaining -= consumed
+            if row_remaining == 0:
+                row_remaining = -1
+        return None
+
+    try:
+        for part in idat_parts:
+            pending = part
+            while pending:
+                output = decompressor.decompress(pending, 65536)
+                inflated_bytes += len(output)
+                if inflated_bytes > expected_bytes:
+                    return "IDAT stream expands beyond the IHDR dimensions", inflated_bytes
+                scanline_issue = consume_scanlines(output)
+                if scanline_issue:
+                    return scanline_issue, inflated_bytes
+                pending = decompressor.unconsumed_tail
+            while True:
+                output = decompressor.decompress(b"", 65536)
+                if not output:
+                    break
+                inflated_bytes += len(output)
+                if inflated_bytes > expected_bytes:
+                    return "IDAT stream expands beyond the IHDR dimensions", inflated_bytes
+                scanline_issue = consume_scanlines(output)
+                if scanline_issue:
+                    return scanline_issue, inflated_bytes
+    except zlib.error as exc:
+        return f"IDAT stream cannot be decoded: {exc}", inflated_bytes
+    if not decompressor.eof:
+        return "IDAT stream is incomplete", inflated_bytes
+    if decompressor.unused_data:
+        return "IDAT stream contains trailing compressed data", inflated_bytes
+    if inflated_bytes != expected_bytes:
+        return (
+            "IDAT stream size does not match IHDR dimensions "
+            f"(expected {expected_bytes}, got {inflated_bytes})",
+            inflated_bytes,
+        )
+    if row_remaining >= 0 or next(rows, None) is not None:
+        return "IDAT stream contains fewer scanlines than IHDR declares", inflated_bytes
+    return None, inflated_bytes
+
+
+def png_integrity_issue(path: Path) -> str | None:
+    return png_integrity_result(path)[0]
 
 
 def validate_media_manifest_entries(
@@ -1625,6 +1856,17 @@ def validate_manifest_file(report: ValidationReport, repo_root: Path, proposal_d
                 else:
                     report.add_error(message)
                 continue
+            if listed_file.suffix.lower() == ".png":
+                remaining_budget = MAX_TOTAL_PNG_INFLATED_BYTES - report.png_inflated_bytes
+                integrity_issue, inflated_bytes = png_integrity_result(
+                    listed_file,
+                    max_inflated_bytes=min(MAX_PNG_INFLATED_BYTES, remaining_budget),
+                )
+                report.png_inflated_bytes += inflated_bytes
+                if integrity_issue:
+                    report.add_error(
+                        f"{proposal_dir}/manifest.json: invalid PNG `{safe_path}`: {integrity_issue}"
+                    )
             declared_digest = item.get("sha256")
             if safe_path != "manifest.json" and not declared_digest:
                 message = f"{proposal_dir}/manifest.json: listed file `{safe_path}` needs sha256"

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -3,10 +3,12 @@ import importlib.util
 import json
 import os
 import shlex
+import struct
 import subprocess
 import sys
 import tempfile
 import unittest
+import zlib
 from pathlib import Path
 from unittest import mock
 
@@ -157,6 +159,24 @@ def run_scaffold(output_dir: Path, stage: str = "formal", cwd: Path = REPO_ROOT)
     )
 
 
+def mark_png_participant_revision(path: Path) -> None:
+    raw = path.read_bytes()
+    iend_offset = raw.rfind(b"\x00\x00\x00\x00IEND")
+    if iend_offset < 0:
+        raise ValueError(f"PNG has no IEND chunk: {path}")
+    chunk_type = b"tEXt"
+    payload = b"Revision\x00participant-revision"
+    checksum = zlib.crc32(chunk_type)
+    checksum = zlib.crc32(payload, checksum) & 0xFFFFFFFF
+    chunk = (
+        struct.pack(">I", len(payload))
+        + chunk_type
+        + payload
+        + struct.pack(">I", checksum)
+    )
+    path.write_bytes(raw[:iend_offset] + chunk + raw[iend_offset:])
+
+
 def complete_scaffold(
     output_dir: Path,
     synchronized_paths: tuple[str, ...] = (),
@@ -178,7 +198,7 @@ def complete_scaffold(
         "assets/figures/metrics-evidence.png",
     ]:
         path = output_dir / rel
-        path.write_bytes(path.read_bytes() + b"participant-revision")
+        mark_png_participant_revision(path)
     geometry = output_dir / "geometry" / "land_use.geojson"
     geometry.write_text(geometry.read_text(encoding="utf-8") + "\n", encoding="utf-8")
     drawing = b"%PDF-1.4\n3 0 obj<</Type/Page/Parent 2 0 R>>endobj\n" + b"0" * 4096
@@ -543,7 +563,7 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
                 "assets/figures/metrics-evidence.png",
             ]:
                 path = output_dir / rel
-                path.write_bytes(path.read_bytes() + b"participant-revision")
+                mark_png_participant_revision(path)
             geometry = output_dir / "geometry" / "land_use.geojson"
             geometry.write_text(geometry.read_text(encoding="utf-8") + "\n", encoding="utf-8")
             drawing = b"%PDF-1.4\n3 0 obj<</Type/Page/Parent 2 0 R>>endobj\n" + b"0" * 4096

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -7,7 +7,9 @@ import subprocess
 import hashlib
 import io
 import re
+import struct
 import urllib.error
+import zlib
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
@@ -29,6 +31,8 @@ from validate_submission import (  # noqa: E402
     ValidationReport,
     is_empty_pdf,
     media_signature_is_valid,
+    png_integrity_issue,
+    png_integrity_result,
     validate_agent_disclosure,
     validate_compliance_matrix_file,
     validate_media_manifest_entries,
@@ -1212,6 +1216,45 @@ REFERENCE_BLOCK = (
 REFERENCE_BLOCK += " " + " ".join(f"[depth:{item_id}]" for item_id in sorted(REQUIRED_DESIGN_DEPTH_IDS))
 
 
+def png_chunk(chunk_type: bytes, payload: bytes) -> bytes:
+    checksum = zlib.crc32(chunk_type)
+    checksum = zlib.crc32(payload, checksum) & 0xFFFFFFFF
+    return struct.pack(">I", len(payload)) + chunk_type + payload + struct.pack(">I", checksum)
+
+
+def valid_png_bytes() -> bytes:
+    ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 6, 0, 0, 0)
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + png_chunk(b"IHDR", ihdr)
+        + png_chunk(b"IDAT", zlib.compress(b"\x00\x00\x00\x00\x00"))
+        + png_chunk(b"IEND", b"")
+    )
+
+
+def custom_png_bytes(
+    ihdr: bytes,
+    scanlines: bytes,
+    *,
+    before_idat: tuple[tuple[bytes, bytes], ...] = (),
+    split_idat: bool = False,
+) -> bytes:
+    compressed = zlib.compress(scanlines)
+    split = max(1, len(compressed) // 2)
+    idat_chunks = (
+        png_chunk(b"IDAT", compressed[:split]) + png_chunk(b"IDAT", compressed[split:])
+        if split_idat
+        else png_chunk(b"IDAT", compressed)
+    )
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + png_chunk(b"IHDR", ihdr)
+        + b"".join(png_chunk(kind, payload) for kind, payload in before_idat)
+        + idat_chunks
+        + png_chunk(b"IEND", b"")
+    )
+
+
 def english_primary(text: str) -> str:
     text = text.replace(
         'language: "zh"',
@@ -1418,6 +1461,119 @@ class SubmissionWorkflowTests(unittest.TestCase):
         path = root / rel
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(content)
+
+    def test_png_integrity_rejects_payload_damage_after_digest_refresh(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/design"
+            changed = self.write_minimal_ai_package(root, base)
+            image = root / base / "assets/figures/key-areas.png"
+            damaged = bytearray(image.read_bytes())
+            idat = damaged.index(b"IDAT")
+            damaged[idat + 5] ^= 0x01
+            image.write_bytes(damaged)
+
+            manifest_path = root / base / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            for item in manifest["files"]:
+                if item.get("path") == "assets/figures/key-areas.png":
+                    item["sha256"] = hashlib.sha256(damaged).hexdigest()
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            report = validate_submission(root, "alice", changed)
+            self.assertIn(
+                "invalid PNG `assets/figures/key-areas.png`: IDAT chunk checksum is invalid",
+                "\n".join(report.errors),
+            )
+            self.assertIsNone(png_integrity_issue(root / base / "assets/figures/site-overview.png"))
+
+    def test_png_integrity_checks_decoder_structure_and_resource_bounds(self) -> None:
+        rgba = struct.pack(">IIBBBBB", 1, 1, 8, 6, 0, 0, 0)
+        indexed = struct.pack(">IIBBBBB", 1, 1, 1, 3, 0, 0, 0)
+        grayscale = struct.pack(">IIBBBBB", 1, 1, 16, 0, 0, 0, 0)
+        interlaced = struct.pack(">IIBBBBB", 1, 1, 8, 6, 0, 0, 1)
+        cases = {
+            "invalid-filter.png": (
+                custom_png_bytes(rgba, b"\x05\x00\x00\x00\x00"),
+                "invalid filter type 5",
+            ),
+            "missing-palette.png": (
+                custom_png_bytes(indexed, b"\x00\x00"),
+                "missing PLTE",
+            ),
+            "empty-palette.png": (
+                custom_png_bytes(indexed, b"\x00\x00", before_idat=((b"PLTE", b""),)),
+                "PLTE chunk has an invalid length",
+            ),
+            "grayscale-palette.png": (
+                custom_png_bytes(
+                    grayscale,
+                    b"\x00\x00\x00",
+                    before_idat=((b"PLTE", b"\x00\x00\x00"),),
+                ),
+                "PLTE is not allowed",
+            ),
+            "unknown-critical.png": (
+                custom_png_bytes(rgba, b"\x00\x00\x00\x00\x00", before_idat=((b"ABCD", b""),)),
+                "unknown critical chunk ABCD",
+            ),
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for name, (payload, expected) in cases.items():
+                path = root / name
+                path.write_bytes(payload)
+                with self.subTest(name=name):
+                    self.assertIn(expected, png_integrity_issue(path) or "")
+
+            for name, payload in {
+                "multi-idat.png": custom_png_bytes(
+                    rgba, b"\x00\x00\x00\x00\x00", split_idat=True
+                ),
+                "adam7.png": custom_png_bytes(interlaced, b"\x00\x00\x00\x00\x00"),
+                "grayscale16.png": custom_png_bytes(grayscale, b"\x00\x00\x00"),
+                "indexed.png": custom_png_bytes(
+                    indexed,
+                    b"\x00\x00",
+                    before_idat=((b"PLTE", b"\x00\x00\x00\xff\xff\xff"),),
+                ),
+            }.items():
+                path = root / name
+                path.write_bytes(payload)
+                with self.subTest(name=name):
+                    self.assertIsNone(png_integrity_issue(path))
+
+            bounded = root / "bounded.png"
+            bounded.write_bytes(valid_png_bytes())
+            issue, decoded = png_integrity_result(bounded, max_inflated_bytes=4)
+            self.assertIn("safe decoding limit", issue or "")
+            self.assertEqual(0, decoded)
+
+    def test_png_integrity_enforces_validation_wide_decode_budget(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = "submissions/alice/design"
+            changed = self.write_minimal_ai_package(root, base)
+            first = root / base / "assets/figures/site-overview.png"
+            rgba = struct.pack(">IIBBBBB", 1, 1, 8, 6, 0, 0, 0)
+            first.write_bytes(custom_png_bytes(rgba, b"\x05\x00\x00\x00\x00"))
+            manifest_path = root / base / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            for item in manifest["files"]:
+                if item.get("path") == "assets/figures/site-overview.png":
+                    item["sha256"] = hashlib.sha256(first.read_bytes()).hexdigest()
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+            )
+            with patch("validate_submission.MAX_TOTAL_PNG_INFLATED_BYTES", 9):
+                report = validate_submission(root, "alice", changed)
+            errors = "\n".join(report.errors)
+            self.assertIn("invalid filter type 5", errors)
+            self.assertIn("safe decoding limit", errors)
+            self.assertEqual(5, report.png_inflated_bytes)
 
     def write_minimal_ai_package(self, root: Path, base: str) -> list[str]:
         proposal = f"{base}/proposal.md"
@@ -1747,11 +1903,7 @@ class SubmissionWorkflowTests(unittest.TestCase):
 </main></body></html>""",
         )
         for figure in figure_assets:
-            self.write(
-                root,
-                f"{base}/{figure}",
-                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><title>Figure</title><rect width="10" height="10"/></svg>',
-            )
+            self.write_bytes(root, f"{base}/{figure}", valid_png_bytes())
         return [proposal] + [f"{base}/{item}" for item in required]
 
     def add_bilingual_v2_display(self, root: Path, base: str, changed: list[str]) -> None:


### PR DESCRIPTION
## Root cause

Follow-up to #3428. The shared validator previously checked manifest hashes, file existence, and extension-level inventory, but did not prove that a PNG could be structurally decoded. `finalize_submission.py` could therefore faithfully refresh the digest of already-corrupt bytes and all trusted gates would still pass.

## Fix

- validate every manifest-listed PNG with the standard library before accepting the package;
- verify signature, chunk order/type/CRC, IHDR and PLTE constraints, IDAT/IEND structure, zlib completion, exact decoded scanline length, and PNG filter bytes;
- bound work with the existing 5 MiB source-file limit, a 128 MiB per-image decoded limit, and a 1 GiB validation-wide decoded budget;
- count decoded bytes even when corruption is discovered late, so invalid images cannot bypass the aggregate budget;
- keep all existing submission, trusted-base, registry, and scoring policy unchanged.

## Verification

- targeted PNG regressions: 3/3 PASS;
- `tests.test_submission_workflow`, `tests.test_agent_scaffold_and_self_check`, and `tests.test_visual_review`: 202/202 PASS;
- `py_compile` and `git diff --check`: PASS;
- current merged #3428 package: 71/71 tracked PNGs accepted, about 506.83 MiB total decoded, largest about 20.14 MiB;
- another current package plus the repository PNG audit passed without compatibility failures.

The tests cover damaged IDAT with a refreshed manifest digest, illegal filters, missing or invalid PLTE, unknown critical chunks, multi-IDAT, Adam7, grayscale 16-bit, per-image limits, and validation-wide budget accounting. No package files or policy registries are changed.