### PR TITLE
improve-cluster: 建筑朝向+街区系统(建筑/公共空间/绿地统一block_id)

### DIFF
--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/buildings.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/buildings.geojson
@@ -15,7 +15,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.504,
         "cluster_id": "NW",
-        "cluster_index": 1
+        "cluster_index": 1,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 31,
+        "block_id": "BLOCK-NW"
       },
       "geometry": {
         "type": "Polygon",
@@ -58,7 +62,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.266,
         "cluster_id": "NW",
-        "cluster_index": 2
+        "cluster_index": 2,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 31,
+        "block_id": "BLOCK-NW"
       },
       "geometry": {
         "type": "Polygon",
@@ -101,7 +109,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.027,
         "cluster_id": "NW",
-        "cluster_index": 3
+        "cluster_index": 3,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-8",
+        "distance_to_road_m": 0,
+        "block_id": "BLOCK-NW"
       },
       "geometry": {
         "type": "Polygon",
@@ -144,7 +156,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.789,
         "cluster_id": "NW",
-        "cluster_index": 4
+        "cluster_index": 4,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 31,
+        "block_id": "BLOCK-NW"
       },
       "geometry": {
         "type": "Polygon",
@@ -187,7 +203,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.551,
         "cluster_id": "NW",
-        "cluster_index": 5
+        "cluster_index": 5,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 31,
+        "block_id": "BLOCK-NW"
       },
       "geometry": {
         "type": "Polygon",
@@ -230,7 +250,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.312,
         "cluster_id": "NW",
-        "cluster_index": 6
+        "cluster_index": 6,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 31,
+        "block_id": "BLOCK-NW"
       },
       "geometry": {
         "type": "Polygon",
@@ -273,7 +297,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.502,
         "cluster_id": "NM",
-        "cluster_index": 1
+        "cluster_index": 1,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 86,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -316,7 +344,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.264,
         "cluster_id": "NM",
-        "cluster_index": 2
+        "cluster_index": 2,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 86,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -359,7 +391,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.026,
         "cluster_id": "NM",
-        "cluster_index": 3
+        "cluster_index": 3,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-8",
+        "distance_to_road_m": 0,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -402,7 +438,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.787,
         "cluster_id": "NM",
-        "cluster_index": 4
+        "cluster_index": 4,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 86,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -445,7 +485,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.549,
         "cluster_id": "NM",
-        "cluster_index": 5
+        "cluster_index": 5,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 86,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -488,7 +532,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.311,
         "cluster_id": "NM",
-        "cluster_index": 6
+        "cluster_index": 6,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 86,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -531,7 +579,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.501,
         "cluster_id": "NM",
-        "cluster_index": 7
+        "cluster_index": 7,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 52,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -574,7 +626,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.262,
         "cluster_id": "NM",
-        "cluster_index": 8
+        "cluster_index": 8,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 52,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -617,7 +673,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.024,
         "cluster_id": "NM",
-        "cluster_index": 9
+        "cluster_index": 9,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-8",
+        "distance_to_road_m": 0,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -660,7 +720,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.786,
         "cluster_id": "NM",
-        "cluster_index": 10
+        "cluster_index": 10,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 52,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -703,7 +767,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.547,
         "cluster_id": "NM",
-        "cluster_index": 11
+        "cluster_index": 11,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 52,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -746,7 +814,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.309,
         "cluster_id": "NM",
-        "cluster_index": 12
+        "cluster_index": 12,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 52,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -789,7 +861,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.499,
         "cluster_id": "NM",
-        "cluster_index": 13
+        "cluster_index": 13,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 64,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -832,7 +908,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.26,
         "cluster_id": "NM",
-        "cluster_index": 14
+        "cluster_index": 14,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 64,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -875,7 +955,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.022,
         "cluster_id": "NM",
-        "cluster_index": 15
+        "cluster_index": 15,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-8",
+        "distance_to_road_m": 0,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -918,7 +1002,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.784,
         "cluster_id": "NM",
-        "cluster_index": 16
+        "cluster_index": 16,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 64,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -961,7 +1049,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.545,
         "cluster_id": "NM",
-        "cluster_index": 17
+        "cluster_index": 17,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 64,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -1004,7 +1096,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.307,
         "cluster_id": "NM",
-        "cluster_index": 18
+        "cluster_index": 18,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 64,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -1047,7 +1143,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.497,
         "cluster_id": "NM",
-        "cluster_index": 19
+        "cluster_index": 19,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 74,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -1090,7 +1190,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.259,
         "cluster_id": "NM",
-        "cluster_index": 20
+        "cluster_index": 20,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 74,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -1133,7 +1237,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.02,
         "cluster_id": "NM",
-        "cluster_index": 21
+        "cluster_index": 21,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-8",
+        "distance_to_road_m": 0,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -1176,7 +1284,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.782,
         "cluster_id": "NM",
-        "cluster_index": 22
+        "cluster_index": 22,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 74,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -1219,7 +1331,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.544,
         "cluster_id": "NM",
-        "cluster_index": 23
+        "cluster_index": 23,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 74,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -1262,7 +1378,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.305,
         "cluster_id": "NM",
-        "cluster_index": 24
+        "cluster_index": 24,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 74,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -1305,7 +1425,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.495,
         "cluster_id": "NE",
-        "cluster_index": 1
+        "cluster_index": 1,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 43,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -1348,7 +1472,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.257,
         "cluster_id": "NE",
-        "cluster_index": 2
+        "cluster_index": 2,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 43,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -1391,7 +1519,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.019,
         "cluster_id": "NE",
-        "cluster_index": 3
+        "cluster_index": 3,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-8",
+        "distance_to_road_m": 0,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -1434,7 +1566,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.78,
         "cluster_id": "NE",
-        "cluster_index": 4
+        "cluster_index": 4,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 43,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -1477,7 +1613,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.542,
         "cluster_id": "NE",
-        "cluster_index": 5
+        "cluster_index": 5,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 43,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -1520,7 +1660,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.304,
         "cluster_id": "NE",
-        "cluster_index": 6
+        "cluster_index": 6,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 43,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -1563,7 +1707,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.494,
         "cluster_id": "NE",
-        "cluster_index": 7
+        "cluster_index": 7,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 95,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -1606,7 +1754,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.255,
         "cluster_id": "NE",
-        "cluster_index": 8
+        "cluster_index": 8,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 95,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -1649,7 +1801,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.017,
         "cluster_id": "NE",
-        "cluster_index": 9
+        "cluster_index": 9,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-8",
+        "distance_to_road_m": 0,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -1692,7 +1848,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.779,
         "cluster_id": "NE",
-        "cluster_index": 10
+        "cluster_index": 10,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 95,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -1735,7 +1895,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.54,
         "cluster_id": "NE",
-        "cluster_index": 11
+        "cluster_index": 11,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 95,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -1778,7 +1942,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.302,
         "cluster_id": "NE",
-        "cluster_index": 12
+        "cluster_index": 12,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 95,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -1821,7 +1989,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.492,
         "cluster_id": "NE",
-        "cluster_index": 13
+        "cluster_index": 13,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 22,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -1864,7 +2036,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.254,
         "cluster_id": "NE",
-        "cluster_index": 14
+        "cluster_index": 14,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 22,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -1907,7 +2083,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5359.015,
         "cluster_id": "NE",
-        "cluster_index": 15
+        "cluster_index": 15,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-8",
+        "distance_to_road_m": 0,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -1950,7 +2130,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.777,
         "cluster_id": "NE",
-        "cluster_index": 16
+        "cluster_index": 16,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 22,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -1993,7 +2177,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.539,
         "cluster_id": "NE",
-        "cluster_index": 17
+        "cluster_index": 17,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 22,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -2036,7 +2224,11 @@
         "name_zh": "众智园AI研发建筑",
         "area_sqm_declared": 5358.3,
         "cluster_id": "NE",
-        "cluster_index": 18
+        "cluster_index": 18,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 22,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -2079,7 +2271,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6210.093,
         "cluster_id": "CW",
-        "cluster_index": 1
+        "cluster_index": 1,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 97,
+        "block_id": "BLOCK-CW"
       },
       "geometry": {
         "type": "Polygon",
@@ -2122,7 +2318,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6209.869,
         "cluster_id": "CW",
-        "cluster_index": 2
+        "cluster_index": 2,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 97,
+        "block_id": "BLOCK-CW"
       },
       "geometry": {
         "type": "Polygon",
@@ -2165,7 +2365,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6209.646,
         "cluster_id": "CW",
-        "cluster_index": 3
+        "cluster_index": 3,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 97,
+        "block_id": "BLOCK-CW"
       },
       "geometry": {
         "type": "Polygon",
@@ -2208,7 +2412,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6209.422,
         "cluster_id": "NW",
-        "cluster_index": 7
+        "cluster_index": 7,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 97,
+        "block_id": "BLOCK-NW"
       },
       "geometry": {
         "type": "Polygon",
@@ -2251,7 +2459,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6210.091,
         "cluster_id": "CM",
-        "cluster_index": 1
+        "cluster_index": 1,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 59,
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -2294,7 +2506,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6209.867,
         "cluster_id": "CM",
-        "cluster_index": 2
+        "cluster_index": 2,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 59,
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -2337,7 +2553,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6209.643,
         "cluster_id": "CM",
-        "cluster_index": 3
+        "cluster_index": 3,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 59,
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -2380,7 +2600,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6209.419,
         "cluster_id": "NM",
-        "cluster_index": 25
+        "cluster_index": 25,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 59,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -2423,7 +2647,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6210.088,
         "cluster_id": "CM",
-        "cluster_index": 4
+        "cluster_index": 4,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 40,
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -2466,7 +2694,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6209.864,
         "cluster_id": "CM",
-        "cluster_index": 5
+        "cluster_index": 5,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 40,
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -2509,7 +2741,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6209.64,
         "cluster_id": "CM",
-        "cluster_index": 6
+        "cluster_index": 6,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 40,
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -2552,7 +2788,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6209.417,
         "cluster_id": "NM",
-        "cluster_index": 26
+        "cluster_index": 26,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 40,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -2595,7 +2835,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6210.085,
         "cluster_id": "CM",
-        "cluster_index": 7
+        "cluster_index": 7,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 116,
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -2638,7 +2882,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6209.861,
         "cluster_id": "CM",
-        "cluster_index": 8
+        "cluster_index": 8,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 116,
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -2681,7 +2929,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6209.638,
         "cluster_id": "CM",
-        "cluster_index": 9
+        "cluster_index": 9,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 116,
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -2724,7 +2976,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6209.414,
         "cluster_id": "NM",
-        "cluster_index": 27
+        "cluster_index": 27,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-6",
+        "distance_to_road_m": 102,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -2767,7 +3023,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6210.083,
         "cluster_id": "CE",
-        "cluster_index": 1
+        "cluster_index": 1,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 17,
+        "block_id": "BLOCK-CE"
       },
       "geometry": {
         "type": "Polygon",
@@ -2810,7 +3070,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6209.859,
         "cluster_id": "CE",
-        "cluster_index": 2
+        "cluster_index": 2,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 17,
+        "block_id": "BLOCK-CE"
       },
       "geometry": {
         "type": "Polygon",
@@ -2853,7 +3117,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6209.635,
         "cluster_id": "CE",
-        "cluster_index": 3
+        "cluster_index": 3,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 17,
+        "block_id": "BLOCK-CE"
       },
       "geometry": {
         "type": "Polygon",
@@ -2896,7 +3164,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6209.411,
         "cluster_id": "NE",
-        "cluster_index": 19
+        "cluster_index": 19,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 17,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -2939,7 +3211,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6210.08,
         "cluster_id": "CE",
-        "cluster_index": 4
+        "cluster_index": 4,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 82,
+        "block_id": "BLOCK-CE"
       },
       "geometry": {
         "type": "Polygon",
@@ -2982,7 +3258,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6209.856,
         "cluster_id": "CE",
-        "cluster_index": 5
+        "cluster_index": 5,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 82,
+        "block_id": "BLOCK-CE"
       },
       "geometry": {
         "type": "Polygon",
@@ -3025,7 +3305,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6209.632,
         "cluster_id": "CE",
-        "cluster_index": 6
+        "cluster_index": 6,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 82,
+        "block_id": "BLOCK-CE"
       },
       "geometry": {
         "type": "Polygon",
@@ -3068,7 +3352,11 @@
         "name_zh": "AI原点创新建筑",
         "area_sqm_declared": 6209.409,
         "cluster_id": "NE",
-        "cluster_index": 20
+        "cluster_index": 20,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 82,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -3111,7 +3399,11 @@
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.969,
         "cluster_id": "SW",
-        "cluster_index": 1
+        "cluster_index": 1,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 67,
+        "block_id": "BLOCK-SW"
       },
       "geometry": {
         "type": "Polygon",
@@ -3154,7 +3446,11 @@
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.801,
         "cluster_id": "SW",
-        "cluster_index": 2
+        "cluster_index": 2,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 67,
+        "block_id": "BLOCK-SW"
       },
       "geometry": {
         "type": "Polygon",
@@ -3197,7 +3493,11 @@
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.633,
         "cluster_id": "SW",
-        "cluster_index": 3
+        "cluster_index": 3,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 67,
+        "block_id": "BLOCK-SW"
       },
       "geometry": {
         "type": "Polygon",
@@ -3240,7 +3540,11 @@
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.965,
         "cluster_id": "SM",
-        "cluster_index": 1
+        "cluster_index": 1,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 101,
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -3283,7 +3587,11 @@
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.797,
         "cluster_id": "SM",
-        "cluster_index": 2
+        "cluster_index": 2,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 101,
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -3326,7 +3634,11 @@
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.629,
         "cluster_id": "SM",
-        "cluster_index": 3
+        "cluster_index": 3,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 101,
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -3369,7 +3681,11 @@
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.962,
         "cluster_id": "SM",
-        "cluster_index": 4
+        "cluster_index": 4,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 120,
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -3412,7 +3728,11 @@
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.794,
         "cluster_id": "SM",
-        "cluster_index": 5
+        "cluster_index": 5,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 120,
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -3455,7 +3775,11 @@
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.625,
         "cluster_id": "SM",
-        "cluster_index": 6
+        "cluster_index": 6,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 120,
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -3498,7 +3822,11 @@
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.958,
         "cluster_id": "SE",
-        "cluster_index": 1
+        "cluster_index": 1,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 86,
+        "block_id": "BLOCK-SE"
       },
       "geometry": {
         "type": "Polygon",
@@ -3541,7 +3869,11 @@
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.79,
         "cluster_id": "SE",
-        "cluster_index": 2
+        "cluster_index": 2,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 86,
+        "block_id": "BLOCK-SE"
       },
       "geometry": {
         "type": "Polygon",
@@ -3584,7 +3916,11 @@
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.622,
         "cluster_id": "SE",
-        "cluster_index": 3
+        "cluster_index": 3,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 86,
+        "block_id": "BLOCK-SE"
       },
       "geometry": {
         "type": "Polygon",
@@ -3627,7 +3963,11 @@
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.954,
         "cluster_id": "SE",
-        "cluster_index": 4
+        "cluster_index": 4,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 52,
+        "block_id": "BLOCK-SE"
       },
       "geometry": {
         "type": "Polygon",
@@ -3670,7 +4010,11 @@
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.786,
         "cluster_id": "SE",
-        "cluster_index": 5
+        "cluster_index": 5,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 52,
+        "block_id": "BLOCK-SE"
       },
       "geometry": {
         "type": "Polygon",
@@ -3713,7 +4057,11 @@
         "name_zh": "大钟寺AI商业建筑",
         "area_sqm_declared": 6003.618,
         "cluster_id": "SE",
-        "cluster_index": 6
+        "cluster_index": 6,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 52,
+        "block_id": "BLOCK-SE"
       },
       "geometry": {
         "type": "Polygon",
@@ -3756,7 +4104,11 @@
         "name_zh": "居住建筑",
         "area_sqm_declared": 4554.819,
         "cluster_id": "SW",
-        "cluster_index": 4
+        "cluster_index": 4,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-1",
+        "distance_to_road_m": 15,
+        "block_id": "BLOCK-SW"
       },
       "geometry": {
         "type": "Polygon",
@@ -3799,7 +4151,11 @@
         "name_zh": "居住建筑",
         "area_sqm_declared": 4554.163,
         "cluster_id": "SW",
-        "cluster_index": 5
+        "cluster_index": 5,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-1",
+        "distance_to_road_m": 15,
+        "block_id": "BLOCK-SW"
       },
       "geometry": {
         "type": "Polygon",
@@ -3842,7 +4198,11 @@
         "name_zh": "居住建筑",
         "area_sqm_declared": 4553.508,
         "cluster_id": "CW",
-        "cluster_index": 4
+        "cluster_index": 4,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-4",
+        "distance_to_road_m": 27,
+        "block_id": "BLOCK-CW"
       },
       "geometry": {
         "type": "Polygon",
@@ -3885,7 +4245,11 @@
         "name_zh": "居住建筑",
         "area_sqm_declared": 4553.507,
         "cluster_id": "CW",
-        "cluster_index": 5
+        "cluster_index": 5,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-1",
+        "distance_to_road_m": 15,
+        "block_id": "BLOCK-CW"
       },
       "geometry": {
         "type": "Polygon",
@@ -3928,7 +4292,11 @@
         "name_zh": "居住建筑",
         "area_sqm_declared": 4552.851,
         "cluster_id": "CW",
-        "cluster_index": 6
+        "cluster_index": 6,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-1",
+        "distance_to_road_m": 15,
+        "block_id": "BLOCK-CW"
       },
       "geometry": {
         "type": "Polygon",
@@ -3971,7 +4339,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 4555.333,
         "cluster_id": "SE",
-        "cluster_index": 7
+        "cluster_index": 7,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-1",
+        "distance_to_road_m": 27,
+        "block_id": "BLOCK-SE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4014,7 +4386,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 4555.331,
         "cluster_id": "SE",
-        "cluster_index": 8
+        "cluster_index": 8,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-1",
+        "distance_to_road_m": 27,
+        "block_id": "BLOCK-SE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4057,7 +4433,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 4555.328,
         "cluster_id": "SE",
-        "cluster_index": 9
+        "cluster_index": 9,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-1",
+        "distance_to_road_m": 27,
+        "block_id": "BLOCK-SE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4100,7 +4480,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 4554.808,
         "cluster_id": "SE",
-        "cluster_index": 10
+        "cluster_index": 10,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-2",
+        "distance_to_road_m": 27,
+        "block_id": "BLOCK-SE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4143,7 +4527,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 4554.806,
         "cluster_id": "SE",
-        "cluster_index": 11
+        "cluster_index": 11,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-2",
+        "distance_to_road_m": 27,
+        "block_id": "BLOCK-SE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4186,7 +4574,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 4554.804,
         "cluster_id": "SE",
-        "cluster_index": 12
+        "cluster_index": 12,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-2",
+        "distance_to_road_m": 27,
+        "block_id": "BLOCK-SE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4229,7 +4621,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 4554.153,
         "cluster_id": "SE",
-        "cluster_index": 13
+        "cluster_index": 13,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-3",
+        "distance_to_road_m": 27,
+        "block_id": "BLOCK-SE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4272,7 +4668,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 4554.151,
         "cluster_id": "SE",
-        "cluster_index": 14
+        "cluster_index": 14,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-3",
+        "distance_to_road_m": 27,
+        "block_id": "BLOCK-SE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4315,7 +4715,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 4554.149,
         "cluster_id": "SE",
-        "cluster_index": 15
+        "cluster_index": 15,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-3",
+        "distance_to_road_m": 27,
+        "block_id": "BLOCK-SE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4358,7 +4762,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 4553.497,
         "cluster_id": "CE",
-        "cluster_index": 7
+        "cluster_index": 7,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-4",
+        "distance_to_road_m": 27,
+        "block_id": "BLOCK-CE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4401,7 +4809,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 4553.495,
         "cluster_id": "CE",
-        "cluster_index": 8
+        "cluster_index": 8,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-4",
+        "distance_to_road_m": 27,
+        "block_id": "BLOCK-CE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4444,7 +4856,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 4553.493,
         "cluster_id": "CE",
-        "cluster_index": 9
+        "cluster_index": 9,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-4",
+        "distance_to_road_m": 27,
+        "block_id": "BLOCK-CE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4487,7 +4903,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 4552.841,
         "cluster_id": "CE",
-        "cluster_index": 10
+        "cluster_index": 10,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 27,
+        "block_id": "BLOCK-CE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4530,7 +4950,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 4552.839,
         "cluster_id": "CE",
-        "cluster_index": 11
+        "cluster_index": 11,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 58,
+        "block_id": "BLOCK-CE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4573,7 +4997,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 432.52,
         "cluster_id": "CE",
-        "cluster_index": 12
+        "cluster_index": 12,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 88,
+        "block_id": "BLOCK-CE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4616,7 +5044,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 4551.529,
         "cluster_id": "NE",
-        "cluster_index": 21
+        "cluster_index": 21,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-4",
+        "distance_to_road_m": 27,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4659,7 +5091,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 4551.527,
         "cluster_id": "NE",
-        "cluster_index": 22
+        "cluster_index": 22,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 58,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4702,7 +5138,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 2345.567,
         "cluster_id": "NE",
-        "cluster_index": 23
+        "cluster_index": 23,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 99,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4745,7 +5185,11 @@
         "name_zh": "商业服务建筑",
         "area_sqm_declared": 4550.212,
         "cluster_id": "NE",
-        "cluster_index": 24
+        "cluster_index": 24,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-5",
+        "distance_to_road_m": 112,
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -4788,7 +5232,11 @@
         "name_zh": "走廊文化公共建筑",
         "area_sqm_declared": 2847.089,
         "cluster_id": "SM",
-        "cluster_index": 7
+        "cluster_index": 7,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 20,
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -4831,7 +5279,11 @@
         "name_zh": "走廊文化公共建筑",
         "area_sqm_declared": 2847.088,
         "cluster_id": "SM",
-        "cluster_index": 8
+        "cluster_index": 8,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-1",
+        "distance_to_road_m": 22,
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -4874,7 +5326,11 @@
         "name_zh": "走廊文化公共建筑",
         "area_sqm_declared": 2847.088,
         "cluster_id": "SM",
-        "cluster_index": 9
+        "cluster_index": 9,
+        "primary_facade": "north_south",
+        "nearest_road": "ROAD-EW-1",
+        "distance_to_road_m": 22,
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -4917,7 +5373,11 @@
         "name_zh": "走廊文化公共建筑",
         "area_sqm_declared": 2846.557,
         "cluster_id": "SM",
-        "cluster_index": 10
+        "cluster_index": 10,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 20,
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -4960,7 +5420,11 @@
         "name_zh": "走廊文化公共建筑",
         "area_sqm_declared": 2846.556,
         "cluster_id": "SM",
-        "cluster_index": 11
+        "cluster_index": 11,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 105,
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -5003,7 +5467,11 @@
         "name_zh": "走廊文化公共建筑",
         "area_sqm_declared": 2846.555,
         "cluster_id": "SM",
-        "cluster_index": 12
+        "cluster_index": 12,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 65,
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -5046,7 +5514,11 @@
         "name_zh": "走廊文化公共建筑",
         "area_sqm_declared": 2846.27,
         "cluster_id": "SM",
-        "cluster_index": 13
+        "cluster_index": 13,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 20,
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -5089,7 +5561,11 @@
         "name_zh": "走廊文化公共建筑",
         "area_sqm_declared": 2846.269,
         "cluster_id": "SM",
-        "cluster_index": 14
+        "cluster_index": 14,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 105,
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -5132,7 +5608,11 @@
         "name_zh": "走廊文化公共建筑",
         "area_sqm_declared": 2846.268,
         "cluster_id": "SM",
-        "cluster_index": 15
+        "cluster_index": 15,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 65,
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -5175,7 +5655,11 @@
         "name_zh": "走廊文化公共建筑",
         "area_sqm_declared": 2846.024,
         "cluster_id": "CM",
-        "cluster_index": 10
+        "cluster_index": 10,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 20,
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -5218,7 +5702,11 @@
         "name_zh": "走廊文化公共建筑",
         "area_sqm_declared": 2846.023,
         "cluster_id": "CM",
-        "cluster_index": 11
+        "cluster_index": 11,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 105,
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -5261,7 +5749,11 @@
         "name_zh": "走廊文化公共建筑",
         "area_sqm_declared": 2846.022,
         "cluster_id": "CM",
-        "cluster_index": 12
+        "cluster_index": 12,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 65,
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -5304,7 +5796,11 @@
         "name_zh": "走廊文化公共建筑",
         "area_sqm_declared": 2845.614,
         "cluster_id": "CM",
-        "cluster_index": 13
+        "cluster_index": 13,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 20,
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -5347,7 +5843,11 @@
         "name_zh": "走廊文化公共建筑",
         "area_sqm_declared": 2845.613,
         "cluster_id": "CM",
-        "cluster_index": 14
+        "cluster_index": 14,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 105,
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -5390,7 +5890,11 @@
         "name_zh": "走廊文化公共建筑",
         "area_sqm_declared": 2845.613,
         "cluster_id": "CM",
-        "cluster_index": 15
+        "cluster_index": 15,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 65,
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -5433,7 +5937,11 @@
         "name_zh": "走廊文化公共建筑",
         "area_sqm_declared": 2844.63,
         "cluster_id": "NM",
-        "cluster_index": 28
+        "cluster_index": 28,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 20,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -5476,7 +5984,11 @@
         "name_zh": "走廊文化公共建筑",
         "area_sqm_declared": 2844.629,
         "cluster_id": "NM",
-        "cluster_index": 29
+        "cluster_index": 29,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-2",
+        "distance_to_road_m": 105,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -5519,7 +6031,11 @@
         "name_zh": "走廊文化公共建筑",
         "area_sqm_declared": 2844.629,
         "cluster_id": "NM",
-        "cluster_index": 30
+        "cluster_index": 30,
+        "primary_facade": "east_west",
+        "nearest_road": "ROAD-NS-3",
+        "distance_to_road_m": 65,
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/green_space.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/green_space.geojson
@@ -18,7 +18,8 @@
         "serves_wing": "M",
         "serves_clusters": [
           "SM"
-        ]
+        ],
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -64,7 +65,8 @@
         "serves_wing": "M",
         "serves_clusters": [
           "CM"
-        ]
+        ],
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -110,7 +112,8 @@
         "serves_wing": "M",
         "serves_clusters": [
           "NM"
-        ]
+        ],
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -156,7 +159,8 @@
         "serves_wing": "W",
         "serves_clusters": [
           "SW"
-        ]
+        ],
+        "block_id": "BLOCK-SW"
       },
       "geometry": {
         "type": "Polygon",
@@ -202,7 +206,8 @@
         "serves_wing": "W",
         "serves_clusters": [
           "SW"
-        ]
+        ],
+        "block_id": "BLOCK-SW"
       },
       "geometry": {
         "type": "Polygon",
@@ -248,7 +253,8 @@
         "serves_wing": "W",
         "serves_clusters": [
           "CW"
-        ]
+        ],
+        "block_id": "BLOCK-CW"
       },
       "geometry": {
         "type": "Polygon",
@@ -294,7 +300,8 @@
         "serves_wing": "E",
         "serves_clusters": [
           "SE"
-        ]
+        ],
+        "block_id": "BLOCK-SE"
       },
       "geometry": {
         "type": "Polygon",
@@ -340,7 +347,8 @@
         "serves_wing": "E",
         "serves_clusters": [
           "CE"
-        ]
+        ],
+        "block_id": "BLOCK-CE"
       },
       "geometry": {
         "type": "Polygon",
@@ -386,7 +394,8 @@
         "serves_wing": "E",
         "serves_clusters": [
           "NE"
-        ]
+        ],
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",
@@ -432,7 +441,8 @@
         "serves_wing": "E",
         "serves_clusters": [
           "NE"
-        ]
+        ],
+        "block_id": "BLOCK-NE"
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/public_space.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/public_space.geojson
@@ -16,7 +16,8 @@
         "area_sqm_declared": 42818.137,
         "nearest_road": "ROAD-EW-8",
         "distance_to_road_m": 199,
