### PR TITLE
improve-spaces-v2: 公共空间node_type+绿地eco_function+用地design_zone

### DIFF
--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/green_space.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/green_space.geojson
@@ -13,7 +13,8 @@
         "geometry_role": "design_proposal",
         "green_type": "park_green",
         "name_zh": "遗址公园服务绿脊(南段)",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "eco_function": "南北生态主轴(大钟寺段)"
       },
       "geometry": {
         "type": "Polygon",
@@ -54,7 +55,8 @@
         "geometry_role": "design_proposal",
         "green_type": "park_green",
         "name_zh": "遗址公园服务绿脊(中段)",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "eco_function": "南北生态主轴(原点段)"
       },
       "geometry": {
         "type": "Polygon",
@@ -95,7 +97,8 @@
         "geometry_role": "design_proposal",
         "green_type": "park_green",
         "name_zh": "遗址公园服务绿脊(北段)",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "eco_function": "南北生态主轴(众智园段)"
       },
       "geometry": {
         "type": "Polygon",
@@ -136,7 +139,8 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "西侧社区公园A",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "eco_function": "西侧社区生态节点"
       },
       "geometry": {
         "type": "Polygon",
@@ -177,7 +181,8 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "西侧社区公园B",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "eco_function": "西侧社区生态节点"
       },
       "geometry": {
         "type": "Polygon",
@@ -218,7 +223,8 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "西侧社区公园C",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "eco_function": "西侧社区生态节点"
       },
       "geometry": {
         "type": "Polygon",
@@ -259,7 +265,8 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "东侧社区公园A",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "eco_function": "东侧社区生态节点"
       },
       "geometry": {
         "type": "Polygon",
@@ -300,7 +307,8 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "东侧社区公园B",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "eco_function": "东侧社区生态节点"
       },
       "geometry": {
         "type": "Polygon",
@@ -341,7 +349,8 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "东侧社区公园C",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "eco_function": "东侧社区生态节点"
       },
       "geometry": {
         "type": "Polygon",
@@ -382,7 +391,8 @@
         "geometry_role": "design_proposal",
         "green_type": "community_park",
         "name_zh": "东侧社区公园D",
-        "ecological_status": "concept_pending_flood_ecology_review"
+        "ecological_status": "concept_pending_flood_ecology_review",
+        "eco_function": "东侧社区生态节点"
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/land_use.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/land_use.geojson
@@ -14,7 +14,8 @@
         "land_use_code": "0702",
         "name_zh": "南侧居住与配套用地",
         "area_sqm_declared": 163096.297,
-        "nearest_road": "ROAD-EW-2"
+        "nearest_road": "ROAD-EW-2",
+        "design_zone": "大钟寺日用信号站"
       },
       "geometry": {
         "type": "Polygon",
@@ -68,7 +69,8 @@
         "land_use_code": "0802",
         "name_zh": "AI产业集聚研发用地",
         "area_sqm_declared": 246713.264,
-        "nearest_road": "ROAD-EW-2"
+        "nearest_road": "ROAD-EW-2",
+        "design_zone": "大钟寺日用信号站"
       },
       "geometry": {
         "type": "Polygon",
@@ -118,7 +120,8 @@
         "land_use_code": "0802",
         "name_zh": "AI产业集聚研发用地",
         "area_sqm_declared": 1801002.535,
-        "nearest_road": "ROAD-EW-2"
+        "nearest_road": "ROAD-EW-2",
+        "design_zone": "大钟寺日用信号站"
       },
       "geometry": {
         "type": "Polygon",
@@ -176,7 +179,8 @@
         "land_use_code": "05",
         "name_zh": "AI智能原生商业体验用地",
         "area_sqm_declared": 1480278.362,
-        "nearest_road": "ROAD-EW-2"
+        "nearest_road": "ROAD-EW-2",
+        "design_zone": "大钟寺日用信号站"
       },
       "geometry": {
         "type": "Polygon",
@@ -242,7 +246,8 @@
         "land_use_code": "0702",
         "name_zh": "西侧居住社区用地",
         "area_sqm_declared": 287719.802,
-        "nearest_road": "ROAD-NS-1"
+        "nearest_road": "ROAD-NS-1",
+        "design_zone": "原点学习信号站"
       },
       "geometry": {
         "type": "Polygon",
@@ -308,7 +313,8 @@
         "land_use_code": "1401",
         "name_zh": "京张遗址公园绿地",
         "area_sqm_declared": 569190.321,
-        "nearest_road": "ROAD-EW-4"
+        "nearest_road": "ROAD-EW-4",
+        "design_zone": "原点学习信号站"
       },
       "geometry": {
         "type": "Polygon",
@@ -366,7 +372,8 @@
         "land_use_code": "0702",
         "name_zh": "东侧居住社区用地",
         "area_sqm_declared": 654570.399,
-        "nearest_road": "ROAD-EW-4"
+        "nearest_road": "ROAD-EW-4",
+        "design_zone": "原点学习信号站"
       },
       "geometry": {
         "type": "Polygon",
@@ -416,7 +423,8 @@
         "land_use_code": "0802",
         "name_zh": "AI原点社区创新用地",
         "area_sqm_declared": 261735.324,
-        "nearest_road": "ROAD-NS-1"
+        "nearest_road": "ROAD-NS-1",
+        "design_zone": "众智园技术信号站"
       },
       "geometry": {
         "type": "Polygon",
@@ -482,7 +490,8 @@
         "land_use_code": "0802",
         "name_zh": "AI原点社区创新用地",
         "area_sqm_declared": 1018509.885,
-        "nearest_road": "ROAD-EW-5"
+        "nearest_road": "ROAD-EW-5",
+        "design_zone": "原点学习信号站"
       },
       "geometry": {
         "type": "Polygon",
@@ -544,7 +553,8 @@
         "land_use_code": "0802",
         "name_zh": "AI创新社区公共空间用地",
         "area_sqm_declared": 1052785.966,
-        "nearest_road": "ROAD-EW-5"
+        "nearest_road": "ROAD-EW-5",
+        "design_zone": "原点学习信号站"
       },
       "geometry": {
         "type": "Polygon",
@@ -610,7 +620,8 @@
         "land_use_code": "0802",
         "name_zh": "西侧科研配套用地",
         "area_sqm_declared": 41523.599,
-        "nearest_road": "ROAD-NS-1"
+        "nearest_road": "ROAD-NS-1",
+        "design_zone": "原点学习信号站"
       },
       "geometry": {
         "type": "Polygon",
@@ -664,7 +675,8 @@
         "land_use_code": "0802",
         "name_zh": "西侧科研配套用地",
         "area_sqm_declared": 5000.277,
-        "nearest_road": "ROAD-NS-2"
+        "nearest_road": "ROAD-NS-2",
+        "design_zone": "众智园技术信号站"
       },
       "geometry": {
         "type": "Polygon",
@@ -702,7 +714,8 @@
         "land_use_code": "0802",
         "name_zh": "AI研发创新与公共平台用地",
         "area_sqm_declared": 1829638.973,
-        "nearest_road": "ROAD-NS-2"
+        "nearest_road": "ROAD-NS-2",
+        "design_zone": "众智园技术信号站"
       },
       "geometry": {
         "type": "Polygon",
@@ -772,7 +785,8 @@
         "land_use_code": "0802",
         "name_zh": "AI全栈研发创新用地",
         "area_sqm_declared": 2001072.359,
-        "nearest_road": "ROAD-NS-4"
+        "nearest_road": "ROAD-NS-4",
+        "design_zone": "众智园技术信号站"
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/public_space.geojson
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/geometry/public_space.geojson
@@ -13,7 +13,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "plaza",
         "name_zh": "众智园AI创新广场",
-        "area_sqm_declared": 42818.137
+        "area_sqm_declared": 42818.137,
+        "node_type": "innovation_plaza"
       },
       "geometry": {
         "type": "Polygon",
@@ -294,7 +295,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "plaza",
         "name_zh": "AI原点社区广场",
-        "area_sqm_declared": 29746.938
+        "area_sqm_declared": 29746.938,
+        "node_type": "community_plaza"
       },
       "geometry": {
         "type": "Polygon",
@@ -575,7 +577,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "plaza",
         "name_zh": "大钟寺AI城市客厅",
-        "area_sqm_declared": 29764.747
+        "area_sqm_declared": 29764.747,
+        "node_type": "civic_living_room"
       },
       "geometry": {
         "type": "Polygon",
@@ -856,7 +859,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
         "name_zh": "京张绿廊活动节点1",
-        "area_sqm_declared": 19050.802
+        "area_sqm_declared": 19050.802,
+        "node_type": "ask_first_desk"
       },
       "geometry": {
         "type": "Polygon",
@@ -1137,7 +1141,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
         "name_zh": "京张绿廊活动节点2",
-        "area_sqm_declared": 19047.239
+        "area_sqm_declared": 19047.239,
+        "node_type": "human_takeover_pavilion"
       },
       "geometry": {
         "type": "Polygon",
@@ -1418,7 +1423,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
         "name_zh": "京张绿廊活动节点3",
-        "area_sqm_declared": 19043.126
+        "area_sqm_declared": 19043.126,
+        "node_type": "public_change_log"
       },
       "geometry": {
         "type": "Polygon",
@@ -1699,7 +1705,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
         "name_zh": "京张绿廊活动节点4",
-        "area_sqm_declared": 19034.347
+        "area_sqm_declared": 19034.347,
+        "node_type": "activity_node"
       },
       "geometry": {
         "type": "Polygon",
@@ -1980,7 +1987,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "activity_node",
         "name_zh": "京张绿廊活动节点5",
-        "area_sqm_declared": 19029.955
+        "area_sqm_declared": 19029.955,
+        "node_type": "activity_node"
       },
       "geometry": {
         "type": "Polygon",
@@ -2261,7 +2269,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园1",
-        "area_sqm_declared": 7441.189
+        "area_sqm_declared": 7441.189,
+        "node_type": "shade_rest_point"
       },
       "geometry": {
         "type": "Polygon",
@@ -2542,7 +2551,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园1",
-        "area_sqm_declared": 7441.18
+        "area_sqm_declared": 7441.18,
+        "node_type": "shade_rest_point"
       },
       "geometry": {
         "type": "Polygon",
@@ -2823,7 +2833,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园2",
-        "area_sqm_declared": 7439.261
+        "area_sqm_declared": 7439.261,
+        "node_type": "shade_rest_point"
       },
       "geometry": {
         "type": "Polygon",
@@ -3104,7 +3115,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园2",
-        "area_sqm_declared": 7439.252
+        "area_sqm_declared": 7439.252,
+        "node_type": "shade_rest_point"
       },
       "geometry": {
         "type": "Polygon",
@@ -3385,7 +3397,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园3",
-        "area_sqm_declared": 7437.868
+        "area_sqm_declared": 7437.868,
+        "node_type": "community_garden"
       },
       "geometry": {
         "type": "Polygon",
@@ -3666,7 +3679,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园3",
-        "area_sqm_declared": 7437.86
+        "area_sqm_declared": 7437.86,
+        "node_type": "community_garden"
       },
       "geometry": {
         "type": "Polygon",
@@ -3947,7 +3961,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园4",
-        "area_sqm_declared": 7436.047
+        "area_sqm_declared": 7436.047,
+        "node_type": "test_garden"
       },
       "geometry": {
         "type": "Polygon",
@@ -4228,7 +4243,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园4",
-        "area_sqm_declared": 7436.038
+        "area_sqm_declared": 7436.038,
+        "node_type": "test_garden"
       },
       "geometry": {
         "type": "Polygon",
@@ -4509,7 +4525,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园5",
-        "area_sqm_declared": 7434.653
+        "area_sqm_declared": 7434.653,
+        "node_type": "test_garden"
       },
       "geometry": {
         "type": "Polygon",
@@ -4790,7 +4807,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园5",
-        "area_sqm_declared": 7434.644
+        "area_sqm_declared": 7434.644,
+        "node_type": "test_garden"
       },
       "geometry": {
         "type": "Polygon",
@@ -5071,7 +5089,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "西侧口袋公园6",
-        "area_sqm_declared": 3901.099
+        "area_sqm_declared": 3901.099,
+        "node_type": "test_garden"
       },
       "geometry": {
         "type": "Polygon",
@@ -5232,7 +5251,8 @@
         "geometry_role": "design_proposal",
         "public_space_type": "pocket_park",
         "name_zh": "东侧口袋公园6",
-        "area_sqm_declared": 7433.143
+        "area_sqm_declared": 7433.143,
+        "node_type": "test_garden"
       },
       "geometry": {
         "type": "Polygon",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/manifest.json
@@ -64,7 +64,7 @@
       "path": "self_check.json",
       "role": "self_check",
       "required": true,
-      "sha256": "02802195f2eae0f474b0f4ded52f12e250c06c7bd5fe7b33980ad876fcdcb431"
+      "sha256": "0ecd2573fa20f944e3e207c4300380c72b40f2caed2620287ff567c1069aa429"
     },
     {
       "path": "compliance_matrix.json",
@@ -247,7 +247,7 @@
       "path": "geometry/green_space.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "6203a2a5fc5a674319dc821f06a8406ad0d721a244bcc9966b094e18c12949be"
+      "sha256": "057ac7c01307f5ad91886db7bb196de3821fe68254be37ca4123d19e22289e2a"
     },
     {
       "path": "geometry/key_areas.geojson",
@@ -259,7 +259,7 @@
       "path": "geometry/land_use.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "ba2648eac701e67169c51eab850fbbed005e4349e3842d5f2baee745ce27b600"
+      "sha256": "26c80dd83410f45fb42ddf7b690e38e49eb8a0f37d21e452432c609fb6d8a5e4"
     },
     {
       "path": "geometry/phasing.geojson",
@@ -271,7 +271,7 @@
       "path": "geometry/public_space.geojson",
       "role": "geometry",
       "required": true,
-      "sha256": "dd8a52b3a391117fbef6dbfaca174019875383bfe6d3b102ac4be32c72a9bdcc"
+      "sha256": "c503e880134df7c9fa208db48ebe8f29b875ccecedcc6617dd7ba767ac61b10d"
     },
     {
       "path": "geometry/roads.geojson",

--- a/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
+++ b/submissions/565431hzhang/jingzhang-ai-heritage-halo/self_check.json
@@ -78,7 +78,7 @@
       "ai_package_stages": {
         "submissions/565431hzhang/jingzhang-ai-heritage-halo": "formal"
       },
-      "total_bytes": 4844944,
+      "total_bytes": 4846971,
       "maintainer_bypass": false
     },
     "stderr": ""


### PR DESCRIPTION
城市设计深化：

1. 公共空间20个: 全部加node_type(先问台/接手亭/改进墙/遮阴休息/社区花园/测试花园)
2. 绿地10个: 加eco_function(南北生态主轴/东西社区生态节点)
3. 用地14块: 加design_zone(大钟寺日用信号站/原点学习信号站/众智园技术信号站)