### PR TITLE
fix: contain long inline code in proposal reports

### DIFF
--- a/scripts/render_proposal_html.py
+++ b/scripts/render_proposal_html.py
@@ -569,6 +569,12 @@ code {{
   padding: 0.1em 0.35em;
   border-radius: 4px;
 }}
+:not(pre) > code {{
+  display: inline-block;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}}
 .summary {{ color: var(--muted); font-size: 17px; }}
 .translation-link a {{ color: var(--accent); font-weight: 700; }}
 .proposal-table {{ margin: 20px 0 26px; overflow-x: auto; }}

--- a/tests/test_render_proposal_html.py
+++ b/tests/test_render_proposal_html.py
@@ -37,6 +37,30 @@ class RenderProposalHtmlTests(unittest.TestCase):
             )
             self.assertNotIn("0.4 <em>", html)
 
+    def test_render_html_wraps_unbroken_inline_code_without_reformatting_fenced_code(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission_dir = Path(tmp)
+            long_token = "urn:haidian:data-coop:" + ("A" * 256)
+            (submission_dir / "proposal.md").write_text(
+                f"Short `SCN-06`.\n\nInline `{long_token}`.\n\n```text\n{long_token}\n```\n",
+                encoding="utf-8",
+            )
+
+            html = render_html(submission_dir)
+
+            self.assertIn("<code>SCN-06</code>", html)
+            self.assertIn(f"<code>{long_token}</code>", html)
+            self.assertIn(f"<pre><code>{long_token}</code></pre>", html)
+            self.assertIn(
+                ":not(pre) > code {\n"
+                "  display: inline-block;\n"
+                "  max-width: 100%;\n"
+                "  overflow-wrap: anywhere;\n"
+                "  word-break: break-word;\n"
+                "}",
+                html,
+            )
+
     def test_render_html_supports_blockquotes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             submission_dir = Path(tmp)


### PR DESCRIPTION
## Theme

Contain unbroken inline-code tokens in generated proposal reports at narrow viewports.

## Frozen references

- Frozen `upstream/main`: `19bb0df433cf6989cfd307fdceebd354627a02df`
- PR creation base: `19bb0df433cf6989cfd307fdceebd354627a02df`
- Exact head: `a785f488e8a952f712ee397d13272eda7c602bda`
- Commit tree: `46d9a24d745b8e3ef3bf7bf1c53ee8f3f591a044`
- Patch SHA-256: `1c17e57febab3de732af420cfb35da8c2e16e5ea0fb45fe7240fefa862f6bead`
- Renderer blob: `1143dd54613fe944448c99d7ef7a6234e88080ce`
- Test blob: `ff45c7f748df13c5fe394acbdd101dff8a36ade3`

## Before / after

**Before:** the trusted renderer gave inline `code` background, color, padding, and radius but no wrapping contract. In a synthetic 390px Chromium device viewport, one 278-character identifier produced `documentElement.clientWidth=390` and `scrollWidth=2114`; its computed `overflow-wrap` and `word-break` were both `normal`.

**After:** inline code is an atomic `inline-block` capped at its containing width, with break opportunities only when content exceeds that width. The same 390px fixture reports `clientWidth=390` and `scrollWidth=390`. A short `SCN-06` identifier remains one text fragment. Direct `pre > code` is excluded and retains `display:inline`, `max-width:none`, `overflow-wrap:normal`, `word-break:normal`, and `white-space:pre`.

## Users and public value

This benefits every participant using `render_proposal_html.py`, especially mobile reviewers and readers inspecting long hashes, protocol IDs, evidence references, or other unbroken tokens. It removes page-level horizontal scrolling without requiring submission-specific HTML repair or JavaScript.

## Non-duplication

Searches across open and closed Issues/PRs for `long token`, `render_proposal_html overflow`, `inline-code overflow`, `scroll width`, `mobile overflow`, `overflow-wrap`, and `word-break` found no change with the same shared-renderer root and acceptance target. Open #780 addresses BOM/title/freshness behavior; its renderer diff contains no wrapping, white-space, or code-rule change.

## Scope

Two shared paths, one root cause:

- `scripts/render_proposal_html.py`: add a fenced-code-safe inline containment rule.
- `tests/test_render_proposal_html.py`: add a long-token regression covering short inline and fenced code output.

Diff: 2 files, 30 additions, 0 deletions. No submission, schema, scoring, source registry, licence, privacy, Gallery, generated artifact, or workflow change.

## Verification

- Red phase confirmed: the focused regression failed on frozen main before the implementation.
- `python -m unittest tests.test_render_proposal_html -v`: 25/25 PASS.
- `python -m unittest tests.test_site_package_contract -v`: 12 PASS, 1 environment-dependent projected-area check SKIPPED.
- `python -m py_compile scripts/render_proposal_html.py tests/test_render_proposal_html.py`: PASS.
- Chromium QA at 390×844: no document-level overflow; short inline code remains atomic; fenced code computed styles unchanged.
- Desktop QA at 1280×900: document scroll width equals viewport width; short and fenced code remain readable.
- Offline check: one local document request, no remote active resources, no console warnings/errors.
- `git diff --check`, approved-scope, file-size, symlink-mode, temporary-file, and common credential-marker checks: PASS.
- Push dry-run and independent fork branch/API head readback: PASS.

No submission package changed, so manifest refresh, participant self-check, and participant preflight are not applicable to this public-good code/test PR.

## Evidence level and limitations

The current-main reproduction plus executable unit/browser regression is E2 synthetic/tooling evidence. It is not E3 field/user evidence, E4 professional/operator confirmation, or E5 adoption. A successful check, review, or merge would show repository intake only—not formal selection, deployment, government endorsement, or permanent display.

## Unchanged boundaries

No external people were contacted. `SCN-06-E3E4` remains `DEFERRED / DO_NOT_CONTACT / DO_NOT_REASK`. This change does not alter planning facts, proposal claims, data handling, safety policy, licences, or scoring semantics.

## Attribution

Authored by `dvd233` with the project Agent. Existing renderer, tests, repository conventions, and maintainers retain their recorded attribution; no `Co-authored-by` claim is added.
