### PR TITLE
fix: align land_use code and schema_version with upstream enum update

### DIFF
--- a/submissions/LiarrDev/jingzhang-ai-spine/geometry/land_use.geojson
+++ b/submissions/LiarrDev/jingzhang-ai-spine/geometry/land_use.geojson
@@ -76,7 +76,7 @@
         "source_type": "agent_generated_design",
         "confidence": "medium",
         "geometry_role": "design_proposal",
-        "land_use_code": "05",
+        "land_use_code": "09",
         "name_zh": "智汇椎-商业服务与智能终端展示用地",
         "name_en": "Convergence Vertebra - Commercial Service and Smart Terminal Display",
         "key_area_id": "dazhongsi_ai_industry_cluster",

--- a/submissions/LiarrDev/jingzhang-ai-spine/manifest.json
+++ b/submissions/LiarrDev/jingzhang-ai-spine/manifest.json
@@ -56,7 +56,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "b1c6d2b3aea78d0b969192294fbc3b4adec678f85f9fe20c3f8ba4f064a88b3c"
+      "sha256": "9a46021752af75e017b9721656ff0c6a50088281e69cad9c436b97f531d3a14a"
     },
     {
       "path": "compliance_matrix.json",
@@ -179,7 +179,7 @@
       "path": "geometry/land_use.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "a0a7df01cf356f6b175b6d858221d439a5505b36d339bbe7514478c0208799b0"
+      "sha256": "d40cc7573a8dec2ff33dcc9bd5fcbd1caaf280c88b2163893335ed3eab2eafa8"
     },
     {
       "path": "geometry/phasing.geojson",

--- a/submissions/LiarrDev/jingzhang-ai-spine/self_check.json
+++ b/submissions/LiarrDev/jingzhang-ai-spine/self_check.json
@@ -161,7 +161,7 @@
   "package_type": "professional_design_package",
   "review_status": "formal-review-ready",
   "next_actions": [],
-  "schema_version": "0.1.0",
+  "schema_version": "0.2.0",
   "checks": [
     {
       "check_id": "DETERMINISTIC_VALIDATION",


### PR DESCRIPTION
## Summary
- 上游更新了 `land_use_codes.json` 枚举：代码 `05` 从"商业服务业用地"改为"湿地"，新增代码 `09` 为"商业服务业用地"
- 将 `land_use.geojson` 中商业服务用地的代码从 `05` 更正为 `09`
- 将 `self_check.json` 的 `schema_version` 从 `0.1.0` 对齐到 `0.2.0`（与 manifest.json 一致）

## 背景
PR #1349 合入后，上游主分支更新了用地分类枚举（`brief/site-package/enums/land_use_codes.json`），代码 `05` 的语义从"商业服务业用地"变为"湿地"。本提交将其商业服务用地 parcel 的代码更正为新的 `09`，保持语义一致。

## Test plan
- [x] `validate_local_submission.py` 通过
- [x] `self_check_submission.py --mark-self-checked` 四门全部 PASS
- [x] manifest schema 验证通过
- [x] SHA256 哈希已更新