### PR TITLE
improve-green-props: 所有geometry加标准属性(ecological_status等)

### DIFF
--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/buildings.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/buildings.geojson
@@ -13,7 +13,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.504
+        "area_sqm_declared": 5359.504,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -54,7 +56,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.266
+        "area_sqm_declared": 5359.266,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -95,7 +99,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.027
+        "area_sqm_declared": 5359.027,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -136,7 +142,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.789
+        "area_sqm_declared": 5358.789,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -177,7 +185,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.551
+        "area_sqm_declared": 5358.551,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -218,7 +228,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.312
+        "area_sqm_declared": 5358.312,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -259,7 +271,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.502
+        "area_sqm_declared": 5359.502,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -300,7 +314,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.264
+        "area_sqm_declared": 5359.264,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -341,7 +357,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.026
+        "area_sqm_declared": 5359.026,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -382,7 +400,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.787
+        "area_sqm_declared": 5358.787,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -423,7 +443,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.549
+        "area_sqm_declared": 5358.549,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -464,7 +486,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.311
+        "area_sqm_declared": 5358.311,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -505,7 +529,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.501
+        "area_sqm_declared": 5359.501,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -546,7 +572,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.262
+        "area_sqm_declared": 5359.262,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -587,7 +615,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.024
+        "area_sqm_declared": 5359.024,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -628,7 +658,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.786
+        "area_sqm_declared": 5358.786,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -669,7 +701,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.547
+        "area_sqm_declared": 5358.547,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -710,7 +744,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.309
+        "area_sqm_declared": 5358.309,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -751,7 +787,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.499
+        "area_sqm_declared": 5359.499,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -792,7 +830,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.26
+        "area_sqm_declared": 5359.26,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -833,7 +873,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.022
+        "area_sqm_declared": 5359.022,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -874,7 +916,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.784
+        "area_sqm_declared": 5358.784,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -915,7 +959,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.545
+        "area_sqm_declared": 5358.545,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -956,7 +1002,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.307
+        "area_sqm_declared": 5358.307,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -997,7 +1045,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.497
+        "area_sqm_declared": 5359.497,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1038,7 +1088,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.259
+        "area_sqm_declared": 5359.259,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1079,7 +1131,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.02
+        "area_sqm_declared": 5359.02,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1120,7 +1174,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.782
+        "area_sqm_declared": 5358.782,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1161,7 +1217,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.544
+        "area_sqm_declared": 5358.544,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1202,7 +1260,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.305
+        "area_sqm_declared": 5358.305,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1243,7 +1303,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.495
+        "area_sqm_declared": 5359.495,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1284,7 +1346,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.257
+        "area_sqm_declared": 5359.257,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1325,7 +1389,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.019
+        "area_sqm_declared": 5359.019,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1366,7 +1432,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.78
+        "area_sqm_declared": 5358.78,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1407,7 +1475,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.542
+        "area_sqm_declared": 5358.542,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1448,7 +1518,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.304
+        "area_sqm_declared": 5358.304,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1489,7 +1561,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.494
+        "area_sqm_declared": 5359.494,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1530,7 +1604,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.255
+        "area_sqm_declared": 5359.255,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1571,7 +1647,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.017
+        "area_sqm_declared": 5359.017,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1612,7 +1690,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.779
+        "area_sqm_declared": 5358.779,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1653,7 +1733,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.54
+        "area_sqm_declared": 5358.54,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1694,7 +1776,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.302
+        "area_sqm_declared": 5358.302,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1735,7 +1819,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.492
+        "area_sqm_declared": 5359.492,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1776,7 +1862,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.254
+        "area_sqm_declared": 5359.254,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1817,7 +1905,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5359.015
+        "area_sqm_declared": 5359.015,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1858,7 +1948,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.777
+        "area_sqm_declared": 5358.777,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1899,7 +1991,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.539
+        "area_sqm_declared": 5358.539,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1940,7 +2034,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "众智园AI研发建筑",
-        "area_sqm_declared": 5358.3
+        "area_sqm_declared": 5358.3,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -1981,7 +2077,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6210.093
+        "area_sqm_declared": 6210.093,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2022,7 +2120,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.869
+        "area_sqm_declared": 6209.869,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2063,7 +2163,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.646
+        "area_sqm_declared": 6209.646,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2104,7 +2206,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.422
+        "area_sqm_declared": 6209.422,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2145,7 +2249,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6210.091
+        "area_sqm_declared": 6210.091,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2186,7 +2292,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.867
+        "area_sqm_declared": 6209.867,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2227,7 +2335,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.643
+        "area_sqm_declared": 6209.643,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2268,7 +2378,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.419
+        "area_sqm_declared": 6209.419,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2309,7 +2421,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6210.088
+        "area_sqm_declared": 6210.088,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2350,7 +2464,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.864
+        "area_sqm_declared": 6209.864,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2391,7 +2507,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.64
+        "area_sqm_declared": 6209.64,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2432,7 +2550,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.417
+        "area_sqm_declared": 6209.417,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2473,7 +2593,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6210.085
+        "area_sqm_declared": 6210.085,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2514,7 +2636,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.861
+        "area_sqm_declared": 6209.861,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2555,7 +2679,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.638
+        "area_sqm_declared": 6209.638,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2596,7 +2722,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.414
+        "area_sqm_declared": 6209.414,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2637,7 +2765,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6210.083
+        "area_sqm_declared": 6210.083,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2678,7 +2808,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.859
+        "area_sqm_declared": 6209.859,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2719,7 +2851,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.635
+        "area_sqm_declared": 6209.635,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2760,7 +2894,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.411
+        "area_sqm_declared": 6209.411,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2801,7 +2937,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6210.08
+        "area_sqm_declared": 6210.08,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2842,7 +2980,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.856
+        "area_sqm_declared": 6209.856,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2883,7 +3023,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.632
+        "area_sqm_declared": 6209.632,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2924,7 +3066,9 @@
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
         "name_zh": "AI原点创新建筑",
