### PR TITLE
fix(validation): reject string-form remote CSS imports

### DIFF
--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -355,6 +355,7 @@ FORBIDDEN_HTML_PATTERNS = [
     (re.compile(r"\bWebSocket\b", re.I), "HTML report must not open WebSocket connections"),
     (re.compile(r"\bsendBeacon\s*\(", re.I), "HTML report must not send beacon requests"),
     (re.compile(r"(?:src|href)\s*=\s*['\"]?(?:https?:)?//", re.I), "HTML report must not load remote resources"),
+    (re.compile(r"@import\s+(?:url\s*\(\s*)?['\"]?(?:https?:)?//", re.I), "HTML report CSS must not import remote styles"),
     (re.compile(r"url\s*\(\s*['\"]?(?:https?:)?//", re.I), "HTML report CSS must not load remote assets"),
 ]
 FORBIDDEN_VISUAL_HTML_PATTERNS = [
@@ -365,7 +366,7 @@ FORBIDDEN_VISUAL_HTML_PATTERNS = [
     (re.compile(r"\bWebSocket\b", re.I), "visual HTML must not open WebSocket connections"),
     (re.compile(r"\bEventSource\b", re.I), "visual HTML must not open EventSource connections"),
     (re.compile(r"\bsendBeacon\s*\(", re.I), "visual HTML must not send beacon requests"),
-    (re.compile(r"@import\s+url\s*\(\s*['\"]?(?:https?:)?//", re.I), "visual HTML/CSS must not import remote styles"),
+    (re.compile(r"@import\s+(?:url\s*\(\s*)?['\"]?(?:https?:)?//", re.I), "visual HTML/CSS must not import remote styles"),
     (re.compile(r"url\s*\(\s*['\"]?(?:https?:)?//", re.I), "visual HTML CSS must not load remote assets"),
     (re.compile(r"<script\b[^>]*\bsrc\s*=\s*['\"]?(?:https?:)?//", re.I), "visual HTML must not load remote scripts"),
     (re.compile(r"<link\b[^>]*\bhref\s*=\s*['\"]?(?:https?:)?//", re.I), "visual HTML must not load remote linked resources"),

--- a/scripts/visual_review.py
+++ b/scripts/visual_review.py
@@ -73,7 +73,7 @@ FORBIDDEN_PATTERNS = [
     (re.compile(r"\bWebSocket\b", re.I), "HTML must not open WebSocket connections"),
     (re.compile(r"\bEventSource\b", re.I), "HTML must not open EventSource connections"),
     (re.compile(r"\bsendBeacon\s*\(", re.I), "HTML must not send beacon requests"),
-    (re.compile(r"@import\s+url\s*\(\s*['\"]?(?:https?:)?//", re.I), "HTML/CSS must not import remote styles"),
+    (re.compile(r"@import\s+(?:url\s*\(\s*)?['\"]?(?:https?:)?//", re.I), "HTML/CSS must not import remote styles"),
     (re.compile(r"url\s*\(\s*['\"]?(?:https?:)?//", re.I), "HTML/CSS must not load remote assets"),
     (re.compile(r"<script\b[^>]*\bsrc\s*=\s*['\"]?(?:https?:)?//", re.I), "HTML must not load remote scripts"),
     (re.compile(r"<link\b[^>]*\bhref\s*=\s*['\"]?(?:https?:)?//", re.I), "HTML must not load remote linked resources"),

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -2381,6 +2381,35 @@ class SubmissionWorkflowTests(unittest.TestCase):
             self.assertIn("HTML report must not load remote resources", errors)
             self.assertIn("missing rendered figure reference `../assets/figures/land-use-structure.png`", errors)
 
+    def test_inline_string_remote_css_imports_fail_validation(self) -> None:
+        cases = (
+            (
+                "report/proposal.html",
+                "https://cdn.example.com/report.css",
+                "HTML report CSS must not import remote styles",
+            ),
+            (
+                "visual/index.html",
+                "//cdn.example.com/visual.css",
+                "visual HTML/CSS must not import remote styles",
+            ),
+        )
+        for rel_path, remote_url, expected in cases:
+            with self.subTest(rel_path=rel_path), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                base = "submissions/alice/ai-urban-loop"
+                changed = self.write_minimal_ai_package(root, base)
+                path = root / base / rel_path
+                html = path.read_text(encoding="utf-8").replace(
+                    "</head>", f'<style>@import "{remote_url}";</style></head>'
+                )
+                path.write_text(html, encoding="utf-8")
+
+                report = validate_submission(root, "alice", changed)
+
+                self.assertFalse(report.ok)
+                self.assertIn(expected, "\n".join(report.errors))
+
     def test_privacy_pattern_fails_validation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_visual_review.py
+++ b/tests/test_visual_review.py
@@ -66,6 +66,38 @@ class VisualReviewTests(unittest.TestCase):
             self.assertFalse(report.ok)
             self.assertIn("VISUAL_REMOTE_OR_ACTIVE_CONTENT", {issue.check_id for issue in report.issues})
 
+    def test_string_remote_css_import_fails(self) -> None:
+        for remote_url in ("https://cdn.example.com/theme.css", "//cdn.example.com/theme.css"):
+            with self.subTest(remote_url=remote_url), tempfile.TemporaryDirectory() as tmp:
+                submission = write_valid_visual_package(Path(tmp))
+                html = VALID_HTML.replace(
+                    "</head>", f'<style>@import "{remote_url}";</style></head>'
+                )
+                (submission / "visual" / "index.html").write_text(html, encoding="utf-8")
+
+                report = review_visual(submission)
+
+                self.assertFalse(report.ok)
+                self.assertTrue(
+                    any(
+                        issue.check_id == "VISUAL_REMOTE_OR_ACTIVE_CONTENT"
+                        and "import remote styles" in issue.message
+                        for issue in report.issues
+                    )
+                )
+
+    def test_local_string_css_import_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = write_valid_visual_package(Path(tmp))
+            html = VALID_HTML.replace(
+                "</head>", '<style>@import "assets/theme.css";</style></head>'
+            )
+            (submission / "visual" / "index.html").write_text(html, encoding="utf-8")
+
+            report = review_visual(submission)
+
+            self.assertTrue(report.ok, [issue.__dict__ for issue in report.issues])
+
     def test_fetch_external_url_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             submission = write_valid_visual_package(Path(tmp))


### PR DESCRIPTION
## Theme

Reject string-form remote CSS `@import` directives in inline report and visual HTML offline gates.

## Frozen evidence

- Frozen `upstream/main`: `dabca770f93ba279db050471604412d3f504504f`
- PR creation base: `dabca770f93ba279db050471604412d3f504504f`
- Current base at creation: `dabca770f93ba279db050471604412d3f504504f`
- Exact head: `1f07d9081018fcd73c9f9de2e300e3d06e9ff18f`
- Commit tree: `a33e4f4c1096934892ecd3de29866de8a9013fb5`
- Patch SHA-256: `c7cc5291717ae692efebe3a1b2bedf78ed28857f3d561922e91f1d330edee494`

## Before / after

Before, current main rejected `@import url(https://...)` but accepted equivalent string forms such as `@import "https://..."` and scheme-relative `@import "//..."` in inline report and visual HTML. This could let an ostensibly offline package depend on a remote stylesheet.

After, the report gate, submission visual gate, and standalone visual reviewer reject explicit-scheme and scheme-relative string forms while continuing to allow local string imports such as `@import "assets/theme.css"`.

## Users and public value

This closes one fail-closed offline/privacy gap for every participant package and gives maintainers a regression-protected, consistent diagnostic across both validation paths.

## Non-duplication

I searched open/recent Issues and PRs for this inline string-import root cause and acceptance target and found no duplicate. PR #2231 is adjacent but distinct: it scans external `visual/assets` CSS/JavaScript files, while this PR fixes the existing inline-HTML pattern gates. This PR does not change #2231's external-asset scope.

## Scope

Only four shared validator/test files change:

- `scripts/validate_submission.py`
- `scripts/visual_review.py`
- `tests/test_submission_workflow.py`
- `tests/test_visual_review.py`

No submission, schema, scoring policy, source registry, Gallery/publication artifact, or third-party content changes.

## Verification

Test-first evidence:

- Red phase on frozen main: both explicit-scheme and scheme-relative string imports passed the affected gates and failed the new tests.
- `python -m unittest tests.test_visual_review`: **16 passed**.
- Affected `SubmissionWorkflowTests` run under the lightweight sparse checkout: **99 passed**; one unrelated peer-package owner-alias fixture was intentionally omitted because that peer submission is outside the sparse checkout.
- Six focused new/nearby regression tests: **6 passed**.
- Scenario validation tests: **2 passed**.
- `py_compile` for all four changed Python files: **PASS**.
- `git diff --check`: **PASS**.
- Direct matrix: quoted `https://`, quoted `//`, `url(https://...)`, and `url(//...)` are blocked; local quoted and local `url(...)` imports remain allowed.

Full-module observation (not hidden): the 155-test workflow module produced seven pre-existing Windows `NamedTemporaryFile` lock/permission errors plus one sparse-omitted peer fixture. The affected test class passes independently as reported above.

## Presentation and evidence boundary

No bilingual prose, PDF, HTML output, media, or visual asset is modified, so no carrier regeneration or visual QA is applicable. Evidence remains **E2 → E2** (reproducible negative case plus regression tests); this PR makes no field-test, professional-confirmation, adoption, or implementation claim.

## Attribution

No external source text or media is introduced. Code and regression tests were authored for this contribution under GitHub identity `dvd233` and the repository's existing contribution terms.
