### PR TITLE
improve-design-v2: 建筑功能名+道路功能命名+公共空间node_type

### DIFF
--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/buildings.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/buildings.geojson
@@ -12,7 +12,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "AI模型测试棚",
         "area_sqm_declared": 5359.504,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -55,7 +55,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "算法验证室",
         "area_sqm_declared": 5359.266,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -98,7 +98,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "芯片测试间",
         "area_sqm_declared": 5359.027,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -141,7 +141,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "安全治理工作坊",
         "area_sqm_declared": 5358.789,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -184,7 +184,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "标准研讨室",
         "area_sqm_declared": 5358.551,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -227,7 +227,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "创新成果展示厅",
         "area_sqm_declared": 5358.312,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -270,7 +270,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "AI模型测试棚",
         "area_sqm_declared": 5359.502,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -313,7 +313,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "算法验证室",
         "area_sqm_declared": 5359.264,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -356,7 +356,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "芯片测试间",
         "area_sqm_declared": 5359.026,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -399,7 +399,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "安全治理工作坊",
         "area_sqm_declared": 5358.787,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -442,7 +442,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "标准研讨室",
         "area_sqm_declared": 5358.549,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -485,7 +485,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "创新成果展示厅",
         "area_sqm_declared": 5358.311,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -528,7 +528,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "AI模型测试棚",
         "area_sqm_declared": 5359.501,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -571,7 +571,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "算法验证室",
         "area_sqm_declared": 5359.262,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -614,7 +614,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "芯片测试间",
         "area_sqm_declared": 5359.024,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -657,7 +657,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "安全治理工作坊",
         "area_sqm_declared": 5358.786,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -700,7 +700,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "标准研讨室",
         "area_sqm_declared": 5358.547,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -743,7 +743,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "创新成果展示厅",
         "area_sqm_declared": 5358.309,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -786,7 +786,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "AI模型测试棚",
         "area_sqm_declared": 5359.499,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -829,7 +829,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "算法验证室",
         "area_sqm_declared": 5359.26,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -872,7 +872,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "芯片测试间",
         "area_sqm_declared": 5359.022,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -915,7 +915,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "安全治理工作坊",
         "area_sqm_declared": 5358.784,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -958,7 +958,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "标准研讨室",
         "area_sqm_declared": 5358.545,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1001,7 +1001,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "创新成果展示厅",
         "area_sqm_declared": 5358.307,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1044,7 +1044,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "AI模型测试棚",
         "area_sqm_declared": 5359.497,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1087,7 +1087,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "算法验证室",
         "area_sqm_declared": 5359.259,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1130,7 +1130,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "芯片测试间",
         "area_sqm_declared": 5359.02,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1173,7 +1173,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "安全治理工作坊",
         "area_sqm_declared": 5358.782,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1216,7 +1216,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "标准研讨室",
         "area_sqm_declared": 5358.544,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1259,7 +1259,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "创新成果展示厅",
         "area_sqm_declared": 5358.305,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1302,7 +1302,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "AI模型测试棚",
         "area_sqm_declared": 5359.495,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1345,7 +1345,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "算法验证室",
         "area_sqm_declared": 5359.257,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1388,7 +1388,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "芯片测试间",
         "area_sqm_declared": 5359.019,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1431,7 +1431,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "安全治理工作坊",
         "area_sqm_declared": 5358.78,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1474,7 +1474,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "标准研讨室",
         "area_sqm_declared": 5358.542,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1517,7 +1517,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "创新成果展示厅",
         "area_sqm_declared": 5358.304,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1560,7 +1560,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "AI模型测试棚",
         "area_sqm_declared": 5359.494,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1603,7 +1603,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "算法验证室",
         "area_sqm_declared": 5359.255,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1646,7 +1646,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "芯片测试间",
         "area_sqm_declared": 5359.017,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1689,7 +1689,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "安全治理工作坊",
         "area_sqm_declared": 5358.779,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1732,7 +1732,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "标准研讨室",
         "area_sqm_declared": 5358.54,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1775,7 +1775,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "创新成果展示厅",
         "area_sqm_declared": 5358.302,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1818,7 +1818,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "AI模型测试棚",
         "area_sqm_declared": 5359.492,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1861,7 +1861,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "算法验证室",
         "area_sqm_declared": 5359.254,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1904,7 +1904,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "芯片测试间",
         "area_sqm_declared": 5359.015,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1947,7 +1947,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "安全治理工作坊",
         "area_sqm_declared": 5358.777,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -1990,7 +1990,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "标准研讨室",
         "area_sqm_declared": 5358.539,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2033,7 +2033,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "众智园AI研发建筑",
