### PR TITLE
improve-v3: 绿地东西向连接+建筑高度层数+用地容积率+道路设计属性

### DIFF
--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/buildings.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/buildings.geojson
@@ -14,7 +14,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "AI模型测试棚",
         "area_sqm_declared": 5359.504,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -56,7 +59,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "算法验证室",
         "area_sqm_declared": 5359.266,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -98,7 +104,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "芯片测试间",
         "area_sqm_declared": 5359.027,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -140,7 +149,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "安全治理工作坊",
         "area_sqm_declared": 5358.789,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -182,7 +194,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "标准研讨室",
         "area_sqm_declared": 5358.551,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -224,7 +239,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "创新成果展示厅",
         "area_sqm_declared": 5358.312,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -266,7 +284,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "AI模型测试棚",
         "area_sqm_declared": 5359.502,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -308,7 +329,10 @@
         "building_type": "lab",
         "name_zh": "算法验证实验室",
         "area_sqm_declared": 5359.264,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "10-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -350,7 +374,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "芯片测试间",
         "area_sqm_declared": 5359.026,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -392,7 +419,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "安全治理工作坊",
         "area_sqm_declared": 5358.787,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -434,7 +464,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "标准研讨室",
         "area_sqm_declared": 5358.549,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -476,7 +509,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "创新成果展示厅",
         "area_sqm_declared": 5358.311,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -518,7 +554,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "AI模型测试棚",
         "area_sqm_declared": 5359.501,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -560,7 +599,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "算法验证室",
         "area_sqm_declared": 5359.262,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -602,7 +644,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "芯片测试间",
         "area_sqm_declared": 5359.024,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -644,7 +689,10 @@
         "building_type": "education",
         "name_zh": "AI教育体验中心",
         "area_sqm_declared": 5358.786,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "10-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -686,7 +734,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "标准研讨室",
         "area_sqm_declared": 5358.547,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -728,7 +779,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "创新成果展示厅",
         "area_sqm_declared": 5358.309,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -770,7 +824,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "AI模型测试棚",
         "area_sqm_declared": 5359.499,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -812,7 +869,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "算法验证室",
         "area_sqm_declared": 5359.26,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -854,7 +914,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "芯片测试间",
         "area_sqm_declared": 5359.022,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -896,7 +959,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "安全治理工作坊",
         "area_sqm_declared": 5358.784,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -938,7 +1004,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "标准研讨室",
         "area_sqm_declared": 5358.545,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -980,7 +1049,10 @@
         "building_type": "community_service",
         "name_zh": "众智园社区服务点",
         "area_sqm_declared": 5358.307,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -1022,7 +1094,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "AI模型测试棚",
         "area_sqm_declared": 5359.497,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1064,7 +1139,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "算法验证室",
         "area_sqm_declared": 5359.259,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1106,7 +1184,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "芯片测试间",
         "area_sqm_declared": 5359.02,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1148,7 +1229,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "安全治理工作坊",
         "area_sqm_declared": 5358.782,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1190,7 +1274,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "标准研讨室",
         "area_sqm_declared": 5358.544,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1232,7 +1319,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "创新成果展示厅",
         "area_sqm_declared": 5358.305,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1274,7 +1364,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "AI模型测试棚",
         "area_sqm_declared": 5359.495,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1316,7 +1409,10 @@
         "building_type": "mixed_use",
         "name_zh": "创新成果展示厅",
         "area_sqm_declared": 5359.257,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1358,7 +1454,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "芯片测试间",
         "area_sqm_declared": 5359.019,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1400,7 +1499,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "安全治理工作坊",
         "area_sqm_declared": 5358.78,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1442,7 +1544,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "标准研讨室",
         "area_sqm_declared": 5358.542,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1484,7 +1589,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "创新成果展示厅",
         "area_sqm_declared": 5358.304,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1526,7 +1634,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "AI模型测试棚",
         "area_sqm_declared": 5359.494,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1568,7 +1679,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "算法验证室",
         "area_sqm_declared": 5359.255,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1610,7 +1724,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "芯片测试间",
         "area_sqm_declared": 5359.017,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1652,7 +1769,10 @@
         "building_type": "office",
         "name_zh": "众智园创新办公",
         "area_sqm_declared": 5358.779,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1694,7 +1814,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "标准研讨室",
         "area_sqm_declared": 5358.54,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1736,7 +1859,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "创新成果展示厅",
         "area_sqm_declared": 5358.302,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1778,7 +1904,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "AI模型测试棚",
         "area_sqm_declared": 5359.492,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1820,7 +1949,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "算法验证室",
         "area_sqm_declared": 5359.254,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1862,7 +1994,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "芯片测试间",
         "area_sqm_declared": 5359.015,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1904,7 +2039,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "安全治理工作坊",
         "area_sqm_declared": 5358.777,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1946,7 +2084,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "标准研讨室",
         "area_sqm_declared": 5358.539,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -1988,7 +2129,10 @@
         "building_type": "talent_apartment",
         "name_zh": "众智园人才公寓",
         "area_sqm_declared": 5358.3,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -2030,7 +2174,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "开源发布厅",
         "area_sqm_declared": 6210.093,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "12-20",
