### PR TITLE
improve-v5: 道路14条网格→9条(脊柱+联络+任务连接)

### DIFF
--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/roads.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/roads.geojson
@@ -13,7 +13,8 @@
         "geometry_role": "design_proposal",
         "road_type": "secondary",
         "name_zh": "西侧联络道",
-        "length_m": 4774.5
+        "length_m": 6232.6,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -82,9 +83,10 @@
         "source_type": "agent_generated_design",
         "confidence": "medium",
         "geometry_role": "design_proposal",
-        "road_type": "pedestrian_priority",
-        "name_zh": "京张绿廊慢行道",
-        "length_m": 7227.6
+        "road_type": "greenway",
+        "name_zh": "公共服务脊柱",
+        "length_m": 9435.0,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -159,97 +161,6 @@
           ],
           [
             116.344,
-            40.024
-          ]
-        ]
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "ROAD-NS-3",
-      "properties": {
-        "id": "ROAD-NS-3",
-        "layer": "ROAD_CENTERLINE",
-        "source_type": "agent_generated_design",
-        "confidence": "medium",
-        "geometry_role": "design_proposal",
-        "road_type": "primary",
-        "name_zh": "中央智脉大道",
-        "length_m": 7227.6
-      },
-      "geometry": {
-        "type": "LineString",
-        "coordinates": [
-          [
-            116.347,
-            39.939
-          ],
-          [
-            116.347,
-            39.944
-          ],
-          [
-            116.347,
-            39.949
-          ],
-          [
-            116.347,
-            39.954
-          ],
-          [
-            116.347,
-            39.959
-          ],
-          [
-            116.347,
-            39.964
-          ],
-          [
-            116.347,
-            39.969
-          ],
-          [
-            116.347,
-            39.974
-          ],
-          [
-            116.347,
-            39.979
-          ],
-          [
-            116.347,
-            39.984
-          ],
-          [
-            116.347,
-            39.989
-          ],
-          [
-            116.347,
-            39.994
-          ],
-          [
-            116.347,
-            39.999
-          ],
-          [
-            116.347,
-            40.004
-          ],
-          [
-            116.347,
-            40.009
-          ],
-          [
-            116.347,
-            40.014
-          ],
-          [
-            116.347,
-            40.019
-          ],
-          [
-            116.347,
             40.024
           ]
         ]
@@ -265,8 +176,9 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "road_type": "secondary",
-        "name_zh": "东侧服务道",
-        "length_m": 7227.6
+        "name_zh": "东侧联络道",
+        "length_m": 9435.0,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -342,136 +254,6 @@
           [
             116.35,
             40.024
-          ]
-        ]
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "ROAD-NS-5",
-      "properties": {
-        "id": "ROAD-NS-5",
-        "layer": "ROAD_CENTERLINE",
-        "source_type": "agent_generated_design",
-        "confidence": "medium",
-        "geometry_role": "design_proposal",
-        "road_type": "primary",
-        "name_zh": "学院路辅路",
-        "length_m": 7227.6
-      },
-      "geometry": {
-        "type": "LineString",
-        "coordinates": [
-          [
-            116.353,
-            39.939
-          ],
-          [
-            116.353,
-            39.944
-          ],
-          [
-            116.353,
-            39.949
-          ],
-          [
-            116.353,
-            39.954
-          ],
-          [
-            116.353,
-            39.959
-          ],
-          [
-            116.353,
-            39.964
-          ],
-          [
-            116.353,
-            39.969
-          ],
-          [
-            116.353,
-            39.974
-          ],
-          [
-            116.353,
-            39.979
-          ],
-          [
-            116.353,
-            39.984
-          ],
-          [
-            116.353,
-            39.989
-          ],
-          [
-            116.353,
-            39.994
-          ],
-          [
-            116.353,
-            39.999
-          ],
-          [
-            116.353,
-            40.004
-          ],
-          [
-            116.353,
-            40.009
-          ],
-          [
-            116.353,
-            40.014
-          ],
-          [
-            116.353,
-            40.019
-          ],
-          [
-            116.353,
-            40.024
-          ]
-        ]
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "ROAD-EW-1",
-      "properties": {
-        "id": "ROAD-EW-1",
-        "layer": "ROAD_CENTERLINE",
-        "source_type": "agent_generated_design",
-        "confidence": "medium",
-        "geometry_role": "design_proposal",
-        "road_type": "secondary",
-        "name_zh": "大钟寺南侧路",
-        "length_m": 1020.4
-      },
-      "geometry": {
-        "type": "LineString",
-        "coordinates": [
-          [
-            116.342,
-            39.942
-          ],
-          [
-            116.345,
-            39.942
-          ],
-          [
-            116.348,
-            39.942
-          ],
-          [
-            116.351,
-            39.942
-          ],
-          [
-            116.354,
-            39.942
           ]
         ]
       }
@@ -485,9 +267,10 @@
         "source_type": "agent_generated_design",
         "confidence": "medium",
         "geometry_role": "design_proposal",
-        "road_type": "secondary",
-        "name_zh": "大钟寺北侧路",
-        "length_m": 1020.4
+        "road_type": "pedestrian_priority",
+        "name_zh": "大钟寺到达连接",
+        "length_m": 1020.0,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -524,9 +307,10 @@
         "source_type": "agent_generated_design",
         "confidence": "medium",
         "geometry_role": "design_proposal",
-        "road_type": "primary",
-        "name_zh": "知春路",
-        "length_m": 1020.4
+        "road_type": "pedestrian_priority",
+        "name_zh": "大钟寺进入连接",
+        "length_m": 1020.0,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -563,9 +347,10 @@
         "source_type": "agent_generated_design",
         "confidence": "medium",
         "geometry_role": "design_proposal",
-        "road_type": "primary",
-        "name_zh": "成府路",
-        "length_m": 1020.4
+        "road_type": "pedestrian_priority",
+        "name_zh": "原点到达连接",
+        "length_m": 1020.0,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -602,9 +387,10 @@
         "source_type": "agent_generated_design",
         "confidence": "medium",
         "geometry_role": "design_proposal",
-        "road_type": "primary",
-        "name_zh": "清华东路",
-        "length_m": 1008.5
+        "road_type": "pedestrian_priority",
+        "name_zh": "原点进入连接",
+        "length_m": 1008.1,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -634,41 +420,6 @@
     },
     {
       "type": "Feature",
-      "id": "ROAD-EW-6",
-      "properties": {
-        "id": "ROAD-EW-6",
-        "layer": "ROAD_CENTERLINE",
-        "source_type": "agent_generated_design",
-        "confidence": "medium",
-        "geometry_role": "design_proposal",
-        "road_type": "secondary",
-        "name_zh": "五道口-学院路",
-        "length_m": 765.3
-      },
-      "geometry": {
-        "type": "LineString",
-        "coordinates": [
-          [
-            116.342,
-            39.993
-          ],
-          [
-            116.345,
-            39.993
-          ],
-          [
-            116.348,
-            39.993
-          ],
-          [
-            116.351,
-            39.993
-          ]
-        ]
-      }
-    },
-    {
-      "type": "Feature",
       "id": "ROAD-EW-7",
       "properties": {
         "id": "ROAD-EW-7",
@@ -676,9 +427,10 @@
         "source_type": "agent_generated_design",
         "confidence": "medium",
         "geometry_role": "design_proposal",
-        "road_type": "primary",
-        "name_zh": "北五环南路",
-        "length_m": 1020.4
+        "road_type": "pedestrian_priority",
+        "name_zh": "众智园到达连接",
+        "length_m": 1020.0,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -715,9 +467,10 @@
         "source_type": "agent_generated_design",
         "confidence": "medium",
         "geometry_role": "design_proposal",
-        "road_type": "secondary",
-        "name_zh": "众智园南界路",
-        "length_m": 1008.5
+        "road_type": "pedestrian_priority",
+        "name_zh": "众智园进入连接",
+        "length_m": 1008.2,
+        "alignment_status": "concept_only_pending_transport_review"
       },
       "geometry": {
         "type": "LineString",
@@ -741,41 +494,6 @@
           [
             116.354,
             40.015
-          ]
-        ]
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "ROAD-EW-9",
-      "properties": {
-        "id": "ROAD-EW-9",
-        "layer": "ROAD_CENTERLINE",
-        "source_type": "agent_generated_design",
-        "confidence": "medium",
-        "geometry_role": "design_proposal",
-        "road_type": "primary",
-        "name_zh": "北五环辅路",
-        "length_m": 765.3
-      },
-      "geometry": {
-        "type": "LineString",
-        "coordinates": [
-          [
-            116.345,
-            40.023
-          ],
-          [
-            116.348,
-            40.023
-          ],
-          [
-            116.351,
-            40.023
-          ],
-          [
-            116.354,
-            40.023
           ]
         ]
       }

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
@@ -46,7 +46,7 @@
       "path": "metrics.json",
       "role": "metrics",
       "required": true,
-      "sha256": "6d5bbe72ce34a337dddbc9fa92a680b146c51f1a7fd55431a9566ccb4551e6e6"
+      "sha256": "b6e60ecc0f09bd858dec7cd325e86049b92b9d56892fd786bc8890a78de4d9a9"
     },
     {
       "path": "assumptions.json",
@@ -64,7 +64,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "bac4c24fceb5eb1dadf90543aa8dbcef8334798095aeaaa2e185a5e4fb7fc2d4"
+      "sha256": "f30e601a86d0ffca9032fe577da0bad7e437c3993b276d13883c56a1cb2c28f0"
     },
     {
       "path": "compliance_matrix.json",
@@ -277,7 +277,7 @@
       "path": "geometry/roads.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "914ab84da17d7b5d1b2ba391e382ff28a5de2da1533954cefda297bbe33b7c85"
+      "sha256": "f1ff25adb06e3cfc4e248b2188e8441f940a9d37edcbd23febd864b7d222f9ed"
     },
     {
       "path": "geometry/site_boundary.geojson",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/metrics.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/metrics.json
@@ -178,7 +178,7 @@
     },
     "road_network_total_length_m": {
       "status": "known",
-      "value": 42334.5,
+      "value": 31198.899999999998,
       "unit": "m",
       "source_files": [
         "geometry/roads.geojson"

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
@@ -78,7 +78,7 @@
       "ai_package_stages": {
         "submissions/565431hzhang/jingzhang-ai-heritage-halo": "formal"
       },
-      "total_bytes": 4847825,
+      "total_bytes": 4839959,
       "maintainer_bypass": false
     },
     "stderr": ""


### PR DESCRIPTION
城市设计改动——改变道路空间结构：

14条平行网格→9条设计结构：
- 1条公共服务脊柱(greenway南北9km)
- 2条联络道(西/东secondary)
- 6条任务连接(pedestrian按三核分布: 大钟寺2+原点2+众智园2)
- 去掉5条冗余道路
- 道路总长31199m
- 加alignment_status