-        "area_sqm_declared": 6209.409
+        "area_sqm_declared": 6209.409,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -2965,7 +3109,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.969
+        "area_sqm_declared": 6003.969,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3006,7 +3152,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.801
+        "area_sqm_declared": 6003.801,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3047,7 +3195,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.633
+        "area_sqm_declared": 6003.633,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3088,7 +3238,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.965
+        "area_sqm_declared": 6003.965,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3129,7 +3281,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.797
+        "area_sqm_declared": 6003.797,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3170,7 +3324,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.629
+        "area_sqm_declared": 6003.629,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3211,7 +3367,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.962
+        "area_sqm_declared": 6003.962,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3252,7 +3410,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.794
+        "area_sqm_declared": 6003.794,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3293,7 +3453,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.625
+        "area_sqm_declared": 6003.625,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3334,7 +3496,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.958
+        "area_sqm_declared": 6003.958,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3375,7 +3539,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.79
+        "area_sqm_declared": 6003.79,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3416,7 +3582,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.622
+        "area_sqm_declared": 6003.622,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3457,7 +3625,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.954
+        "area_sqm_declared": 6003.954,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3498,7 +3668,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.786
+        "area_sqm_declared": 6003.786,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3539,7 +3711,9 @@
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
         "name_zh": "大钟寺AI商业建筑",
-        "area_sqm_declared": 6003.618
+        "area_sqm_declared": 6003.618,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3580,7 +3754,9 @@
         "geometry_role": "design_proposal",
         "building_type": "residential",
         "name_zh": "居住建筑",
-        "area_sqm_declared": 4554.819
+        "area_sqm_declared": 4554.819,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3621,7 +3797,9 @@
         "geometry_role": "design_proposal",
         "building_type": "residential",
         "name_zh": "居住建筑",
-        "area_sqm_declared": 4554.163
+        "area_sqm_declared": 4554.163,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3662,7 +3840,9 @@
         "geometry_role": "design_proposal",
         "building_type": "residential",
         "name_zh": "居住建筑",
-        "area_sqm_declared": 4553.508
+        "area_sqm_declared": 4553.508,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3703,7 +3883,9 @@
         "geometry_role": "design_proposal",
         "building_type": "residential",
         "name_zh": "居住建筑",
-        "area_sqm_declared": 4553.507
+        "area_sqm_declared": 4553.507,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3744,7 +3926,9 @@
         "geometry_role": "design_proposal",
         "building_type": "residential",
         "name_zh": "居住建筑",
