### PR TITLE
chore: refresh generated gallery snapshot

### DIFF
--- a/submissions-data.js
+++ b/submissions-data.js
@@ -3289,6 +3289,7 @@ window.HAIDIAN_SUBMISSIONS = [
     "featured": false,
     "selectionReason": "",
     "selectionReasonEn": "",
+    "coverUrl": "submissions/aplaybox/jingzhang-ai-artery/assets/media/cover.webp",
     "thumbnailUrl": "submissions/aplaybox/jingzhang-ai-artery/report/proposal.html",
     "visualUrl": "submissions/aplaybox/jingzhang-ai-artery/visual/index.html",
     "thumbnailUrlZh": "submissions/aplaybox/jingzhang-ai-artery/report/proposal.html",


### PR DESCRIPTION
Trusted Gallery maintenance handoff for exact current main `46241e8d2fcb20a94a8ad9bd6cbcea7f0430cf96`.

The workflow updated `automation/gallery-snapshot` to exact commit `d8bdd1d2bf644365a6a582ca480ba81104f5e659` but intentionally failed closed because `GITHUB_TOKEN` could not open the Draft PR. This maintainer-created Draft uses the normal protected review path; it is not a publication, award, implementation approval, or government endorsement.