-        "serves_cluster": "NM"
+        "serves_cluster": "NM",
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -300,7 +301,8 @@
         "area_sqm_declared": 29746.938,
         "nearest_road": "ROAD-NS-3",
         "distance_to_road_m": 71,
-        "serves_cluster": "CM"
+        "serves_cluster": "CM",
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -584,7 +586,8 @@
         "area_sqm_declared": 29764.747,
         "nearest_road": "ROAD-NS-4",
         "distance_to_road_m": 263,
-        "serves_cluster": "SM"
+        "serves_cluster": "SM",
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -868,7 +871,8 @@
         "area_sqm_declared": 19050.802,
         "nearest_road": "ROAD-EW-1",
         "distance_to_road_m": 1,
-        "serves_cluster": "SM"
+        "serves_cluster": "SM",
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -1152,7 +1156,8 @@
         "area_sqm_declared": 19047.239,
         "nearest_road": "ROAD-NS-2",
         "distance_to_road_m": 140,
-        "serves_cluster": "SM"
+        "serves_cluster": "SM",
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -1436,7 +1441,8 @@
         "area_sqm_declared": 19043.126,
         "nearest_road": "ROAD-EW-4",
         "distance_to_road_m": 1,
-        "serves_cluster": "CM"
+        "serves_cluster": "CM",
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -1720,7 +1726,8 @@
         "area_sqm_declared": 19034.347,
         "nearest_road": "ROAD-NS-2",
         "distance_to_road_m": 238,