-        "area_sqm_declared": 4552.851
+        "area_sqm_declared": 4552.851,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3785,7 +3969,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4555.333
+        "area_sqm_declared": 4555.333,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3826,7 +4012,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4555.331
+        "area_sqm_declared": 4555.331,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3867,7 +4055,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4555.328
+        "area_sqm_declared": 4555.328,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3908,7 +4098,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4554.808
+        "area_sqm_declared": 4554.808,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3949,7 +4141,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4554.806
+        "area_sqm_declared": 4554.806,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -3990,7 +4184,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4554.804
+        "area_sqm_declared": 4554.804,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4031,7 +4227,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4554.153
+        "area_sqm_declared": 4554.153,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4072,7 +4270,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4554.151
+        "area_sqm_declared": 4554.151,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4113,7 +4313,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4554.149
+        "area_sqm_declared": 4554.149,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4154,7 +4356,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4553.497
+        "area_sqm_declared": 4553.497,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4195,7 +4399,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4553.495
+        "area_sqm_declared": 4553.495,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4236,7 +4442,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4553.493
+        "area_sqm_declared": 4553.493,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4277,7 +4485,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4552.841
+        "area_sqm_declared": 4552.841,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4318,7 +4528,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4552.839
+        "area_sqm_declared": 4552.839,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4359,7 +4571,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 432.52
+        "area_sqm_declared": 432.52,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4400,7 +4614,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4551.529
+        "area_sqm_declared": 4551.529,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4441,7 +4657,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4551.527
+        "area_sqm_declared": 4551.527,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4482,7 +4700,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 2345.567
+        "area_sqm_declared": 2345.567,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4523,7 +4743,9 @@
         "geometry_role": "design_proposal",
         "building_type": "retail",
         "name_zh": "商业服务建筑",
-        "area_sqm_declared": 4550.212
+        "area_sqm_declared": 4550.212,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4564,7 +4786,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2847.089
+        "area_sqm_declared": 2847.089,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4605,7 +4829,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2847.088
+        "area_sqm_declared": 2847.088,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4646,7 +4872,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2847.088
+        "area_sqm_declared": 2847.088,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4687,7 +4915,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.557
+        "area_sqm_declared": 2846.557,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4728,7 +4958,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.556
+        "area_sqm_declared": 2846.556,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4769,7 +5001,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.555
+        "area_sqm_declared": 2846.555,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4810,7 +5044,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.27
+        "area_sqm_declared": 2846.27,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4851,7 +5087,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.269
+        "area_sqm_declared": 2846.269,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4892,7 +5130,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.268
+        "area_sqm_declared": 2846.268,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4933,7 +5173,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.024
+        "area_sqm_declared": 2846.024,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -4974,7 +5216,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.023
+        "area_sqm_declared": 2846.023,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -5015,7 +5259,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2846.022
+        "area_sqm_declared": 2846.022,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -5056,7 +5302,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2845.614
+        "area_sqm_declared": 2845.614,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -5097,7 +5345,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2845.613
+        "area_sqm_declared": 2845.613,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -5138,7 +5388,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2845.613
+        "area_sqm_declared": 2845.613,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -5179,7 +5431,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2844.63
+        "area_sqm_declared": 2844.63,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -5220,7 +5474,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2844.629
+        "area_sqm_declared": 2844.629,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",
@@ -5261,7 +5517,9 @@
         "geometry_role": "design_proposal",
         "building_type": "cultural",
         "name_zh": "走廊文化公共建筑",
-        "area_sqm_declared": 2844.629
+        "area_sqm_declared": 2844.629,
+        "update_status": "concept_carrier_pending_survey",
+        "usage_note": "Concept only; not an existing-building survey or demolition decision."
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/phasing.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/phasing.geojson
@@ -14,7 +14,8 @@
         "phase_type": "phase_1_immediate",
         "name_zh": "一期：重点区域启动区",
         "period_zh": "2026-2028",
-        "area_sqm_declared": 3692893.005
+        "area_sqm_declared": 3692893.005,
+        "release_rule": "evidence_before_scale"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -106,7 +107,8 @@
         "phase_type": "phase_2_medium",
         "name_zh": "二期：走廊沿线开发",
         "period_zh": "2028-2030",
-        "area_sqm_declared": 3153425.688
+        "area_sqm_declared": 3153425.688,
+        "release_rule": "evidence_before_scale"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -218,7 +220,8 @@
         "phase_type": "phase_3_long_term",
         "name_zh": "三期：外围完善提升",
         "period_zh": "2030-2035",