+        "name_zh": "创新成果展示厅",
         "area_sqm_declared": 5358.3,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2076,7 +2076,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "开源发布厅",
         "area_sqm_declared": 6210.093,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2119,7 +2119,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "成果转化室",
         "area_sqm_declared": 6209.869,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2162,7 +2162,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "孵化加速器",
         "area_sqm_declared": 6209.646,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2205,7 +2205,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "安全治理工作坊",
         "area_sqm_declared": 6209.422,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2248,7 +2248,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "开源发布厅",
         "area_sqm_declared": 6210.091,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2291,7 +2291,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "成果转化室",
         "area_sqm_declared": 6209.867,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2334,7 +2334,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "孵化加速器",
         "area_sqm_declared": 6209.643,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2377,7 +2377,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "算法验证室",
         "area_sqm_declared": 6209.419,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2420,7 +2420,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "开源发布厅",
         "area_sqm_declared": 6210.088,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2463,7 +2463,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "成果转化室",
         "area_sqm_declared": 6209.864,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2506,7 +2506,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "孵化加速器",
         "area_sqm_declared": 6209.64,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2549,7 +2549,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "创新成果展示厅",
         "area_sqm_declared": 6209.417,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2592,7 +2592,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "开源发布厅",
         "area_sqm_declared": 6210.085,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2635,7 +2635,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "成果转化室",
         "area_sqm_declared": 6209.861,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2678,7 +2678,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "孵化加速器",
         "area_sqm_declared": 6209.638,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2721,7 +2721,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "安全治理工作坊",
         "area_sqm_declared": 6209.414,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2764,7 +2764,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "开源发布厅",
         "area_sqm_declared": 6210.083,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2807,7 +2807,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "成果转化室",
         "area_sqm_declared": 6209.859,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2850,7 +2850,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "孵化加速器",
         "area_sqm_declared": 6209.635,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2893,7 +2893,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "算法验证室",
         "area_sqm_declared": 6209.411,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2936,7 +2936,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "开源发布厅",
         "area_sqm_declared": 6210.08,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -2979,7 +2979,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "成果转化室",
         "area_sqm_declared": 6209.856,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3022,7 +3022,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "孵化加速器",
         "area_sqm_declared": 6209.632,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3065,7 +3065,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "ai_r_and_d",
-        "name_zh": "AI原点创新建筑",
+        "name_zh": "创新成果展示厅",
         "area_sqm_declared": 6209.409,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3108,7 +3108,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
+        "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.969,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3151,7 +3151,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
+        "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.801,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3194,7 +3194,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
+        "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.633,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3237,7 +3237,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
+        "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.965,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3280,7 +3280,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
+        "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.797,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3323,7 +3323,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
+        "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.629,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3366,7 +3366,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
+        "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.962,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3409,7 +3409,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
+        "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.794,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3452,7 +3452,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
+        "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.625,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3495,7 +3495,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
+        "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.958,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3538,7 +3538,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
+        "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.79,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3581,7 +3581,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
+        "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.622,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3624,7 +3624,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
+        "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.954,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3667,7 +3667,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
+        "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.786,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3710,7 +3710,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "mixed_use",
-        "name_zh": "大钟寺AI商业建筑",
+        "name_zh": "国际路演中心",
         "area_sqm_declared": 6003.618,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3753,7 +3753,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "residential",