+        "floor_count": "3-5",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2072,7 +2219,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "成果转化室",
         "area_sqm_declared": 6209.869,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "12-20",
+        "floor_count": "3-5",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2114,7 +2264,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "孵化加速器",
         "area_sqm_declared": 6209.646,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "12-20",
+        "floor_count": "3-5",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2156,7 +2309,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "安全治理工作坊",
         "area_sqm_declared": 6209.422,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2198,7 +2354,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "开源发布厅",
         "area_sqm_declared": 6210.091,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "12-20",
+        "floor_count": "3-5",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2240,7 +2399,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "成果转化室",
         "area_sqm_declared": 6209.867,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "12-20",
+        "floor_count": "3-5",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2282,7 +2444,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "孵化加速器",
         "area_sqm_declared": 6209.643,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "12-20",
+        "floor_count": "3-5",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2324,7 +2489,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "算法验证室",
         "area_sqm_declared": 6209.419,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2366,7 +2534,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "开源发布厅",
         "area_sqm_declared": 6210.088,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "12-20",
+        "floor_count": "3-5",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2408,7 +2579,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "成果转化室",
         "area_sqm_declared": 6209.864,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "12-20",
+        "floor_count": "3-5",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2450,7 +2624,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "孵化加速器",
         "area_sqm_declared": 6209.64,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "12-20",
+        "floor_count": "3-5",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2492,7 +2669,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "创新成果展示厅",
         "area_sqm_declared": 6209.417,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2534,7 +2714,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "开源发布厅",
         "area_sqm_declared": 6210.085,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "12-20",
+        "floor_count": "3-5",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2576,7 +2759,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "成果转化室",
         "area_sqm_declared": 6209.861,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "12-20",
+        "floor_count": "3-5",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2618,7 +2804,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "孵化加速器",
         "area_sqm_declared": 6209.638,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "12-20",
+        "floor_count": "3-5",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2660,7 +2849,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "安全治理工作坊",
         "area_sqm_declared": 6209.414,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2702,7 +2894,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "开源发布厅",
         "area_sqm_declared": 6210.083,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "12-20",
+        "floor_count": "3-5",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2744,7 +2939,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "成果转化室",
         "area_sqm_declared": 6209.859,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "12-20",
+        "floor_count": "3-5",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2786,7 +2984,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "孵化加速器",
         "area_sqm_declared": 6209.635,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "12-20",
+        "floor_count": "3-5",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2828,7 +3029,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "算法验证室",
         "area_sqm_declared": 6209.411,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2870,7 +3074,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "开源发布厅",
         "area_sqm_declared": 6210.08,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "12-20",
+        "floor_count": "3-5",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2912,7 +3119,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "成果转化室",
         "area_sqm_declared": 6209.856,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "12-20",
+        "floor_count": "3-5",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2954,7 +3164,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "孵化加速器",
         "area_sqm_declared": 6209.632,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "12-20",
+        "floor_count": "3-5",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -2996,7 +3209,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "创新成果展示厅",
         "area_sqm_declared": 6209.409,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -3038,7 +3254,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "智能体测试场",
         "area_sqm_declared": 6003.969,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "25-40",
+        "floor_count": "6-10",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -3080,7 +3299,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "数据要素会客厅",
         "area_sqm_declared": 6003.801,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "25-40",
+        "floor_count": "6-10",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -3122,7 +3344,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "AI产品展示厅",
         "area_sqm_declared": 6003.633,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "25-40",