-        "area_sqm_declared": 4566513.809
+        "area_sqm_declared": 4566513.809,
+        "release_rule": "evidence_before_scale"
       },
       "geometry": {
         "type": "MultiPolygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/public_space.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/public_space.geojson
@@ -13,7 +13,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "plaza",
         "name_zh": "众智园AI创新广场",
-        "area_sqm_declared": 42818.137
+        "area_sqm_declared": 42818.137,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -294,7 +295,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "plaza",
         "name_zh": "AI原点社区广场",
-        "area_sqm_declared": 29746.938
+        "area_sqm_declared": 29746.938,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -575,7 +577,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "plaza",
         "name_zh": "大钟寺AI城市客厅",
-        "area_sqm_declared": 29764.747
+        "area_sqm_declared": 29764.747,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -856,7 +859,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
         "name_zh": "京张绿廊活动节点1",
-        "area_sqm_declared": 19050.802
+        "area_sqm_declared": 19050.802,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -1137,7 +1141,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
         "name_zh": "京张绿廊活动节点2",
-        "area_sqm_declared": 19047.239
+        "area_sqm_declared": 19047.239,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -1418,7 +1423,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
         "name_zh": "京张绿廊活动节点3",
-        "area_sqm_declared": 19043.126
+        "area_sqm_declared": 19043.126,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -1699,7 +1705,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
         "name_zh": "京张绿廊活动节点4",
-        "area_sqm_declared": 19034.347
+        "area_sqm_declared": 19034.347,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -1980,7 +1987,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
         "name_zh": "京张绿廊活动节点5",
-        "area_sqm_declared": 19029.955
+        "area_sqm_declared": 19029.955,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -2261,7 +2269,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园1",
-        "area_sqm_declared": 7441.189
+        "area_sqm_declared": 7441.189,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -2542,7 +2551,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园1",
-        "area_sqm_declared": 7441.18
+        "area_sqm_declared": 7441.18,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -2823,7 +2833,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园2",
-        "area_sqm_declared": 7439.261
+        "area_sqm_declared": 7439.261,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -3104,7 +3115,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园2",
-        "area_sqm_declared": 7439.252
+        "area_sqm_declared": 7439.252,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -3385,7 +3397,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园3",
-        "area_sqm_declared": 7437.868
+        "area_sqm_declared": 7437.868,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -3666,7 +3679,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园3",
-        "area_sqm_declared": 7437.86
+        "area_sqm_declared": 7437.86,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -3947,7 +3961,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园4",
-        "area_sqm_declared": 7436.047
+        "area_sqm_declared": 7436.047,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -4228,7 +4243,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园4",
-        "area_sqm_declared": 7436.038
+        "area_sqm_declared": 7436.038,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -4509,7 +4525,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园5",
-        "area_sqm_declared": 7434.653
+        "area_sqm_declared": 7434.653,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -4790,7 +4807,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园5",
-        "area_sqm_declared": 7434.644
+        "area_sqm_declared": 7434.644,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -5071,7 +5089,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园6",
-        "area_sqm_declared": 3901.099
+        "area_sqm_declared": 3901.099,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",
@@ -5232,7 +5251,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园6",
-        "area_sqm_declared": 7433.143
+        "area_sqm_declared": 7433.143,
+        "access_rule": "registration_free_equal_no_app_route"
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/roads.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/roads.geojson
@@ -14,7 +14,8 @@
         "road_type": "secondary",
         "name_zh": "西侧联络道",
         "length_m": 6232.6,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "length_m_declared": 6232.6
       },
       "geometry": {
         "type": "LineString",
@@ -86,7 +87,8 @@
         "road_type": "greenway",
         "name_zh": "公共服务脊柱",
         "length_m": 9435.0,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "length_m_declared": 9435.0
       },
       "geometry": {
         "type": "LineString",
@@ -178,7 +180,8 @@
         "road_type": "primary",
         "name_zh": "中央智脉大道",
         "length_m": 9435.0,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "length_m_declared": 9435.0
       },
       "geometry": {
         "type": "LineString",
@@ -270,7 +273,8 @@
         "road_type": "secondary",
         "name_zh": "东侧服务道",
         "length_m": 9435.0,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "length_m_declared": 9435.0
       },
       "geometry": {
         "type": "LineString",
@@ -362,7 +366,8 @@
         "road_type": "primary",
         "name_zh": "学院路辅路",
         "length_m": 9435.0,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "length_m_declared": 9435.0
       },
       "geometry": {
         "type": "LineString",
@@ -454,7 +459,8 @@
         "road_type": "secondary",
         "name_zh": "大钟寺南侧路",
         "length_m": 1020.0,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "length_m_declared": 1020.0
       },
       "geometry": {
         "type": "LineString",
@@ -494,7 +500,8 @@
         "road_type": "secondary",
         "name_zh": "大钟寺北侧路",
         "length_m": 1020.0,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "length_m_declared": 1020.0
       },
       "geometry": {
         "type": "LineString",
@@ -534,7 +541,8 @@
         "road_type": "pedestrian_priority",
         "name_zh": "大钟寺进入连接",
         "length_m": 1020.0,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "length_m_declared": 1020.0
       },
       "geometry": {
         "type": "LineString",
@@ -574,7 +582,8 @@
         "road_type": "primary",
         "name_zh": "成府路",
         "length_m": 1020.0,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "length_m_declared": 1020.0
       },
       "geometry": {
         "type": "LineString",
@@ -614,7 +623,8 @@
         "road_type": "pedestrian_priority",
         "name_zh": "原点进入连接",
         "length_m": 1008.1,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "length_m_declared": 1008.1
       },
       "geometry": {
         "type": "LineString",
@@ -654,7 +664,8 @@
         "road_type": "secondary",
         "name_zh": "五道口-学院路",
         "length_m": 765.0,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "length_m_declared": 765.0
       },
       "geometry": {
         "type": "LineString",
@@ -690,7 +701,8 @@
         "road_type": "pedestrian_priority",
         "name_zh": "众智园到达连接",
         "length_m": 1020.0,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "length_m_declared": 1020.0
       },
       "geometry": {
         "type": "LineString",
@@ -730,7 +742,8 @@
         "road_type": "secondary",
         "name_zh": "众智园南界路",
         "length_m": 1008.2,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "length_m_declared": 1008.2
       },
       "geometry": {
         "type": "LineString",
@@ -770,7 +783,8 @@
         "road_type": "primary",
         "name_zh": "北五环辅路",
         "length_m": 765.0,
-        "alignment_status": "concept_only_pending_transport_review"
+        "alignment_status": "concept_only_pending_transport_review",
+        "length_m_declared": 765.0
       },
       "geometry": {
         "type": "LineString",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
@@ -64,7 +64,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "541078c2115e87f7a6b2d50a59c6b74a629d31053f6fb8898545e02753e0b9e6"
+      "sha256": "e3825a2ada905ad5dd40d6bc02ac95dafdb5c873f67b54997fd94d292aae7d5f"
     },
     {
       "path": "compliance_matrix.json",
@@ -235,7 +235,7 @@
       "path": "geometry/buildings.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "bc9e0f74a2f627650e2aa5e82881e617c73561f9e2566a32aec958b32a001595"
+      "sha256": "9050c1e1dd3c138209eeda3897356f7cd23dfecb453cdb66ee2d1c61a5bb9f51"
     },
     {
       "path": "geometry/constraints.geojson",
@@ -265,19 +265,19 @@
       "path": "geometry/phasing.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "3c1a7807fd0b47ec3c954e6d54a18cfc48f173214108a4fe29758f821f4f66dd"
+      "sha256": "5472c2b0d3eb121a8f8a777b23761b0a1b9eacb56e54aa50a3048c85ac35af9d"
     },
     {
       "path": "geometry/public_space.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "dd8a52b3a391117fbef6dbfaca174019875383bfe6d3b102ac4be32c72a9bdcc"
+      "sha256": "a41a9a361df57e28ed746d13fc7140c3c349d4dc60b6e44989bfa446f0f19c3f"
     },
     {
       "path": "geometry/roads.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "7afc3a267fb681012c255d5070781f828aac2eb119bdd78656d54caa840529bf"
+      "sha256": "06b37f8ff65550f58baa2b2ee3ca72457d79706c1f62eed9cbb9dafb1fc165a7"
     },
     {
       "path": "geometry/site_boundary.geojson",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
@@ -78,7 +78,7 @@
       "ai_package_stages": {
         "submissions/565431hzhang/jingzhang-ai-heritage-halo": "formal"
       },
-      "total_bytes": 4845809,
+      "total_bytes": 4867598,
       "maintainer_bypass": false
     },
     "stderr": ""


### PR DESCRIPTION
城市设计深化——所有geometry文件加标准属性：

1. 绿地: ecological_status=concept_pending_flood_ecology_review
2. 道路: length_m_declared + alignment_status=concept_only_pending_transport_review
3. 建筑: update_status=concept_carrier_pending_survey + usage_note
4. 公共空间: access_rule=registration_free_equal_no_app_route
5. 分期: release_rule=evidence_before_scale

不改坐标，不加/删feature，只加属性