-        "name_zh": "居住建筑",
+        "name_zh": "大钟寺居住配套",
         "area_sqm_declared": 4554.819,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3796,7 +3796,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "residential",
-        "name_zh": "居住建筑",
+        "name_zh": "大钟寺居住配套",
         "area_sqm_declared": 4554.163,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3839,7 +3839,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "residential",
-        "name_zh": "居住建筑",
+        "name_zh": "人才公寓",
         "area_sqm_declared": 4553.508,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3882,7 +3882,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "residential",
-        "name_zh": "居住建筑",
+        "name_zh": "人才公寓",
         "area_sqm_declared": 4553.507,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3925,7 +3925,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "residential",
-        "name_zh": "居住建筑",
+        "name_zh": "人才公寓",
         "area_sqm_declared": 4552.851,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -3968,7 +3968,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "AI体验商业",
         "area_sqm_declared": 4555.333,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4011,7 +4011,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "AI体验商业",
         "area_sqm_declared": 4555.331,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4054,7 +4054,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "AI体验商业",
         "area_sqm_declared": 4555.328,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4097,7 +4097,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "AI体验商业",
         "area_sqm_declared": 4554.808,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4140,7 +4140,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "AI体验商业",
         "area_sqm_declared": 4554.806,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4183,7 +4183,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "AI体验商业",
         "area_sqm_declared": 4554.804,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4226,7 +4226,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "AI体验商业",
         "area_sqm_declared": 4554.153,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4269,7 +4269,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "AI体验商业",
         "area_sqm_declared": 4554.151,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4312,7 +4312,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "AI体验商业",
         "area_sqm_declared": 4554.149,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4355,7 +4355,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "社区商业",
         "area_sqm_declared": 4553.497,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4398,7 +4398,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "社区商业",
         "area_sqm_declared": 4553.495,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4441,7 +4441,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "社区商业",
         "area_sqm_declared": 4553.493,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4484,7 +4484,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "社区商业",
         "area_sqm_declared": 4552.841,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4527,7 +4527,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "社区商业",
         "area_sqm_declared": 4552.839,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4570,7 +4570,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "社区商业",
         "area_sqm_declared": 432.52,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4613,7 +4613,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "众智园配套商业",
         "area_sqm_declared": 4551.529,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4656,7 +4656,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "众智园配套商业",
         "area_sqm_declared": 4551.527,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4699,7 +4699,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "众智园配套商业",
         "area_sqm_declared": 2345.567,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4742,7 +4742,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "retail",
-        "name_zh": "商业服务建筑",
+        "name_zh": "众智园配套商业",
         "area_sqm_declared": 4550.212,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4785,7 +4785,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "name_zh": "数字钟楼文化空间",
         "area_sqm_declared": 2847.089,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4828,7 +4828,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "name_zh": "数字钟楼文化空间",
         "area_sqm_declared": 2847.088,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4871,7 +4871,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "name_zh": "数字钟楼文化空间",
         "area_sqm_declared": 2847.088,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4914,7 +4914,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "name_zh": "数字钟楼文化空间",
         "area_sqm_declared": 2846.557,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -4957,7 +4957,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "name_zh": "数字钟楼文化空间",
         "area_sqm_declared": 2846.556,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -5000,7 +5000,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "name_zh": "数字钟楼文化空间",
         "area_sqm_declared": 2846.555,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -5043,7 +5043,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "name_zh": "数字钟楼文化空间",
         "area_sqm_declared": 2846.27,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -5086,7 +5086,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "name_zh": "数字钟楼文化空间",
         "area_sqm_declared": 2846.269,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -5129,7 +5129,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "name_zh": "数字钟楼文化空间",
         "area_sqm_declared": 2846.268,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -5172,7 +5172,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "name_zh": "文化展示空间",
         "area_sqm_declared": 2846.024,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -5215,7 +5215,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "name_zh": "文化展示空间",
         "area_sqm_declared": 2846.023,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -5258,7 +5258,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "name_zh": "文化展示空间",
         "area_sqm_declared": 2846.022,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -5301,7 +5301,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "name_zh": "文化展示空间",
         "area_sqm_declared": 2845.614,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -5344,7 +5344,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "name_zh": "文化展示空间",
         "area_sqm_declared": 2845.613,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -5387,7 +5387,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "name_zh": "文化展示空间",
         "area_sqm_declared": 2845.613,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -5430,7 +5430,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "name_zh": "京张铁路文化展示",
         "area_sqm_declared": 2844.63,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -5473,7 +5473,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "name_zh": "京张铁路文化展示",
         "area_sqm_declared": 2844.629,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."
