### PR TITLE
Fix intake fail-open when multimodal review requests changes

### DIFF
--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -184,6 +184,12 @@ def decide(review: dict[str, Any], decision: dict[str, Any], threshold: float) -
     failed = sorted(name for name in required if gates.get(name, {}).get("status") != "pass")
     if failed:
         return Decision("request-changes", decision.get("weighted_score_100"), f"failed gates: {', '.join(failed)}")
+    if review.get("recommendation") != "formal-review-ready" or review.get("can_enter_formal_review") is not True:
+        return Decision(
+            "request-changes",
+            decision.get("weighted_score_100"),
+            "multimodal review did not confirm formal-review readiness",
+        )
     score = decision.get("weighted_score_100")
     if not isinstance(score, (int, float)):
         raise WorkerError("AI decision has no numeric weighted_score_100")

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -76,6 +76,8 @@ class AutoReviewQueueTests(unittest.TestCase):
     def test_accepts_score_at_threshold_when_all_gates_pass(self) -> None:
         review = {
             "mandatory_rejection": {"result": "pass"},
+            "recommendation": "formal-review-ready",
+            "can_enter_formal_review": True,
             "gate_checks": {
                 name: {"status": "pass"}
                 for name in [
@@ -91,6 +93,8 @@ class AutoReviewQueueTests(unittest.TestCase):
     def test_low_score_is_not_merged(self) -> None:
         review = {
             "mandatory_rejection": {"result": "pass"},
+            "recommendation": "formal-review-ready",
+            "can_enter_formal_review": True,
             "gate_checks": {
                 name: {"status": "pass"}
                 for name in [
@@ -106,11 +110,49 @@ class AutoReviewQueueTests(unittest.TestCase):
     def test_failed_gate_overrides_high_score(self) -> None:
         review = {
             "mandatory_rejection": {"result": "pass"},
+            "recommendation": "formal-review-ready",
+            "can_enter_formal_review": True,
             "gate_checks": {
                 "deterministic_validation": {"status": "pass"},
                 "spatial_review": {"status": "pass"},
                 "visual_review": {"status": "fail"},
                 "professional_evidence_review": {"status": "pass"},
+            },
+        }
+        self.assertEqual("request-changes", decide(review, {"weighted_score_100": 95}, 60).action)
+
+    def test_multimodal_request_changes_overrides_threshold_score(self) -> None:
+        review = {
+            "mandatory_rejection": {"result": "pass"},
+            "recommendation": "request-changes",
+            "can_enter_formal_review": False,
+            "gate_checks": {
+                name: {"status": "pass"}
+                for name in [
+                    "deterministic_validation",
+                    "spatial_review",
+                    "visual_review",
+                    "professional_evidence_review",
+                ]
+            },
+        }
+        decision = decide(review, {"weighted_score_100": 60}, 60)
+        self.assertEqual("request-changes", decision.action)
+        self.assertIn("multimodal", decision.reason)
+
+    def test_formal_recommendation_without_readiness_is_fail_closed(self) -> None:
+        review = {
+            "mandatory_rejection": {"result": "pass"},
+            "recommendation": "formal-review-ready",
+            "can_enter_formal_review": False,
+            "gate_checks": {
+                name: {"status": "pass"}
+                for name in [
+                    "deterministic_validation",
+                    "spatial_review",
+                    "visual_review",
+                    "professional_evidence_review",
+                ]
             },
         }
         self.assertEqual("request-changes", decide(review, {"weighted_score_100": 95}, 60).action)
@@ -253,6 +295,8 @@ class AutoReviewQueueTests(unittest.TestCase):
             review = {
                 "submission_dir": "submissions/alice/plan",
                 "mandatory_rejection": {"result": "pass"},
+                "recommendation": "formal-review-ready",
+                "can_enter_formal_review": True,
                 "gate_checks": {
                     name: {"status": "pass"}
                     for name in [


### PR DESCRIPTION
Closes #3809.

The queue now requires both `recommendation == formal-review-ready` and `can_enter_formal_review == true` before score-based acceptance. This preserves the mandatory rejection and four authoritative local gates while making the required multimodal visible-quality verdict fail closed.

Regression coverage includes exact-threshold and high-score reviews that are not ready.

Tests: `python3 -m unittest tests.test_auto_review_queue tests.test_ai_review_submission` (34 passed); `python3 -m py_compile scripts/auto_review_queue.py`; `git diff --check`.