### PR TITLE
add-eco-corridor: 绿地东西向连接属性

### DIFF
--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/green_space.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/green_space.geojson
@@ -13,7 +13,9 @@
         "geometry_role": "design_proposal",
         "green_type": "park_green",
         "name_zh": "遗址公园服务绿脊(南段)",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "north_south_spine",
+        "eco_segment": "south"
       },
       "geometry": {
         "type": "Polygon",
@@ -54,7 +56,9 @@
         "geometry_role": "design_proposal",
         "green_type": "park_green",
         "name_zh": "遗址公园服务绿脊(中段)",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "north_south_spine",
+        "eco_segment": "central"
       },
       "geometry": {
         "type": "Polygon",
@@ -95,7 +99,9 @@
         "geometry_role": "design_proposal",
         "green_type": "park_green",
         "name_zh": "遗址公园服务绿脊(北段)",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "north_south_spine",
+        "eco_segment": "north"
       },
       "geometry": {
         "type": "Polygon",
@@ -136,7 +142,10 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "西侧社区公园A",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "east_west_link",
+        "wing_position": "west",
+        "connected_spine": "GREEN-CORR-1"
       },
       "geometry": {
         "type": "Polygon",
@@ -177,7 +186,10 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "西侧社区公园B",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "east_west_link",
+        "wing_position": "west",
+        "connected_spine": "GREEN-CORR-1"
       },
       "geometry": {
         "type": "Polygon",
@@ -218,7 +230,10 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "西侧社区公园C",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "east_west_link",
+        "wing_position": "west",
+        "connected_spine": "GREEN-CORR-3"
       },
       "geometry": {
         "type": "Polygon",
@@ -259,7 +274,10 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "东侧社区公园A",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "east_west_link",
+        "wing_position": "east",
+        "connected_spine": "GREEN-CORR-1"
       },
       "geometry": {
         "type": "Polygon",
@@ -300,7 +318,10 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "东侧社区公园B",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "east_west_link",
+        "wing_position": "east",
+        "connected_spine": "GREEN-CORR-3"
       },
       "geometry": {
         "type": "Polygon",
@@ -341,7 +362,10 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "东侧社区公园C",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "east_west_link",
+        "wing_position": "east",
+        "connected_spine": "GREEN-CORR-5"
       },
       "geometry": {
         "type": "Polygon",
@@ -382,7 +406,10 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "东侧社区公园D",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "connectivity_role": "east_west_link",
+        "wing_position": "east",
+        "connected_spine": "GREEN-CORR-5"
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
@@ -64,7 +64,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "a338dc7508616811fecabf174e14f2b1e2ddc5d57e286df2396edeb861344fe8"
+      "sha256": "f749c6dc064c6065798200853f1742bcab2a20aeafdf2238bd9f4a8f6aa1aa3d"
     },
     {
       "path": "compliance_matrix.json",
@@ -247,7 +247,7 @@
       "path": "geometry/green_space.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "6203a2a5fc5a674319dc821f06a8406ad0d721a244bcc9966b094e18c12949be"
+      "sha256": "a1cabe78cea90a4138eabbd20018213da9817922108d8821d5e0aa0da51d2373"
     },
     {
       "path": "geometry/key_areas.geojson",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
@@ -85,7 +85,7 @@
       "ai_package_stages": {
         "submissions/565431hzhang/jingzhang-ai-heritage-halo": "formal"
       },
-      "total_bytes": 5248108,
+      "total_bytes": 5252256,
       "maintainer_bypass": false
     },
     "stderr": ""


### PR DESCRIPTION
城市设计深化：

绿地10个加东西向连接属性：
- 走廊段: connectivity_role=north_south_spine + eco_segment(南/中/北)
- 社区公园: connectivity_role=east_west_link + wing_position(东/西) + connected_spine(连接到哪段绿脊)