+        "floor_count": "6-10",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -3164,7 +3389,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "AI安全评测室",
         "area_sqm_declared": 6003.965,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "25-40",
+        "floor_count": "6-10",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -3206,7 +3434,10 @@
         "building_type": "ai_r_and_d",
         "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.797,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "25-40",
+        "floor_count": "6-10",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -3248,7 +3479,10 @@
         "building_type": "mixed_use",
         "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.629,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "25-40",
+        "floor_count": "6-10",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -3290,7 +3524,10 @@
         "building_type": "mixed_use",
         "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.962,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "25-40",
+        "floor_count": "6-10",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -3332,7 +3569,10 @@
         "building_type": "mixed_use",
         "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.794,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "25-40",
+        "floor_count": "6-10",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -3374,7 +3614,10 @@
         "building_type": "mixed_use",
         "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.625,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "25-40",
+        "floor_count": "6-10",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -3416,7 +3659,10 @@
         "building_type": "mixed_use",
         "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.958,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "25-40",
+        "floor_count": "6-10",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -3458,7 +3704,10 @@
         "building_type": "mixed_use",
         "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.79,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "25-40",
+        "floor_count": "6-10",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -3500,7 +3749,10 @@
         "building_type": "mixed_use",
         "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.622,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "25-40",
+        "floor_count": "6-10",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -3542,7 +3794,10 @@
         "building_type": "mixed_use",
         "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.954,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "25-40",
+        "floor_count": "6-10",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -3584,7 +3839,10 @@
         "building_type": "mixed_use",
         "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.786,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "25-40",
+        "floor_count": "6-10",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -3626,7 +3884,10 @@
         "building_type": "mixed_use",
         "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.618,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "25-40",
