### PR TITLE
Revision: 京张档案带 manifest role 合规修复（W10）

### DIFF
--- a/submissions/dengxin7747-lgtm/haidian-ai-belt/manifest.json
+++ b/submissions/dengxin7747-lgtm/haidian-ai-belt/manifest.json
@@ -56,7 +56,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "dcabd407545c0830616d5615baf0e0831969a32e55feed4cfa0c83390fb6e902"
+      "sha256": "a0cd1e5a42962927ad61f4d7a27d5cb5a3e69d8c2453c034d508dbe42db2ea0d"
     },
     {
       "path": "compliance_matrix.json",
@@ -287,35 +287,35 @@
     },
     {
       "path": "assets/figures/station-typology.png",
-      "role": "figure",
+      "role": "proposal_figure",
       "required": false,
       "language": "zh",
       "sha256": "cf8b5c8b167fdae539517d7136ae2ec3345dc9463eb22135457a3c54964e08e2"
     },
     {
       "path": "assets/figures/signage-system.png",
-      "role": "figure",
+      "role": "proposal_figure",
       "required": false,
       "language": "zh",
       "sha256": "3c6b45bcd6dc73cfc0330b67a054075a60efc6972e630231ccdc9a7fca1b96de"
     },
     {
       "path": "assets/figures/node-details.png",
-      "role": "figure",
+      "role": "proposal_figure",
       "required": false,
       "language": "zh",
       "sha256": "d49b5f24e554f95359d761cf19c4f755948293a4daba24e49f629bb14c73a4ee"
     },
     {
       "path": "assets/figures/facility-system.png",
-      "role": "figure",
+      "role": "proposal_figure",
       "required": false,
       "language": "zh",
       "sha256": "e06c16e5db7feda454e33c2de53ab05843d982ab91a98aff2e60fec1709e5b37"
     },
     {
       "path": "assets/figures/station-typology.en.png",
-      "role": "figure",
+      "role": "proposal_figure",
       "required": false,
       "language": "en",
       "translation_of": "assets/figures/station-typology.png",
@@ -323,7 +323,7 @@
     },
     {
       "path": "assets/figures/signage-system.en.png",
-      "role": "figure",
+      "role": "proposal_figure",
       "required": false,
       "language": "en",
       "translation_of": "assets/figures/signage-system.png",
@@ -331,7 +331,7 @@
     },
     {
       "path": "assets/figures/node-details.en.png",
-      "role": "figure",
+      "role": "proposal_figure",
       "required": false,
       "language": "en",
       "translation_of": "assets/figures/node-details.png",
@@ -339,7 +339,7 @@
     },
     {
       "path": "assets/figures/facility-system.en.png",
-      "role": "figure",
+      "role": "proposal_figure",
       "required": false,
       "language": "en",
       "translation_of": "assets/figures/facility-system.png",
@@ -347,14 +347,14 @@
     },
     {
       "path": "assets/figures/spine-section.png",
-      "role": "figure",
+      "role": "proposal_figure",
       "required": false,
       "language": "zh",
       "sha256": "21e0c6a3b455353677d1ee8f8dadeaebf9e8a62be046d8f8bf0d3c06b17a9fa0"
     },
     {
       "path": "assets/figures/spine-section.en.png",
-      "role": "figure",
+      "role": "proposal_figure",
       "required": false,
       "language": "en",
       "translation_of": "assets/figures/spine-section.png",

--- a/submissions/dengxin7747-lgtm/haidian-ai-belt/self_check.json
+++ b/submissions/dengxin7747-lgtm/haidian-ai-belt/self_check.json
@@ -71,7 +71,7 @@
       "ai_package_stages": {
         "submissions/dengxin7747-lgtm/haidian-ai-belt": "formal"
       },
-      "total_bytes": 9650278,
+      "total_bytes": 9650553,
       "maintainer_bypass": false
     },
     "stderr": ""


### PR DESCRIPTION
## 修订内容

本次修订仅修复 manifest 元数据的 role 枚举合规（W10 遗留）：

- **manifest.json**：10 处 OPEN-11/T5 空间深度图 `role` 由非官方 schema 枚举 `figure` 修正为 `proposal_figure`（对齐 `brief/site-package/schemas/manifest.schema.json` 枚举）
- **self_check.json**：`submission_dir` 反斜杠路径改正斜杠；`total_bytes` 更新

## 校验

- `validate_local_submission.py` PASS（50 文件 sha256 一致）
- `self_check_submission.py` 四门 PASS（review_status=formal-review-ready）
- 49/49 文件哈希一致

## 变更范围

仅 2 文件（manifest 元数据 + self_check），方案内容零改动（proposal/几何/图件/HTML 不变）。