### PR TITLE
holistic-design: 同时修改4个文件空间关系

### DIFF
--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/buildings.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/buildings.geojson
@@ -13,7 +13,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.504
+        "area_sqm_declared": 5359.504,
+        "cluster_id": "NW",
+        "cluster_index": 1
       },
       "geometry": {
         "type": "Polygon",
@@ -54,7 +56,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.266
+        "area_sqm_declared": 5359.266,
+        "cluster_id": "NW",
+        "cluster_index": 2
       },
       "geometry": {
         "type": "Polygon",
@@ -95,7 +99,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.027
+        "area_sqm_declared": 5359.027,
+        "cluster_id": "NW",
+        "cluster_index": 3
       },
       "geometry": {
         "type": "Polygon",
@@ -136,7 +142,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.789
+        "area_sqm_declared": 5358.789,
+        "cluster_id": "NW",
+        "cluster_index": 4
       },
       "geometry": {
         "type": "Polygon",
@@ -177,7 +185,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.551
+        "area_sqm_declared": 5358.551,
+        "cluster_id": "NW",
+        "cluster_index": 5
       },
       "geometry": {
         "type": "Polygon",
@@ -218,7 +228,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.312
+        "area_sqm_declared": 5358.312,
+        "cluster_id": "NW",
+        "cluster_index": 6
       },
       "geometry": {
         "type": "Polygon",
@@ -259,7 +271,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.502
+        "area_sqm_declared": 5359.502,
+        "cluster_id": "NM",
+        "cluster_index": 1
       },
       "geometry": {
         "type": "Polygon",
@@ -300,7 +314,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.264
+        "area_sqm_declared": 5359.264,
+        "cluster_id": "NM",
+        "cluster_index": 2
       },
       "geometry": {
         "type": "Polygon",
@@ -341,7 +357,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.026
+        "area_sqm_declared": 5359.026,
+        "cluster_id": "NM",
+        "cluster_index": 3
       },
       "geometry": {
         "type": "Polygon",
@@ -382,7 +400,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.787
+        "area_sqm_declared": 5358.787,
+        "cluster_id": "NM",
+        "cluster_index": 4
       },
       "geometry": {
         "type": "Polygon",
@@ -423,7 +443,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.549
+        "area_sqm_declared": 5358.549,
+        "cluster_id": "NM",
+        "cluster_index": 5
       },
       "geometry": {
         "type": "Polygon",
@@ -464,7 +486,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.311
+        "area_sqm_declared": 5358.311,
+        "cluster_id": "NM",
+        "cluster_index": 6
       },
       "geometry": {
         "type": "Polygon",
@@ -505,7 +529,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.501
+        "area_sqm_declared": 5359.501,
+        "cluster_id": "NM",
+        "cluster_index": 7
       },
       "geometry": {
         "type": "Polygon",
@@ -546,7 +572,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.262
+        "area_sqm_declared": 5359.262,
+        "cluster_id": "NM",
+        "cluster_index": 8
       },
       "geometry": {
         "type": "Polygon",
@@ -587,7 +615,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.024
+        "area_sqm_declared": 5359.024,
+        "cluster_id": "NM",
+        "cluster_index": 9
       },
       "geometry": {
         "type": "Polygon",
@@ -628,7 +658,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.786
+        "area_sqm_declared": 5358.786,
+        "cluster_id": "NM",
+        "cluster_index": 10
       },
       "geometry": {
         "type": "Polygon",
@@ -669,7 +701,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.547
+        "area_sqm_declared": 5358.547,
+        "cluster_id": "NM",
+        "cluster_index": 11
       },
       "geometry": {
         "type": "Polygon",
@@ -710,7 +744,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.309
+        "area_sqm_declared": 5358.309,
+        "cluster_id": "NM",
+        "cluster_index": 12
       },
       "geometry": {
         "type": "Polygon",
@@ -751,7 +787,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.499
+        "area_sqm_declared": 5359.499,
+        "cluster_id": "NM",
+        "cluster_index": 13
       },
       "geometry": {
         "type": "Polygon",
@@ -792,7 +830,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.26
+        "area_sqm_declared": 5359.26,
+        "cluster_id": "NM",
+        "cluster_index": 14
       },
       "geometry": {
         "type": "Polygon",
@@ -833,7 +873,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.022
+        "area_sqm_declared": 5359.022,
+        "cluster_id": "NM",
+        "cluster_index": 15
       },
       "geometry": {
         "type": "Polygon",
@@ -874,7 +916,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.784
+        "area_sqm_declared": 5358.784,
+        "cluster_id": "NM",
+        "cluster_index": 16
       },
       "geometry": {
         "type": "Polygon",
@@ -915,7 +959,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.545
+        "area_sqm_declared": 5358.545,
+        "cluster_id": "NM",
+        "cluster_index": 17
       },
       "geometry": {
         "type": "Polygon",
@@ -956,7 +1002,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.307
+        "area_sqm_declared": 5358.307,
+        "cluster_id": "NM",
+        "cluster_index": 18
       },
       "geometry": {
         "type": "Polygon",
@@ -997,7 +1045,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.497
+        "area_sqm_declared": 5359.497,
+        "cluster_id": "NM",
+        "cluster_index": 19
       },
       "geometry": {
         "type": "Polygon",
@@ -1038,7 +1088,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.259
+        "area_sqm_declared": 5359.259,
+        "cluster_id": "NM",
+        "cluster_index": 20
       },
       "geometry": {
         "type": "Polygon",
@@ -1079,7 +1131,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.02
+        "area_sqm_declared": 5359.02,
+        "cluster_id": "NM",
+        "cluster_index": 21
       },
       "geometry": {
         "type": "Polygon",
@@ -1120,7 +1174,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.782
+        "area_sqm_declared": 5358.782,
+        "cluster_id": "NM",
+        "cluster_index": 22
       },
       "geometry": {
         "type": "Polygon",
@@ -1161,7 +1217,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.544
+        "area_sqm_declared": 5358.544,
+        "cluster_id": "NM",
+        "cluster_index": 23
       },
       "geometry": {
         "type": "Polygon",
@@ -1202,7 +1260,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.305
+        "area_sqm_declared": 5358.305,
+        "cluster_id": "NM",
+        "cluster_index": 24
       },
       "geometry": {
         "type": "Polygon",
@@ -1243,7 +1303,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.495
+        "area_sqm_declared": 5359.495,
+        "cluster_id": "NE",
+        "cluster_index": 1
       },
       "geometry": {
         "type": "Polygon",
@@ -1284,7 +1346,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.257
+        "area_sqm_declared": 5359.257,
+        "cluster_id": "NE",
+        "cluster_index": 2
       },
       "geometry": {
         "type": "Polygon",
@@ -1325,7 +1389,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.019
+        "area_sqm_declared": 5359.019,
+        "cluster_id": "NE",
+        "cluster_index": 3
       },
       "geometry": {
         "type": "Polygon",
@@ -1366,7 +1432,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.78
+        "area_sqm_declared": 5358.78,
+        "cluster_id": "NE",
+        "cluster_index": 4
       },
       "geometry": {
         "type": "Polygon",
@@ -1407,7 +1475,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.542
+        "area_sqm_declared": 5358.542,
+        "cluster_id": "NE",
+        "cluster_index": 5
       },
       "geometry": {
         "type": "Polygon",
@@ -1448,7 +1518,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.304
+        "area_sqm_declared": 5358.304,
+        "cluster_id": "NE",
+        "cluster_index": 6
       },
       "geometry": {
         "type": "Polygon",
@@ -1489,7 +1561,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.494
+        "area_sqm_declared": 5359.494,
+        "cluster_id": "NE",
+        "cluster_index": 7
       },
       "geometry": {
         "type": "Polygon",
@@ -1530,7 +1604,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.255
+        "area_sqm_declared": 5359.255,
+        "cluster_id": "NE",
+        "cluster_index": 8
       },
       "geometry": {
         "type": "Polygon",
@@ -1571,7 +1647,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.017
+        "area_sqm_declared": 5359.017,
+        "cluster_id": "NE",
+        "cluster_index": 9
       },
       "geometry": {
         "type": "Polygon",
@@ -1612,7 +1690,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.779
+        "area_sqm_declared": 5358.779,
+        "cluster_id": "NE",
+        "cluster_index": 10
       },
       "geometry": {
         "type": "Polygon",
@@ -1653,7 +1733,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.54
+        "area_sqm_declared": 5358.54,
+        "cluster_id": "NE",
+        "cluster_index": 11
       },
       "geometry": {
         "type": "Polygon",
@@ -1694,7 +1776,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.302
+        "area_sqm_declared": 5358.302,
+        "cluster_id": "NE",
+        "cluster_index": 12
       },
       "geometry": {
         "type": "Polygon",
@@ -1735,7 +1819,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.492
+        "area_sqm_declared": 5359.492,
+        "cluster_id": "NE",
+        "cluster_index": 13
       },
       "geometry": {
         "type": "Polygon",
@@ -1776,7 +1862,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.254
+        "area_sqm_declared": 5359.254,
+        "cluster_id": "NE",
+        "cluster_index": 14
       },
       "geometry": {
         "type": "Polygon",
@@ -1817,7 +1905,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.015
+        "area_sqm_declared": 5359.015,
+        "cluster_id": "NE",
+        "cluster_index": 15
       },
       "geometry": {
         "type": "Polygon",
@@ -1858,7 +1948,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.777
+        "area_sqm_declared": 5358.777,
+        "cluster_id": "NE",
+        "cluster_index": 16
       },
       "geometry": {
         "type": "Polygon",
@@ -1899,7 +1991,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.539
+        "area_sqm_declared": 5358.539,
+        "cluster_id": "NE",
+        "cluster_index": 17
       },
       "geometry": {
         "type": "Polygon",
@@ -1940,7 +2034,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.3
+        "area_sqm_declared": 5358.3,
+        "cluster_id": "NE",
+        "cluster_index": 18
       },
       "geometry": {
         "type": "Polygon",
@@ -1981,7 +2077,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6210.093
+        "area_sqm_declared": 6210.093,
+        "cluster_id": "CW",
+        "cluster_index": 1
       },
       "geometry": {
         "type": "Polygon",
@@ -2022,7 +2120,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.869
+        "area_sqm_declared": 6209.869,
+        "cluster_id": "CW",
+        "cluster_index": 2
       },
       "geometry": {
         "type": "Polygon",
@@ -2063,7 +2163,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.646
+        "area_sqm_declared": 6209.646,
+        "cluster_id": "CW",
+        "cluster_index": 3
       },
       "geometry": {
         "type": "Polygon",
@@ -2104,7 +2206,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.422
+        "area_sqm_declared": 6209.422,
+        "cluster_id": "NW",
+        "cluster_index": 7
       },
       "geometry": {
         "type": "Polygon",
@@ -2145,7 +2249,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6210.091
+        "area_sqm_declared": 6210.091,
+        "cluster_id": "CM",
+        "cluster_index": 1
       },
       "geometry": {
         "type": "Polygon",
@@ -2186,7 +2292,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.867
+        "area_sqm_declared": 6209.867,
+        "cluster_id": "CM",
+        "cluster_index": 2
       },
       "geometry": {
         "type": "Polygon",
@@ -2227,7 +2335,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.643
+        "area_sqm_declared": 6209.643,
+        "cluster_id": "CM",
+        "cluster_index": 3
       },
       "geometry": {
         "type": "Polygon",
@@ -2268,7 +2378,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.419
+        "area_sqm_declared": 6209.419,
+        "cluster_id": "NM",
+        "cluster_index": 25
       },
       "geometry": {
         "type": "Polygon",
@@ -2309,7 +2421,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6210.088
+        "area_sqm_declared": 6210.088,
+        "cluster_id": "CM",
+        "cluster_index": 4
       },
       "geometry": {
         "type": "Polygon",
@@ -2350,7 +2464,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.864
+        "area_sqm_declared": 6209.864,
+        "cluster_id": "CM",
+        "cluster_index": 5
       },
       "geometry": {
         "type": "Polygon",
@@ -2391,7 +2507,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.64
+        "area_sqm_declared": 6209.64,
+        "cluster_id": "CM",
+        "cluster_index": 6
       },
       "geometry": {
         "type": "Polygon",
@@ -2432,7 +2550,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.417
+        "area_sqm_declared": 6209.417,
+        "cluster_id": "NM",
+        "cluster_index": 26
       },
       "geometry": {
         "type": "Polygon",
@@ -2473,7 +2593,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6210.085
+        "area_sqm_declared": 6210.085,
+        "cluster_id": "CM",
+        "cluster_index": 7
       },
       "geometry": {
         "type": "Polygon",
@@ -2514,7 +2636,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.861
+        "area_sqm_declared": 6209.861,
+        "cluster_id": "CM",
+        "cluster_index": 8
       },
       "geometry": {
         "type": "Polygon",
@@ -2555,7 +2679,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.638
+        "area_sqm_declared": 6209.638,
+        "cluster_id": "CM",
+        "cluster_index": 9
       },
       "geometry": {
         "type": "Polygon",
@@ -2596,7 +2722,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.414
+        "area_sqm_declared": 6209.414,
+        "cluster_id": "NM",
+        "cluster_index": 27
       },
       "geometry": {
         "type": "Polygon",
@@ -2637,7 +2765,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6210.083
+        "area_sqm_declared": 6210.083,
+        "cluster_id": "CE",
+        "cluster_index": 1
       },
       "geometry": {
         "type": "Polygon",
@@ -2678,7 +2808,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.859
+        "area_sqm_declared": 6209.859,
+        "cluster_id": "CE",
+        "cluster_index": 2
       },
       "geometry": {
         "type": "Polygon",
@@ -2719,7 +2851,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.635
+        "area_sqm_declared": 6209.635,
+        "cluster_id": "CE",
+        "cluster_index": 3
       },
       "geometry": {
         "type": "Polygon",
@@ -2760,7 +2894,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.411
+        "area_sqm_declared": 6209.411,
+        "cluster_id": "NE",
+        "cluster_index": 19
       },
       "geometry": {
         "type": "Polygon",
@@ -2801,7 +2937,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6210.08
+        "area_sqm_declared": 6210.08,
+        "cluster_id": "CE",
+        "cluster_index": 4
       },
       "geometry": {
         "type": "Polygon",
@@ -2842,7 +2980,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.856
+        "area_sqm_declared": 6209.856,
+        "cluster_id": "CE",
+        "cluster_index": 5
       },
       "geometry": {
         "type": "Polygon",
@@ -2883,7 +3023,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.632
+        "area_sqm_declared": 6209.632,
+        "cluster_id": "CE",
+        "cluster_index": 6
       },
       "geometry": {
         "type": "Polygon",
@@ -2924,7 +3066,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.409
+        "area_sqm_declared": 6209.409,
+        "cluster_id": "NE",
+        "cluster_index": 20
       },
       "geometry": {
         "type": "Polygon",
@@ -2965,7 +3109,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.969
+        "area_sqm_declared": 6003.969,
+        "cluster_id": "SW",
+        "cluster_index": 1
       },
       "geometry": {
         "type": "Polygon",
@@ -3006,7 +3152,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.801
+        "area_sqm_declared": 6003.801,
+        "cluster_id": "SW",
+        "cluster_index": 2
       },
       "geometry": {
         "type": "Polygon",
@@ -3047,7 +3195,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.633
+        "area_sqm_declared": 6003.633,
+        "cluster_id": "SW",
+        "cluster_index": 3
       },
       "geometry": {
         "type": "Polygon",
@@ -3088,7 +3238,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.965
+        "area_sqm_declared": 6003.965,
+        "cluster_id": "SM",
+        "cluster_index": 1
       },
       "geometry": {
         "type": "Polygon",
@@ -3129,7 +3281,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.797
+        "area_sqm_declared": 6003.797,
+        "cluster_id": "SM",
+        "cluster_index": 2
       },
       "geometry": {
         "type": "Polygon",
@@ -3170,7 +3324,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.629
+        "area_sqm_declared": 6003.629,
+        "cluster_id": "SM",
+        "cluster_index": 3
       },
       "geometry": {
         "type": "Polygon",
@@ -3211,7 +3367,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.962
+        "area_sqm_declared": 6003.962,
+        "cluster_id": "SM",
+        "cluster_index": 4
       },
       "geometry": {
         "type": "Polygon",
@@ -3252,7 +3410,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.794
+        "area_sqm_declared": 6003.794,
+        "cluster_id": "SM",
+        "cluster_index": 5
       },
       "geometry": {
         "type": "Polygon",
@@ -3293,7 +3453,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.625
+        "area_sqm_declared": 6003.625,
+        "cluster_id": "SM",
+        "cluster_index": 6
       },
       "geometry": {
         "type": "Polygon",
@@ -3334,7 +3496,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.958
+        "area_sqm_declared": 6003.958,
+        "cluster_id": "SE",
+        "cluster_index": 1
       },
       "geometry": {
         "type": "Polygon",
@@ -3375,7 +3539,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.79
+        "area_sqm_declared": 6003.79,
+        "cluster_id": "SE",
+        "cluster_index": 2
       },
       "geometry": {
         "type": "Polygon",
@@ -3416,7 +3582,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.622
+        "area_sqm_declared": 6003.622,
+        "cluster_id": "SE",
+        "cluster_index": 3
       },
       "geometry": {
         "type": "Polygon",
@@ -3457,7 +3625,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.954
+        "area_sqm_declared": 6003.954,
+        "cluster_id": "SE",
+        "cluster_index": 4
       },
       "geometry": {
         "type": "Polygon",
@@ -3498,7 +3668,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.786
+        "area_sqm_declared": 6003.786,
+        "cluster_id": "SE",
+        "cluster_index": 5
       },
       "geometry": {
         "type": "Polygon",
@@ -3539,7 +3711,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.618
+        "area_sqm_declared": 6003.618,
+        "cluster_id": "SE",
+        "cluster_index": 6
       },
       "geometry": {
         "type": "Polygon",
@@ -3580,7 +3754,9 @@
         "geometry_role": "design_proposal",
         "building_type": "residential",
         "name_zh": "居住建筑",
-        "area_sqm_declared": 4554.819
+        "area_sqm_declared": 4554.819,
+        "cluster_id": "SW",
+        "cluster_index": 4
       },
       "geometry": {
         "type": "Polygon",
@@ -3621,7 +3797,9 @@
         "geometry_role": "design_proposal",
         "building_type": "residential",
         "name_zh": "居住建筑",
-        "area_sqm_declared": 4554.163
+        "area_sqm_declared": 4554.163,
+        "cluster_id": "SW",
+        "cluster_index": 5
       },
       "geometry": {
         "type": "Polygon",
@@ -3662,7 +3840,9 @@
         "geometry_role": "design_proposal",
         "building_type": "residential",
         "name_zh": "居住建筑",
-        "area_sqm_declared": 4553.508
+        "area_sqm_declared": 4553.508,
+        "cluster_id": "CW",
+        "cluster_index": 4
       },
       "geometry": {
         "type": "Polygon",
@@ -3703,7 +3883,9 @@
         "geometry_role": "design_proposal",
         "building_type": "residential",
         "name_zh": "居住建筑",
-        "area_sqm_declared": 4553.507
+        "area_sqm_declared": 4553.507,
+        "cluster_id": "CW",
+        "cluster_index": 5
       },
       "geometry": {
         "type": "Polygon",
@@ -3744,7 +3926,9 @@
         "geometry_role": "design_proposal",
         "building_type": "residential",
         "name_zh": "居住建筑",
-        "area_sqm_declared": 4552.851
+        "area_sqm_declared": 4552.851,
+        "cluster_id": "CW",
+        "cluster_index": 6
       },
       "geometry": {
         "type": "Polygon",
@@ -3785,7 +3969,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4555.333
+        "area_sqm_declared": 4555.333,
+        "cluster_id": "SE",
+        "cluster_index": 7
       },
       "geometry": {
         "type": "Polygon",
@@ -3826,7 +4012,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4555.331
+        "area_sqm_declared": 4555.331,
+        "cluster_id": "SE",
+        "cluster_index": 8
       },
       "geometry": {
         "type": "Polygon",
@@ -3867,7 +4055,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4555.328
+        "area_sqm_declared": 4555.328,
+        "cluster_id": "SE",
+        "cluster_index": 9
       },
       "geometry": {
         "type": "Polygon",
@@ -3908,7 +4098,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4554.808
+        "area_sqm_declared": 4554.808,
+        "cluster_id": "SE",
+        "cluster_index": 10
       },
       "geometry": {
         "type": "Polygon",
@@ -3949,7 +4141,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4554.806
+        "area_sqm_declared": 4554.806,
+        "cluster_id": "SE",
+        "cluster_index": 11
       },
       "geometry": {
         "type": "Polygon",
@@ -3990,7 +4184,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4554.804
+        "area_sqm_declared": 4554.804,
+        "cluster_id": "SE",
+        "cluster_index": 12
       },
       "geometry": {
         "type": "Polygon",
@@ -4031,7 +4227,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4554.153
+        "area_sqm_declared": 4554.153,
+        "cluster_id": "SE",
+        "cluster_index": 13
       },
       "geometry": {
         "type": "Polygon",
@@ -4072,7 +4270,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4554.151
+        "area_sqm_declared": 4554.151,
+        "cluster_id": "SE",
+        "cluster_index": 14
       },
       "geometry": {
         "type": "Polygon",
@@ -4113,7 +4313,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4554.149
+        "area_sqm_declared": 4554.149,
+        "cluster_id": "SE",
+        "cluster_index": 15
       },
       "geometry": {
         "type": "Polygon",
@@ -4154,7 +4356,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4553.497
+        "area_sqm_declared": 4553.497,
+        "cluster_id": "CE",
+        "cluster_index": 7
       },
       "geometry": {
         "type": "Polygon",
@@ -4195,7 +4399,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4553.495
+        "area_sqm_declared": 4553.495,
+        "cluster_id": "CE",
+        "cluster_index": 8
       },
       "geometry": {
         "type": "Polygon",
@@ -4236,7 +4442,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4553.493
+        "area_sqm_declared": 4553.493,
+        "cluster_id": "CE",
+        "cluster_index": 9
       },
       "geometry": {
         "type": "Polygon",
@@ -4277,7 +4485,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4552.841
+        "area_sqm_declared": 4552.841,
+        "cluster_id": "CE",
+        "cluster_index": 10
       },
       "geometry": {
         "type": "Polygon",
@@ -4318,7 +4528,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4552.839
+        "area_sqm_declared": 4552.839,
+        "cluster_id": "CE",
+        "cluster_index": 11
       },
       "geometry": {
         "type": "Polygon",
@@ -4359,7 +4571,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 432.52
+        "area_sqm_declared": 432.52,
+        "cluster_id": "CE",
+        "cluster_index": 12
       },
       "geometry": {
         "type": "Polygon",
@@ -4400,7 +4614,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4551.529
+        "area_sqm_declared": 4551.529,
+        "cluster_id": "NE",
+        "cluster_index": 21
       },
       "geometry": {
         "type": "Polygon",
@@ -4441,7 +4657,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4551.527
+        "area_sqm_declared": 4551.527,
+        "cluster_id": "NE",
+        "cluster_index": 22
       },
       "geometry": {
         "type": "Polygon",
@@ -4482,7 +4700,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 2345.567
+        "area_sqm_declared": 2345.567,
+        "cluster_id": "NE",
+        "cluster_index": 23
       },
       "geometry": {
         "type": "Polygon",
@@ -4523,7 +4743,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4550.212
+        "area_sqm_declared": 4550.212,
+        "cluster_id": "NE",
+        "cluster_index": 24
       },
       "geometry": {
         "type": "Polygon",
@@ -4564,7 +4786,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2847.089
+        "area_sqm_declared": 2847.089,
+        "cluster_id": "SM",
+        "cluster_index": 7
       },
       "geometry": {
         "type": "Polygon",
@@ -4605,7 +4829,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2847.088
+        "area_sqm_declared": 2847.088,
+        "cluster_id": "SM",
+        "cluster_index": 8
       },
       "geometry": {
         "type": "Polygon",
@@ -4646,7 +4872,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2847.088
+        "area_sqm_declared": 2847.088,
+        "cluster_id": "SM",
+        "cluster_index": 9
       },
       "geometry": {
         "type": "Polygon",
@@ -4687,7 +4915,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.557
+        "area_sqm_declared": 2846.557,
+        "cluster_id": "SM",
+        "cluster_index": 10
       },
       "geometry": {
         "type": "Polygon",
@@ -4728,7 +4958,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.556
+        "area_sqm_declared": 2846.556,
+        "cluster_id": "SM",
+        "cluster_index": 11
       },
       "geometry": {
         "type": "Polygon",
@@ -4769,7 +5001,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.555
+        "area_sqm_declared": 2846.555,
+        "cluster_id": "SM",
+        "cluster_index": 12
       },
       "geometry": {
         "type": "Polygon",
@@ -4810,7 +5044,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.27
+        "area_sqm_declared": 2846.27,
+        "cluster_id": "SM",
+        "cluster_index": 13
       },
       "geometry": {
         "type": "Polygon",
@@ -4851,7 +5087,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.269
+        "area_sqm_declared": 2846.269,
+        "cluster_id": "SM",
+        "cluster_index": 14
       },
       "geometry": {
         "type": "Polygon",
@@ -4892,7 +5130,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.268
+        "area_sqm_declared": 2846.268,
+        "cluster_id": "SM",
+        "cluster_index": 15
       },
       "geometry": {
         "type": "Polygon",
@@ -4933,7 +5173,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.024
+        "area_sqm_declared": 2846.024,
+        "cluster_id": "CM",
+        "cluster_index": 10
       },
       "geometry": {
         "type": "Polygon",
@@ -4974,7 +5216,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.023
+        "area_sqm_declared": 2846.023,
+        "cluster_id": "CM",
+        "cluster_index": 11
       },
       "geometry": {
         "type": "Polygon",
@@ -5015,7 +5259,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.022
+        "area_sqm_declared": 2846.022,
+        "cluster_id": "CM",
+        "cluster_index": 12
       },
       "geometry": {
         "type": "Polygon",
@@ -5056,7 +5302,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2845.614
+        "area_sqm_declared": 2845.614,
+        "cluster_id": "CM",
+        "cluster_index": 13
       },
       "geometry": {
         "type": "Polygon",
@@ -5097,7 +5345,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2845.613
+        "area_sqm_declared": 2845.613,
+        "cluster_id": "CM",
+        "cluster_index": 14
       },
       "geometry": {
         "type": "Polygon",
@@ -5138,7 +5388,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2845.613
+        "area_sqm_declared": 2845.613,
+        "cluster_id": "CM",
+        "cluster_index": 15
       },
       "geometry": {
         "type": "Polygon",
@@ -5179,7 +5431,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2844.63
+        "area_sqm_declared": 2844.63,
+        "cluster_id": "NM",
+        "cluster_index": 28
       },
       "geometry": {
         "type": "Polygon",
@@ -5220,7 +5474,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2844.629
+        "area_sqm_declared": 2844.629,
+        "cluster_id": "NM",
+        "cluster_index": 29
       },
       "geometry": {
         "type": "Polygon",
@@ -5261,7 +5517,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2844.629
+        "area_sqm_declared": 2844.629,
+        "cluster_id": "NM",
+        "cluster_index": 30
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/green_space.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/green_space.geojson
@@ -13,7 +13,12 @@
         "geometry_role": "design_proposal",
         "green_type": "park_green",
         "name_zh": "遗址公园服务绿脊(南段)",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "serves_zone": "S",
+        "serves_wing": "M",
+        "serves_clusters": [
+          "SM"
+        ]
       },
       "geometry": {
         "type": "Polygon",
@@ -54,7 +59,12 @@
         "geometry_role": "design_proposal",
         "green_type": "park_green",
         "name_zh": "遗址公园服务绿脊(中段)",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "serves_zone": "C",
+        "serves_wing": "M",
+        "serves_clusters": [
+          "CM"
+        ]
       },
       "geometry": {
         "type": "Polygon",
@@ -95,7 +105,12 @@
         "geometry_role": "design_proposal",
         "green_type": "park_green",
         "name_zh": "遗址公园服务绿脊(北段)",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "serves_zone": "N",
+        "serves_wing": "M",
+        "serves_clusters": [
+          "NM"
+        ]
       },
       "geometry": {
         "type": "Polygon",
@@ -136,7 +151,12 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "西侧社区公园A",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "serves_zone": "S",
+        "serves_wing": "W",
+        "serves_clusters": [
+          "SW"
+        ]
       },
       "geometry": {
         "type": "Polygon",
@@ -177,7 +197,12 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "西侧社区公园B",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "serves_zone": "S",
+        "serves_wing": "W",
+        "serves_clusters": [
+          "SW"
+        ]
       },
       "geometry": {
         "type": "Polygon",
@@ -218,7 +243,12 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "西侧社区公园C",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "serves_zone": "C",
+        "serves_wing": "W",
+        "serves_clusters": [
+          "CW"
+        ]
       },
       "geometry": {
         "type": "Polygon",
@@ -259,7 +289,12 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "东侧社区公园A",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "serves_zone": "S",
+        "serves_wing": "E",
+        "serves_clusters": [
+          "SE"
+        ]
       },
       "geometry": {
         "type": "Polygon",
@@ -300,7 +335,12 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "东侧社区公园B",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "serves_zone": "C",
+        "serves_wing": "E",
+        "serves_clusters": [
+          "CE"
+        ]
       },
       "geometry": {
         "type": "Polygon",
@@ -341,7 +381,12 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "东侧社区公园C",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "serves_zone": "N",
+        "serves_wing": "E",
+        "serves_clusters": [
+          "NE"
+        ]
       },
       "geometry": {
         "type": "Polygon",
@@ -382,7 +427,12 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "东侧社区公园D",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "serves_zone": "N",
+        "serves_wing": "E",
+        "serves_clusters": [
+          "NE"
+        ]
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/land_use.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/land_use.geojson
@@ -13,7 +13,8 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0702",
         "name_zh": "南侧居住与配套用地",
-        "area_sqm_declared": 163096.297
+        "area_sqm_declared": 163096.297,
+        "nearest_road": "ROAD-EW-2"
       },
       "geometry": {
         "type": "Polygon",
@@ -66,7 +67,8 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
         "name_zh": "AI产业集聚研发用地",
-        "area_sqm_declared": 246713.264
+        "area_sqm_declared": 246713.264,
+        "nearest_road": "ROAD-EW-2"
       },
       "geometry": {
         "type": "Polygon",
@@ -115,7 +117,8 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
         "name_zh": "AI产业集聚研发用地",
-        "area_sqm_declared": 1801002.535
+        "area_sqm_declared": 1801002.535,
+        "nearest_road": "ROAD-EW-2"
       },
       "geometry": {
         "type": "Polygon",
@@ -172,7 +175,8 @@
         "geometry_role": "design_proposal",
         "land_use_code": "05",
         "name_zh": "AI智能原生商业体验用地",
-        "area_sqm_declared": 1480278.362
+        "area_sqm_declared": 1480278.362,
+        "nearest_road": "ROAD-EW-2"
       },
       "geometry": {
         "type": "Polygon",
@@ -237,7 +241,8 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0702",
         "name_zh": "西侧居住社区用地",
-        "area_sqm_declared": 287719.802
+        "area_sqm_declared": 287719.802,
+        "nearest_road": "ROAD-NS-1"
       },
       "geometry": {
         "type": "Polygon",
@@ -302,7 +307,8 @@
         "geometry_role": "design_proposal",
         "land_use_code": "1401",
         "name_zh": "京张遗址公园绿地",
-        "area_sqm_declared": 569190.321
+        "area_sqm_declared": 569190.321,
+        "nearest_road": "ROAD-EW-4"
       },
       "geometry": {
         "type": "Polygon",
@@ -359,7 +365,8 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0702",
         "name_zh": "东侧居住社区用地",
-        "area_sqm_declared": 654570.399
+        "area_sqm_declared": 654570.399,
+        "nearest_road": "ROAD-EW-4"
       },
       "geometry": {
         "type": "Polygon",
@@ -408,7 +415,8 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
         "name_zh": "AI原点社区创新用地",
-        "area_sqm_declared": 261735.324
+        "area_sqm_declared": 261735.324,
+        "nearest_road": "ROAD-NS-1"
       },
       "geometry": {
         "type": "Polygon",
@@ -473,7 +481,8 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
         "name_zh": "AI原点社区创新用地",
-        "area_sqm_declared": 1018509.885
+        "area_sqm_declared": 1018509.885,
+        "nearest_road": "ROAD-EW-5"
       },
       "geometry": {
         "type": "Polygon",
@@ -534,7 +543,8 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
         "name_zh": "AI创新社区公共空间用地",
-        "area_sqm_declared": 1052785.966
+        "area_sqm_declared": 1052785.966,
+        "nearest_road": "ROAD-EW-5"
       },
       "geometry": {
         "type": "Polygon",
@@ -599,7 +609,8 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
         "name_zh": "西侧科研配套用地",
-        "area_sqm_declared": 41523.599
+        "area_sqm_declared": 41523.599,
+        "nearest_road": "ROAD-NS-1"
       },
       "geometry": {
         "type": "Polygon",
@@ -652,7 +663,8 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
         "name_zh": "西侧科研配套用地",
-        "area_sqm_declared": 5000.277
+        "area_sqm_declared": 5000.277,
+        "nearest_road": "ROAD-NS-2"
       },
       "geometry": {
         "type": "Polygon",
@@ -689,7 +701,8 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
         "name_zh": "AI研发创新与公共平台用地",
-        "area_sqm_declared": 1829638.973
+        "area_sqm_declared": 1829638.973,
+        "nearest_road": "ROAD-NS-2"
       },
       "geometry": {
         "type": "Polygon",
@@ -758,7 +771,8 @@
         "geometry_role": "design_proposal",
         "land_use_code": "0802",
         "name_zh": "AI全栈研发创新用地",
-        "area_sqm_declared": 2001072.359
+        "area_sqm_declared": 2001072.359,
+        "nearest_road": "ROAD-NS-4"
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/public_space.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/public_space.geojson
@@ -13,7 +13,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "plaza",
         "name_zh": "众智园AI创新广场",
-        "area_sqm_declared": 42818.137
+        "area_sqm_declared": 42818.137,
+        "nearest_road": "ROAD-EW-8",
+        "distance_to_road_m": 199,
+        "serves_cluster": "NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -294,7 +297,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "plaza",
         "name_zh": "AI原点社区广场",
-        "area_sqm_declared": 29746.938
+        "area_sqm_declared": 29746.938,
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 71,
+        "serves_cluster": "CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -575,7 +581,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "plaza",
         "name_zh": "大钟寺AI城市客厅",
-        "area_sqm_declared": 29764.747
+        "area_sqm_declared": 29764.747,
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 263,
+        "serves_cluster": "SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -856,7 +865,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
         "name_zh": "京张绿廊活动节点1",
-        "area_sqm_declared": 19050.802
+        "area_sqm_declared": 19050.802,
+        "nearest_road": "ROAD-EW-1",
+        "distance_to_road_m": 1,
+        "serves_cluster": "SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -1137,7 +1149,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
         "name_zh": "京张绿廊活动节点2",
-        "area_sqm_declared": 19047.239
+        "area_sqm_declared": 19047.239,
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 140,
+        "serves_cluster": "SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -1418,7 +1433,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
         "name_zh": "京张绿廊活动节点3",
-        "area_sqm_declared": 19043.126
+        "area_sqm_declared": 19043.126,
+        "nearest_road": "ROAD-EW-4",
+        "distance_to_road_m": 1,
+        "serves_cluster": "CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -1699,7 +1717,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
         "name_zh": "京张绿廊活动节点4",
-        "area_sqm_declared": 19034.347
+        "area_sqm_declared": 19034.347,
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 238,
+        "serves_cluster": "NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -1980,7 +2001,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
         "name_zh": "京张绿廊活动节点5",
-        "area_sqm_declared": 19029.955
+        "area_sqm_declared": 19029.955,
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 141,
+        "serves_cluster": "NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -2261,7 +2285,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园1",
-        "area_sqm_declared": 7441.189
+        "area_sqm_declared": 7441.189,
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 256,
+        "serves_cluster": "SW"
       },
       "geometry": {
         "type": "Polygon",
@@ -2542,7 +2569,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园1",
-        "area_sqm_declared": 7441.18
+        "area_sqm_declared": 7441.18,
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 226,
+        "serves_cluster": "SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -2823,7 +2853,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园2",
-        "area_sqm_declared": 7439.261
+        "area_sqm_declared": 7439.261,
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 169,
+        "serves_cluster": "SW"
       },
       "geometry": {
         "type": "Polygon",
@@ -3104,7 +3137,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园2",
-        "area_sqm_declared": 7439.252
+        "area_sqm_declared": 7439.252,
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 119,
+        "serves_cluster": "SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -3385,7 +3421,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园3",
-        "area_sqm_declared": 7437.868
+        "area_sqm_declared": 7437.868,
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 169,
+        "serves_cluster": "CW"
       },
       "geometry": {
         "type": "Polygon",
@@ -3666,7 +3705,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园3",
-        "area_sqm_declared": 7437.86
+        "area_sqm_declared": 7437.86,
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 119,
+        "serves_cluster": "CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -3947,7 +3989,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园4",
-        "area_sqm_declared": 7436.047
+        "area_sqm_declared": 7436.047,
+        "nearest_road": "ROAD-NS-1",
+        "distance_to_road_m": 129,
+        "serves_cluster": "NW"
       },
       "geometry": {
         "type": "Polygon",
@@ -4228,7 +4273,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园4",
-        "area_sqm_declared": 7436.038
+        "area_sqm_declared": 7436.038,
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 119,
+        "serves_cluster": "NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -4509,7 +4557,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园5",
-        "area_sqm_declared": 7434.653
+        "area_sqm_declared": 7434.653,
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 169,
+        "serves_cluster": "NW"
       },
       "geometry": {
         "type": "Polygon",
@@ -4790,7 +4841,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园5",
-        "area_sqm_declared": 7434.644
+        "area_sqm_declared": 7434.644,
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 119,
+        "serves_cluster": "NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -5071,7 +5125,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园6",
-        "area_sqm_declared": 3901.099
+        "area_sqm_declared": 3901.099,
+        "nearest_road": "ROAD-EW-9",
+        "distance_to_road_m": 218,
+        "serves_cluster": "NW"
       },
       "geometry": {
         "type": "Polygon",
@@ -5232,7 +5289,10 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园6",
-        "area_sqm_declared": 7433.143
+        "area_sqm_declared": 7433.143,
+        "nearest_road": "ROAD-EW-9",
+        "distance_to_road_m": 119,
+        "serves_cluster": "NM"
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
@@ -64,7 +64,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "b9839f810e46cbb6e22190acef6c60cee9e09de2b993485c3e1e40d07a7ca387"
+      "sha256": "1bbce531b71c73d945daf02713b7271e259f6e195204f09161253e0265eccd51"
     },
     {
       "path": "compliance_matrix.json",
@@ -235,7 +235,7 @@
       "path": "geometry/buildings.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "bc9e0f74a2f627650e2aa5e82881e617c73561f9e2566a32aec958b32a001595"
+      "sha256": "15f2c9d86c17bff8a1d97aa289f1a3597c84ee23e1b5dcdf745602fa579326cf"
     },
     {
       "path": "geometry/constraints.geojson",
@@ -247,7 +247,7 @@
       "path": "geometry/green_space.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "6203a2a5fc5a674319dc821f06a8406ad0d721a244bcc9966b094e18c12949be"
+      "sha256": "67da3a4e7574fb821cd000d51239eb0971fe8ac585a992355c8a13117e13169e"
     },
     {
       "path": "geometry/key_areas.geojson",
@@ -259,7 +259,7 @@
       "path": "geometry/land_use.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "9c6b0b0a8f5f87c31add125dc66f06f06cef8e971e495d8b16d1f72c2997ce57"
+      "sha256": "ba2648eac701e67169c51eab850fbbed005e4349e3842d5f2baee745ce27b600"
     },
     {
       "path": "geometry/phasing.geojson",
@@ -271,7 +271,7 @@
       "path": "geometry/public_space.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "dd8a52b3a391117fbef6dbfaca174019875383bfe6d3b102ac4be32c72a9bdcc"
+      "sha256": "d442486455f423541f251f10042d5d53d80d5fe2e24220460677b7f55c66b71b"
     },
     {
       "path": "geometry/roads.geojson",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
@@ -85,7 +85,7 @@
       "ai_package_stages": {
         "submissions/565431hzhang/jingzhang-ai-heritage-halo": "formal"
       },
-      "total_bytes": 5251147,
+      "total_bytes": 5262131,
       "maintainer_bypass": false
     },
     "stderr": ""


### PR DESCRIPTION
城市设计改动——同时修改4个geometry文件的空间关系：

1. 建筑129栋: 分为9个组团(NW/NM/NE/CW/CM/CE/SW/SM/SE), 加cluster_id+cluster_index
2. 绿地10个: 加serves_zone(南/中/北)+serves_wing(东/西/中)+serves_clusters(连接的建筑组团)
3. 公共空间20个: 加nearest_road(最近道路)+distance_to_road_m(距离)+serves_cluster(服务的建筑组团)
4. 用地14块: 加nearest_road(最近道路)

不改坐标，只加空间关系属性，让4个文件之间形成协调的整体