@@ -5516,7 +5516,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "building_type": "cultural",
-        "name_zh": "走廊文化公共建筑",
+        "name_zh": "京张铁路文化展示",
         "area_sqm_declared": 2844.629,
         "update_status": "concept_carrier_pending_survey",
         "usage_note": "Concept only; not an existing-building survey or demolition decision."

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/public_space.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/public_space.geojson
@@ -14,7 +14,8 @@
         "public_space_type": "plaza",
         "name_zh": "众智园AI创新广场",
         "area_sqm_declared": 42818.137,
-        "access_rule": "registration_free_equal_no_app_route"
+        "access_rule": "registration_free_equal_no_app_route",
+        "node_type": "innovation_plaza"
       },
       "geometry": {
         "type": "Polygon",
@@ -294,9 +295,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "public_space_type": "plaza",
-        "name_zh": "AI原点社区广场",
+        "name_zh": "原点社区广场",
         "area_sqm_declared": 29746.938,
-        "access_rule": "registration_free_equal_no_app_route"
+        "access_rule": "registration_free_equal_no_app_route",
+        "node_type": "community_plaza"
       },
       "geometry": {
         "type": "Polygon",
@@ -578,7 +580,8 @@
         "public_space_type": "plaza",
         "name_zh": "大钟寺AI城市客厅",
         "area_sqm_declared": 29764.747,
-        "access_rule": "registration_free_equal_no_app_route"
+        "access_rule": "registration_free_equal_no_app_route",
+        "node_type": "civic_living_room"
       },
       "geometry": {
         "type": "Polygon",
@@ -858,9 +861,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
-        "name_zh": "京张绿廊活动节点1",
+        "name_zh": "先问台公共前场",
         "area_sqm_declared": 19050.802,
-        "access_rule": "registration_free_equal_no_app_route"
+        "access_rule": "registration_free_equal_no_app_route",
+        "node_type": "ask_first_desk"
       },
       "geometry": {
         "type": "Polygon",
@@ -1140,9 +1144,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
-        "name_zh": "京张绿廊活动节点2",
+        "name_zh": "人工接手亭公共前场",
         "area_sqm_declared": 19047.239,
-        "access_rule": "registration_free_equal_no_app_route"
+        "access_rule": "registration_free_equal_no_app_route",
+        "node_type": "human_takeover_pavilion"
       },
       "geometry": {
         "type": "Polygon",
@@ -1422,9 +1427,10 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
-        "name_zh": "京张绿廊活动节点3",
+        "name_zh": "公开改进墙公共前场",
         "area_sqm_declared": 19043.126,
-        "access_rule": "registration_free_equal_no_app_route"
+        "access_rule": "registration_free_equal_no_app_route",
+        "node_type": "public_change_log"
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/roads.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/roads.geojson
@@ -271,7 +271,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "road_type": "secondary",
-        "name_zh": "东侧服务道",
+        "name_zh": "东侧联络道",
         "length_m": 9435.0,
         "alignment_status": "concept_only_pending_transport_review",
         "length_m_declared": 9435.0
@@ -457,7 +457,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "road_type": "secondary",
-        "name_zh": "大钟寺南侧路",
+        "name_zh": "大钟寺南侧连接",
         "length_m": 1020.0,
         "alignment_status": "concept_only_pending_transport_review",
         "length_m_declared": 1020.0
@@ -498,7 +498,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "road_type": "secondary",
-        "name_zh": "大钟寺北侧路",
+        "name_zh": "大钟寺北侧连接",
         "length_m": 1020.0,
         "alignment_status": "concept_only_pending_transport_review",
         "length_m_declared": 1020.0
@@ -580,7 +580,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "road_type": "primary",
-        "name_zh": "成府路",
+        "name_zh": "原点到达连接",
         "length_m": 1020.0,
         "alignment_status": "concept_only_pending_transport_review",
         "length_m_declared": 1020.0
@@ -662,7 +662,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "road_type": "secondary",
-        "name_zh": "五道口-学院路",
+        "name_zh": "五道口连接",
         "length_m": 765.0,
         "alignment_status": "concept_only_pending_transport_review",
         "length_m_declared": 765.0
@@ -740,7 +740,7 @@
         "confidence": "medium",
         "geometry_role": "design_proposal",
         "road_type": "secondary",
-        "name_zh": "众智园南界路",
+        "name_zh": "众智园进入连接",
         "length_m": 1008.2,
         "alignment_status": "concept_only_pending_transport_review",
         "length_m_declared": 1008.2

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
@@ -64,7 +64,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "e3825a2ada905ad5dd40d6bc02ac95dafdb5c873f67b54997fd94d292aae7d5f"
+      "sha256": "73d6085067af924b394c6b6f157609eeba4658341bdb46bbee8c3a273a952a17"
     },
     {
       "path": "compliance_matrix.json",
@@ -235,7 +235,7 @@
       "path": "geometry/buildings.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "9050c1e1dd3c138209eeda3897356f7cd23dfecb453cdb66ee2d1c61a5bb9f51"
+      "sha256": "f0a6965c11d7ada1e39a505a1cc5439c707f5dfa5433fd21475f21c75e5c2568"
     },
     {
       "path": "geometry/constraints.geojson",
@@ -271,13 +271,13 @@
       "path": "geometry/public_space.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "a41a9a361df57e28ed746d13fc7140c3c349d4dc60b6e44989bfa446f0f19c3f"
+      "sha256": "c6ca1f152b8a41c5aac677f3df394fab01786da08505c333f28dc71e036c1a6a"
     },
     {
       "path": "geometry/roads.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "06b37f8ff65550f58baa2b2ee3ca72457d79706c1f62eed9cbb9dafb1fc165a7"
+      "sha256": "7dd63c5c35dc2ccdc4e523806cbd59f4038dadab2c43ed260df4810156cdfc96"
     },
     {
       "path": "geometry/site_boundary.geojson",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
@@ -78,7 +78,7 @@
       "ai_package_stages": {
         "submissions/565431hzhang/jingzhang-ai-heritage-halo": "formal"
       },
-      "total_bytes": 4867598,
+      "total_bytes": 4867341,
       "maintainer_bypass": false
     },
     "stderr": ""


### PR DESCRIPTION
城市设计深化——给geometry元素赋予功能含义：

1. 建筑129栋: 众智园(AI模型测试棚/算法验证室/芯片测试间等) 原点(开源发布厅/成果转化室/夜间协作空间等) 大钟寺(国际路演中心/数字钟楼文化空间等)
2. 道路14条: 按功能命名(公共服务脊柱/西侧联络道/大钟寺进入连接等)
3. 公共空间: 3个广场+3个节点加node_type(先问台/人工接手亭/公开改进墙)