+        "floor_count": "6-10",
+        "green_roof_eligible": true
       },
       "geometry": {
         "type": "Polygon",
@@ -3668,7 +3929,10 @@
         "building_type": "residential",
         "name_zh": "大钟寺居住配套",
         "area_sqm_declared": 4554.819,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -3710,7 +3974,10 @@
         "building_type": "residential",
         "name_zh": "大钟寺居住配套",
         "area_sqm_declared": 4554.163,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -3752,7 +4019,10 @@
         "building_type": "residential",
         "name_zh": "人才公寓",
         "area_sqm_declared": 4553.508,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -3794,7 +4064,10 @@
         "building_type": "residential",
         "name_zh": "人才公寓",
         "area_sqm_declared": 4553.507,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -3836,7 +4109,10 @@
         "building_type": "residential",
         "name_zh": "人才公寓",
         "area_sqm_declared": 4552.851,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "15-25",
+        "floor_count": "4-6",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -3878,7 +4154,10 @@
         "building_type": "retail",
         "name_zh": "AI体验商业",
         "area_sqm_declared": 4555.333,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -3920,7 +4199,10 @@
         "building_type": "retail",
         "name_zh": "AI体验商业",
         "area_sqm_declared": 4555.331,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -3962,7 +4244,10 @@
         "building_type": "retail",
         "name_zh": "AI体验商业",
         "area_sqm_declared": 4555.328,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4004,7 +4289,10 @@
         "building_type": "retail",
         "name_zh": "AI体验商业",
         "area_sqm_declared": 4554.808,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4046,7 +4334,10 @@
         "building_type": "retail",
         "name_zh": "AI体验商业",
         "area_sqm_declared": 4554.806,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4088,7 +4379,10 @@
         "building_type": "retail",
         "name_zh": "AI体验商业",
         "area_sqm_declared": 4554.804,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4130,7 +4424,10 @@
         "building_type": "retail",
         "name_zh": "AI体验商业",
         "area_sqm_declared": 4554.153,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4172,7 +4469,10 @@
         "building_type": "retail",
         "name_zh": "AI体验商业",
         "area_sqm_declared": 4554.151,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4214,7 +4514,10 @@
         "building_type": "retail",
         "name_zh": "AI体验商业",
         "area_sqm_declared": 4554.149,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4256,7 +4559,10 @@
         "building_type": "retail",
         "name_zh": "社区商业",
         "area_sqm_declared": 4553.497,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4298,7 +4604,10 @@
         "building_type": "retail",
         "name_zh": "社区商业",
         "area_sqm_declared": 4553.495,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4340,7 +4649,10 @@
         "building_type": "retail",
         "name_zh": "社区商业",
         "area_sqm_declared": 4553.493,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4382,7 +4694,10 @@
         "building_type": "retail",
         "name_zh": "社区商业",
         "area_sqm_declared": 4552.841,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4424,7 +4739,10 @@
         "building_type": "retail",
         "name_zh": "社区商业",
         "area_sqm_declared": 4552.839,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4466,7 +4784,10 @@
         "building_type": "retail",
         "name_zh": "社区商业",
         "area_sqm_declared": 432.52,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4508,7 +4829,10 @@
         "building_type": "retail",
         "name_zh": "众智园配套商业",
         "area_sqm_declared": 4551.529,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4550,7 +4874,10 @@
         "building_type": "retail",
         "name_zh": "众智园配套商业",
         "area_sqm_declared": 4551.527,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4592,7 +4919,10 @@
         "building_type": "retail",
         "name_zh": "众智园配套商业",
         "area_sqm_declared": 2345.567,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4634,7 +4964,10 @@
         "building_type": "retail",
         "name_zh": "众智园配套商业",
         "area_sqm_declared": 4550.212,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4676,7 +5009,10 @@
         "building_type": "cultural",
         "name_zh": "数字钟楼文化空间",
         "area_sqm_declared": 2847.089,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4718,7 +5054,10 @@
         "building_type": "cultural",
         "name_zh": "数字钟楼文化空间",
         "area_sqm_declared": 2847.088,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4760,7 +5099,10 @@
         "building_type": "cultural",
         "name_zh": "数字钟楼文化空间",
         "area_sqm_declared": 2847.088,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4802,7 +5144,10 @@
         "building_type": "cultural",
         "name_zh": "数字钟楼文化空间",
         "area_sqm_declared": 2846.557,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4844,7 +5189,10 @@
         "building_type": "cultural",
         "name_zh": "数字钟楼文化空间",
         "area_sqm_declared": 2846.556,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4886,7 +5234,10 @@
         "building_type": "cultural",
         "name_zh": "数字钟楼文化空间",
         "area_sqm_declared": 2846.555,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4928,7 +5279,10 @@
         "building_type": "cultural",
         "name_zh": "数字钟楼文化空间",
         "area_sqm_declared": 2846.27,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -4970,7 +5324,10 @@
         "building_type": "cultural",
         "name_zh": "数字钟楼文化空间",
         "area_sqm_declared": 2846.269,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -5012,7 +5369,10 @@
         "building_type": "cultural",
         "name_zh": "数字钟楼文化空间",
         "area_sqm_declared": 2846.268,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-18",
+        "floor_count": "2-4",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -5054,7 +5414,10 @@
         "building_type": "cultural",
         "name_zh": "文化展示空间",
         "area_sqm_declared": 2846.024,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -5096,7 +5459,10 @@
         "building_type": "cultural",
         "name_zh": "文化展示空间",
         "area_sqm_declared": 2846.023,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -5138,7 +5504,10 @@
         "building_type": "cultural",
         "name_zh": "文化展示空间",
         "area_sqm_declared": 2846.022,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -5180,7 +5549,10 @@
         "building_type": "cultural",
         "name_zh": "文化展示空间",
         "area_sqm_declared": 2845.614,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -5222,7 +5594,10 @@
         "building_type": "cultural",
         "name_zh": "文化展示空间",
         "area_sqm_declared": 2845.613,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -5264,7 +5639,10 @@
         "building_type": "cultural",
         "name_zh": "文化展示空间",
         "area_sqm_declared": 2845.613,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -5306,7 +5684,10 @@
         "building_type": "cultural",
         "name_zh": "京张铁路文化展示",
         "area_sqm_declared": 2844.63,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -5348,7 +5729,10 @@
         "building_type": "cultural",
         "name_zh": "京张铁路文化展示",
         "area_sqm_declared": 2844.629,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",
@@ -5390,7 +5774,10 @@
         "building_type": "cultural",
         "name_zh": "京张铁路文化展示",
         "area_sqm_declared": 2844.629,
-        "update_status": "concept_carrier_pending_survey"
+        "update_status": "concept_carrier_pending_survey",
+        "height_range_m": "8-15",
+        "floor_count": "2-3",
+        "green_roof_eligible": false
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/green_space.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/green_space.geojson
@@ -13,7 +13,9 @@
         "geometry_role": "design_proposal",
         "green_type": "park_green",
         "name_zh": "遗址公园服务绿脊(南段)",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "north_south_spine",
+        "eco_segment": "south_dazhongsi"
       },
       "geometry": {
         "type": "Polygon",
@@ -54,7 +56,9 @@
         "geometry_role": "design_proposal",
         "green_type": "park_green",
         "name_zh": "遗址公园服务绿脊(中段)",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "north_south_spine",
+        "eco_segment": "central_origin"
       },
       "geometry": {
         "type": "Polygon",
@@ -95,7 +99,9 @@
         "geometry_role": "design_proposal",
         "green_type": "park_green",
         "name_zh": "遗址公园服务绿脊(北段)",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "north_south_spine",
+        "eco_segment": "north_zhongzhi"
       },
       "geometry": {
         "type": "Polygon",
@@ -136,7 +142,9 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "清河遮阴与休息带",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "east_west_link",
+        "eco_segment": "south_dazhongsi"
       },
       "geometry": {
         "type": "Polygon",
@@ -177,7 +185,9 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "小月河场景赋能带",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "east_west_link",
+        "eco_segment": "north_zhongzhi"
       },
       "geometry": {
         "type": "Polygon",
@@ -218,7 +228,9 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "西侧社区公园B",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "east_west_link",
+        "eco_segment": "south_dazhongsi"
       },
       "geometry": {
         "type": "Polygon",
@@ -259,7 +271,9 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "西侧社区公园C",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "east_west_link",
+        "eco_segment": "central_origin"
       },
       "geometry": {
         "type": "Polygon",
@@ -300,7 +314,9 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "东侧社区公园B",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "east_west_link",
+        "eco_segment": "central_origin"
       },
       "geometry": {
         "type": "Polygon",
@@ -341,7 +357,9 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "东侧社区公园C",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "east_west_link",
+        "eco_segment": "north_zhongzhi"
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/land_use.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/land_use.geojson
@@ -13,7 +13,9 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0702",
         "name_zh": "南侧居住与配套用地",
-        "area_sqm_declared": 163096.297
+        "area_sqm_declared": 163096.297,
+        "far_conceptual": "1.5-2.5",
+        "ground_floor": "residential_or_commercial"
       },
       "geometry": {
         "type": "Polygon",
@@ -66,7 +68,9 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
         "name_zh": "AI产业集聚研发用地",
-        "area_sqm_declared": 246713.264
+        "area_sqm_declared": 246713.264,
+        "far_conceptual": "2.5-3.5",
+        "ground_floor": "commercial_or_public"
       },
       "geometry": {
         "type": "Polygon",
@@ -115,7 +119,9 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
         "name_zh": "AI产业集聚研发用地",
-        "area_sqm_declared": 1801002.535
+        "area_sqm_declared": 1801002.535,
+        "far_conceptual": "2.5-3.5",
+        "ground_floor": "commercial_or_public"
       },
       "geometry": {
         "type": "Polygon",
@@ -172,7 +178,9 @@
         "geometry_role": "design_proposal",
         "land_use_code": "05",
         "name_zh": "大钟寺商业与文化体验用地",
-        "area_sqm_declared": 1480278.362
+        "area_sqm_declared": 1480278.362,
+        "far_conceptual": "2.0-3.0",
+        "ground_floor": "commercial"
       },
       "geometry": {
         "type": "Polygon",
@@ -237,7 +245,9 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0702",
         "name_zh": "西侧居住社区用地",
-        "area_sqm_declared": 287719.802
+        "area_sqm_declared": 287719.802,
+        "far_conceptual": "1.5-2.5",
+        "ground_floor": "residential_or_commercial"
       },
       "geometry": {
         "type": "Polygon",
@@ -302,7 +312,9 @@
         "geometry_role": "design_proposal",
         "land_use_code": "1401",
         "name_zh": "京张遗址公园绿地",
-        "area_sqm_declared": 569190.321
+        "area_sqm_declared": 569190.321,
+        "far_conceptual": "0.1-0.5",
+        "ground_floor": "open_space"
       },
       "geometry": {
         "type": "Polygon",
@@ -359,7 +371,9 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0702",
         "name_zh": "东侧居住社区用地",
-        "area_sqm_declared": 654570.399
+        "area_sqm_declared": 654570.399,
+        "far_conceptual": "1.5-2.5",
+        "ground_floor": "residential_or_commercial"
       },
       "geometry": {
         "type": "Polygon",
@@ -408,7 +422,9 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
         "name_zh": "AI原点社区创新用地",
-        "area_sqm_declared": 261735.324
+        "area_sqm_declared": 261735.324,
+        "far_conceptual": "2.5-3.5",
+        "ground_floor": "commercial_or_public"
       },
       "geometry": {
         "type": "Polygon",
@@ -473,7 +489,9 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
         "name_zh": "AI原点社区创新用地",
-        "area_sqm_declared": 1018509.885
+        "area_sqm_declared": 1018509.885,
+        "far_conceptual": "2.5-3.5",
+        "ground_floor": "commercial_or_public"
       },
       "geometry": {
         "type": "Polygon",
@@ -534,7 +552,9 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0803",
         "name_zh": "AI社区科研教育用地",
-        "area_sqm_declared": 1052785.966
+        "area_sqm_declared": 1052785.966,
+        "far_conceptual": "1.5-2.5",
+        "ground_floor": "education_or_research"
       },
       "geometry": {
         "type": "Polygon",
@@ -599,7 +619,9 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0804",
         "name_zh": "西侧测试与中试用地",
-        "area_sqm_declared": 41523.599
+        "area_sqm_declared": 41523.599,
+        "far_conceptual": "1.0-2.0",
+        "ground_floor": "lab_or_test"
       },
       "geometry": {
         "type": "Polygon",
@@ -652,7 +674,9 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0805",
         "name_zh": "西侧产业服务用地",
-        "area_sqm_declared": 5000.277
+        "area_sqm_declared": 5000.277,
+        "far_conceptual": "1.5-2.5",
+        "ground_floor": "industry_service"
       },
       "geometry": {
         "type": "Polygon",
@@ -689,7 +713,9 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
         "name_zh": "AI研发创新与公共平台用地",
-        "area_sqm_declared": 1829638.973
+        "area_sqm_declared": 1829638.973,
+        "far_conceptual": "2.5-3.5",
+        "ground_floor": "commercial_or_public"
       },
       "geometry": {
         "type": "Polygon",
@@ -758,7 +784,9 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
         "name_zh": "AI全栈研发创新用地",
-        "area_sqm_declared": 2001072.359
+        "area_sqm_declared": 2001072.359,
+        "far_conceptual": "2.5-3.5",
+        "ground_floor": "commercial_or_public"
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/roads.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/roads.geojson
@@ -14,7 +14,11 @@
         "road_type": "secondary",
         "name_zh": "西侧联络道",
         "length_m": 6232.6,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "sidewalk_width_m": 4,
+        "bike_lane": "shared",
+        "lighting": "standard",
+        "surface": "asphalt"
       },
       "geometry": {
         "type": "LineString",
@@ -86,7 +90,11 @@
         "road_type": "greenway",
         "name_zh": "公共服务脊柱",
         "length_m": 9435.0,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "sidewalk_width_m": 8,
+        "bike_lane": "parallel_separated",
+        "lighting": "standard",
+        "surface": "permeable_paving"
       },
       "geometry": {
         "type": "LineString",
@@ -178,7 +186,11 @@
         "road_type": "secondary",
         "name_zh": "东侧联络道",
         "length_m": 9435.0,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "sidewalk_width_m": 4,
+        "bike_lane": "shared",
+        "lighting": "standard",
+        "surface": "asphalt"
       },
       "geometry": {
         "type": "LineString",
@@ -270,7 +282,11 @@
         "road_type": "pedestrian_priority",
         "name_zh": "大钟寺到达连接",
         "length_m": 1020.0,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "sidewalk_width_m": 6,
+        "bike_lane": "prohibited",
+        "lighting": "standard",
+        "surface": "permeable_paving"
       },
       "geometry": {
         "type": "LineString",
@@ -310,7 +326,11 @@
         "road_type": "pedestrian_priority",
         "name_zh": "大钟寺进入连接",
         "length_m": 1020.0,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "sidewalk_width_m": 6,
+        "bike_lane": "prohibited",
+        "lighting": "standard",
+        "surface": "permeable_paving"
       },
       "geometry": {
         "type": "LineString",
@@ -350,7 +370,11 @@
         "road_type": "pedestrian_priority",
         "name_zh": "原点到达连接",
         "length_m": 1020.0,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "sidewalk_width_m": 6,
+        "bike_lane": "prohibited",
+        "lighting": "standard",
+        "surface": "permeable_paving"
       },
       "geometry": {
         "type": "LineString",
@@ -390,7 +414,11 @@
         "road_type": "pedestrian_priority",
         "name_zh": "原点进入连接",
         "length_m": 1008.1,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "sidewalk_width_m": 6,
+        "bike_lane": "prohibited",
+        "lighting": "standard",
+        "surface": "permeable_paving"
       },
       "geometry": {
         "type": "LineString",
@@ -430,7 +458,11 @@
         "road_type": "pedestrian_priority",
         "name_zh": "众智园到达连接",
         "length_m": 1020.0,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "sidewalk_width_m": 6,
+        "bike_lane": "prohibited",
+        "lighting": "standard",
+        "surface": "permeable_paving"
       },
       "geometry": {
         "type": "LineString",
@@ -470,7 +502,11 @@
         "road_type": "pedestrian_priority",
         "name_zh": "众智园进入连接",
         "length_m": 1008.2,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "sidewalk_width_m": 6,
+        "bike_lane": "prohibited",
+        "lighting": "standard",
+        "surface": "permeable_paving"
       },
       "geometry": {
         "type": "LineString",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
@@ -64,7 +64,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "04195051d54a1deef890f5a20c6d6e63283b27e8345872aa82356bb2397f5a0f"
+      "sha256": "9261b8d64f717f06599ff20f2e227386c416dd645a4543f33b0f37c2c0d564be"
     },
     {
       "path": "compliance_matrix.json",
@@ -235,7 +235,7 @@
       "path": "geometry/buildings.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "5e2868e7a3b0c3bffee5c7228e88a267cd1955945d7143be74cad437c658cb7b"
+      "sha256": "ec37873d0e1abe5d112ad5f9236686e41eac1116dcb5a5aff32d09e69d363cf3"
     },
     {
       "path": "geometry/constraints.geojson",
@@ -247,7 +247,7 @@
       "path": "geometry/green_space.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "03b4a0b6c3c4a8b2b5d3d6508985c4a80b4e72f96e730ddbb94df069307effe2"
+      "sha256": "e6d63903390eb1172d162cc5a8768246fb0cd29fd89f7d44aa4cab7119df2048"
     },
     {
       "path": "geometry/key_areas.geojson",
@@ -259,7 +259,7 @@
       "path": "geometry/land_use.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "b0c7978f666ed4b4320c7ece16c9eafe6689d494343e3540de6634f12b64d23e"
+      "sha256": "9a7358186f5b52d976c2ccb10dc4788914b72898d4727f808148732179eb4edd"
     },
     {
       "path": "geometry/phasing.geojson",
@@ -277,7 +277,7 @@
       "path": "geometry/roads.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "f1ff25adb06e3cfc4e248b2188e8441f940a9d37edcbd23febd864b7d222f9ed"
+      "sha256": "09bef5be99d5e6015d4c53b53c94d35b95252164ba099415235ad0b26df0a07f"
     },
     {
       "path": "geometry/site_boundary.geojson",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
@@ -78,7 +78,7 @@
       "ai_package_stages": {
         "submissions/565431hzhang/jingzhang-ai-heritage-halo": "formal"
       },
-      "total_bytes": 3874106,
+      "total_bytes": 3890474,
       "maintainer_bypass": false
     },
     "stderr": ""


### PR DESCRIPTION
城市设计深化（不改坐标，只加设计属性）：

1. 绿地: connectivity_role(南北脊柱/东西连接)+eco_segment(南/中/北)
2. 建筑: height_range_m(众智园15-25m/原点12-20m/大钟寺25-40m)+floor_count+green_roof_eligible
3. 用地: far_conceptual(0802:2.5-3.5/0702:1.5-2.5/05:2.0-3.0等)+ground_floor(商业/居住/教育/实验室)
4. 道路: sidewalk_width_m(greenway:8m/secondary:4m/pedestrian:6m)+bike_lane+lighting+surface