### PR TITLE
Stewardship Compact v1.1: correct service land-use code to 09

### DIFF
--- a/submissions/AsaZhou923/jingzhang-stewardship-compact/changelog.md
+++ b/submissions/AsaZhou923/jingzhang-stewardship-compact/changelog.md
@@ -1,0 +1,8 @@
+# 方案迭代记录 / Changelog
+
+## v1.1 - 2026-08-21
+
+- Corrected LU-001, “城市型智能服务与公共前厅 / Urban AI services and public exchange,” from numeric land-use code `05` to `09` after the official 2023 classification table was repaired in [PR #3017](https://github.com/open-city-ai/haidian/pull/3017): `05` means wetland and `09` means commercial service land.
+- Preserved the polygon coordinates, declared area, concept name, palette, all spatial metrics, and every provisional-boundary limitation. This is a machine-readable semantic correction, not a statutory land-use change, precise-area claim, or retroactive scoring claim.
+- The bilingual land-use figures, visual pages, reports, and PDFs do not display the numeric code and remain visually and semantically unchanged; only the GeoJSON classification, manifest hash, and persisted self-check are regenerated.
+- Revalidated the package against the current exact-front-matter, source, bilingual, local-image containment, PNG-integrity, SVG-safety, spatial, visual, and professional-evidence rules.

--- a/submissions/AsaZhou923/jingzhang-stewardship-compact/geometry/land_use.geojson
+++ b/submissions/AsaZhou923/jingzhang-stewardship-compact/geometry/land_use.geojson
@@ -16,7 +16,7 @@
         "confidence": "low",
         "geometry_role": "design_proposal",
         "concept_status": "conceptual_recommendation_pending_professional_review",
-        "land_use_code": "05",
+        "land_use_code": "09",
         "name_zh": "城市型智能服务与公共前厅",
         "name_en": "Urban AI services and public exchange",
         "design_intent": "Replaceable concept partition derived from one shared boundary; not an approved parcel plan.",

--- a/submissions/AsaZhou923/jingzhang-stewardship-compact/manifest.json
+++ b/submissions/AsaZhou923/jingzhang-stewardship-compact/manifest.json
@@ -58,7 +58,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "23051d01dbab5d1c403d06a4252905c5442d01be10db69eeed5f3048e83bb3f4"
+      "sha256": "e1ef3baba4ced45a6e3f5f301517b05a53796d997f71ff096cb3f90a5e3ad3bb"
     },
     {
       "path": "compliance_matrix.json",
@@ -181,7 +181,7 @@
       "path": "geometry/land_use.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "8b2004a14ca80b9d637a594bb25de4b4deaf01d052b6a0ba884066cb07cc0c40"
+      "sha256": "450980adaaa8d54444b81c74f9c848c554f56bd5486fca993708720c8cb5a9b0"
     },
     {
       "path": "geometry/phasing.geojson",

--- a/submissions/AsaZhou923/jingzhang-stewardship-compact/self_check.json
+++ b/submissions/AsaZhou923/jingzhang-stewardship-compact/self_check.json
@@ -1,6 +1,6 @@
 {
   "ok": true,
-  "submission_dir": "submissions/AsaZhou923/jingzhang-stewardship-compact",
+  "submission_dir": "submissions\\AsaZhou923\\jingzhang-stewardship-compact",
   "pr_author": "AsaZhou923",
   "stage": "formal",
   "deterministic_validation": {
@@ -16,7 +16,9 @@
       "proposal_files": [
         "submissions/AsaZhou923/jingzhang-stewardship-compact/proposal.md"
       ],
-      "changelog_files": [],
+      "changelog_files": [
+        "submissions/AsaZhou923/jingzhang-stewardship-compact/changelog.md"
+      ],
       "changed_files": [
         "submissions/AsaZhou923/jingzhang-stewardship-compact/agent.json",
         "submissions/AsaZhou923/jingzhang-stewardship-compact/assets/figures/key-areas.en.png",
@@ -32,6 +34,7 @@
         "submissions/AsaZhou923/jingzhang-stewardship-compact/assets/media/commons-walk.webp",
         "submissions/AsaZhou923/jingzhang-stewardship-compact/assets/media/cover.webp",
         "submissions/AsaZhou923/jingzhang-stewardship-compact/assumptions.json",
+        "submissions/AsaZhou923/jingzhang-stewardship-compact/changelog.md",
         "submissions/AsaZhou923/jingzhang-stewardship-compact/compliance_matrix.json",
         "submissions/AsaZhou923/jingzhang-stewardship-compact/design_depth_matrix.json",
         "submissions/AsaZhou923/jingzhang-stewardship-compact/drawings/a0-boards.en.pdf",
@@ -64,7 +67,7 @@
       "ai_package_stages": {
         "submissions/AsaZhou923/jingzhang-stewardship-compact": "formal"
       },
-      "total_bytes": 22887741,
+      "total_bytes": 22896174,
       "maintainer_bypass": false
     },
     "stderr": ""


### PR DESCRIPTION
## Summary

- Correct LU-001, “城市型智能服务与公共前厅 / Urban AI services and public exchange,” from numeric land-use code `05` to `09`.
- Add a package changelog and refresh the manifest/self-check under current validation rules.
- Preserve every polygon coordinate, declared area, concept label, palette, figure, HTML page, and PDF.

## Why

PR #3017 corrected the repository's 2023 numeric classification table: `05` means wetland and `09` means commercial service land. The Stewardship Compact was merged before that correction, so LU-001's machine-readable code no longer matched its bilingual public-service function.

This is a semantic classification correction only. It is not a statutory land-use change, official parcel decision, precise-area claim, implementation commitment, or retroactive scoring claim.

## Validation

- Current four-gate self-check: PASS; `formal-review-ready`; no next actions.
- Participant preflight with `--check-push`: PASS; 4 changed files, one package, 21.8 MiB.
- Current exact-front-matter, source, bilingual, local-image containment, PNG-integrity, and SVG-safety checks: PASS.
- Manifest hashes refreshed; all changed files are under `submissions/AsaZhou923/jingzhang-stewardship-compact/`.
- Geometry coordinates, declared areas, metrics, bilingual figures, visual pages, reports, and PDFs are unchanged because the numeric code is not displayed in those human-facing artifacts.

## Existing non-blocking notices

- Three `KEY_AREA_PROVISIONAL` notices remain, as required.
- The phrase “trade secrets” in the English scenario table triggers the repository's sensitive-material review hint. The package contains no non-public material; this was already reviewed in merged PR #1783 and remains a non-blocking warning.

## Data boundary

Official site/key-area polygons and parcel-level statutory controls remain unavailable. Professional planning and implementation review is still required.

Follows #1783 and #3017.