-        "serves_cluster": "NM"
+        "serves_cluster": "NM",
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -2004,7 +2011,8 @@
         "area_sqm_declared": 19029.955,
         "nearest_road": "ROAD-NS-2",
         "distance_to_road_m": 141,
-        "serves_cluster": "NM"
+        "serves_cluster": "NM",
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -2288,7 +2296,8 @@
         "area_sqm_declared": 7441.189,
         "nearest_road": "ROAD-NS-2",
         "distance_to_road_m": 256,
-        "serves_cluster": "SW"
+        "serves_cluster": "SW",
+        "block_id": "BLOCK-SW"
       },
       "geometry": {
         "type": "Polygon",
@@ -2572,7 +2581,8 @@
         "area_sqm_declared": 7441.18,
         "nearest_road": "ROAD-NS-3",
         "distance_to_road_m": 226,
-        "serves_cluster": "SM"
+        "serves_cluster": "SM",
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -2856,7 +2866,8 @@
         "area_sqm_declared": 7439.261,
         "nearest_road": "ROAD-NS-2",
         "distance_to_road_m": 169,
-        "serves_cluster": "SW"
+        "serves_cluster": "SW",
+        "block_id": "BLOCK-SW"
       },
       "geometry": {
         "type": "Polygon",
@@ -3140,7 +3151,8 @@
         "area_sqm_declared": 7439.252,
         "nearest_road": "ROAD-NS-3",
         "distance_to_road_m": 119,
-        "serves_cluster": "SM"
+        "serves_cluster": "SM",
+        "block_id": "BLOCK-SM"
       },
       "geometry": {
         "type": "Polygon",
@@ -3424,7 +3436,8 @@
         "area_sqm_declared": 7437.868,
         "nearest_road": "ROAD-NS-2",
         "distance_to_road_m": 169,
-        "serves_cluster": "CW"
+        "serves_cluster": "CW",
+        "block_id": "BLOCK-CW"
       },
       "geometry": {
         "type": "Polygon",
@@ -3708,7 +3721,8 @@
         "area_sqm_declared": 7437.86,
         "nearest_road": "ROAD-NS-3",
         "distance_to_road_m": 119,
-        "serves_cluster": "CM"
+        "serves_cluster": "CM",
+        "block_id": "BLOCK-CM"
       },
       "geometry": {
         "type": "Polygon",
@@ -3992,7 +4006,8 @@
         "area_sqm_declared": 7436.047,
         "nearest_road": "ROAD-NS-1",
         "distance_to_road_m": 129,
-        "serves_cluster": "NW"
+        "serves_cluster": "NW",
+        "block_id": "BLOCK-NW"
       },
       "geometry": {
         "type": "Polygon",
@@ -4276,7 +4291,8 @@
         "area_sqm_declared": 7436.038,
         "nearest_road": "ROAD-NS-3",
         "distance_to_road_m": 119,
-        "serves_cluster": "NM"
+        "serves_cluster": "NM",
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -4560,7 +4576,8 @@
         "area_sqm_declared": 7434.653,
         "nearest_road": "ROAD-NS-2",
         "distance_to_road_m": 169,
-        "serves_cluster": "NW"
+        "serves_cluster": "NW",
+        "block_id": "BLOCK-NW"
       },
       "geometry": {
         "type": "Polygon",
@@ -4844,7 +4861,8 @@
         "area_sqm_declared": 7434.644,
         "nearest_road": "ROAD-NS-3",
         "distance_to_road_m": 119,
-        "serves_cluster": "NM"
+        "serves_cluster": "NM",
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",
@@ -5128,7 +5146,8 @@
         "area_sqm_declared": 3901.099,
         "nearest_road": "ROAD-EW-9",
         "distance_to_road_m": 218,
-        "serves_cluster": "NW"
+        "serves_cluster": "NW",
+        "block_id": "BLOCK-NW"
       },
       "geometry": {
         "type": "Polygon",
@@ -5292,7 +5311,8 @@
         "area_sqm_declared": 7433.143,
         "nearest_road": "ROAD-EW-9",
         "distance_to_road_m": 119,
-        "serves_cluster": "NM"
+        "serves_cluster": "NM",
+        "block_id": "BLOCK-NM"
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
@@ -64,7 +64,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "1bbce531b71c73d945daf02713b7271e259f6e195204f09161253e0265eccd51"
+      "sha256": "2b7a5768b99e3c3c1008d7adc6e702d8633ec8393faef4b691b8fdd067acfd31"
     },
     {
       "path": "compliance_matrix.json",
@@ -235,7 +235,7 @@
       "path": "geometry/buildings.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "15f2c9d86c17bff8a1d97aa289f1a3597c84ee23e1b5dcdf745602fa579326cf"
+      "sha256": "fc3404a294504d0a48b76474dda2f1cf1ba5ed3da9ce31ca10b086ff1bb44fb9"
     },
     {
       "path": "geometry/constraints.geojson",
@@ -247,7 +247,7 @@
       "path": "geometry/green_space.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "67da3a4e7574fb821cd000d51239eb0971fe8ac585a992355c8a13117e13169e"
+      "sha256": "d38ef1f0b1653a7ec25129ecf4bcd7d0a4278161d0d858bc4a1bcdf755009432"
     },
     {
       "path": "geometry/key_areas.geojson",
@@ -271,7 +271,7 @@
       "path": "geometry/public_space.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "d442486455f423541f251f10042d5d53d80d5fe2e24220460677b7f55c66b71b"
+      "sha256": "87010455eef6cbb749d026a737b136bec82318091af252771b59a705b2d766e7"
     },
     {
       "path": "geometry/roads.geojson",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
@@ -85,7 +85,7 @@
       "ai_package_stages": {
         "submissions/565431hzhang/jingzhang-ai-heritage-halo": "formal"
       },
-      "total_bytes": 5262131,
+      "total_bytes": 5281465,
       "maintainer_bypass": false
     },
     "stderr": ""


### PR DESCRIPTION
城市设计深化：

建筑129栋: 加primary_facade(朝向最近道路)+nearest_road+distance_to_road_m+block_id
公共空间20个: 加block_id(与建筑组团对应)
绿地10个: 加block_id(与建筑组团对应)

形成统一街区系统——建筑、公共空间、绿地都归属于同一个block_id, 可以追踪每个街区内有哪些设施