### PR TITLE
test: make manifest permission regression portable

### DIFF
--- a/tests/test_refresh_submission_manifest.py
+++ b/tests/test_refresh_submission_manifest.py
@@ -37,6 +37,9 @@ class RefreshSubmissionManifestTests(unittest.TestCase):
             (root / "proposal.md").write_text("# Updated proposal\n", encoding="utf-8")
             manifest_path = self.write_manifest(root, "proposal.md")
             os.chmod(manifest_path, 0o640)
+            expected_mode = stat.S_IMODE(manifest_path.stat().st_mode)
+            if os.name == "posix":
+                self.assertEqual(expected_mode, 0o640)
 
             with mock.patch(
                 "refresh_submission_manifest.os.fchmod",
@@ -46,7 +49,7 @@ class RefreshSubmissionManifestTests(unittest.TestCase):
                 ok, error, _refreshed = refresh_manifest(root)
 
             self.assertTrue(ok, error)
-            self.assertEqual(stat.S_IMODE(manifest_path.stat().st_mode), 0o640)
+            self.assertEqual(stat.S_IMODE(manifest_path.stat().st_mode), expected_mode)
 
     def test_chmod_failure_returns_error_and_removes_temporary_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Theme

Make the manifest permission-preservation regression reflect the permissions that the running platform can actually observe, without weakening the exact POSIX `0640` contract.

## Frozen revision

- Frozen `upstream/main`: `78476e15f7aea24b1ab2aeb8c0733880ac7bf20e`
- PR creation base: `78476e15f7aea24b1ab2aeb8c0733880ac7bf20e`
- Current base at creation: `78476e15f7aea24b1ab2aeb8c0733880ac7bf20e`
- Exact head: `ddd350999cf0144b25adffd06faf2d1b156ccf9b`
- Exact tree: `1e5201811b32979a697ce26d6983c284ba2b8112`
- Changed-file Git blob: `ae85bf6987571268ca3e77da3d3bddf08a34a717`
- Changed-file SHA-256: `a3455f686af15f25f8df8f1a1cc6cb01eb8dbe8db64544e9e8fb10cf962cecb2`

## Before / after

**Before:** on current main under Windows/Python 3.10, `os.chmod(path, 0o640)` is represented by `stat()` as the platform-normalized mode `0o666`. `test_preserves_manifest_permissions` nevertheless hard-coded `0o640`, so it failed with `438 != 416` even though refresh preserved the same observable mode.

**After:** the test captures the manifest's observable mode immediately after setup and compares the post-refresh mode with that value. On POSIX, it separately asserts that setup produced exactly `0o640`, so the original Unix permission guarantee remains explicit.

## User and public value

Windows contributors can run this focused manifest regression without a POSIX-only false failure. Maintainers retain the exact POSIX check and gain a regression that tests the real contract—mode preservation—on both platform families.

## Non-duplicate evidence

- Reproduced against the frozen current main with the isolated test.
- Searched open and closed Issues/PRs for `refresh_submission_manifest permissions`, `preserves manifest permissions`, `manifest chmod Windows`, `test_preserves_manifest_permissions`, and `manifest file mode`.
- Searched open PR titles/bodies for manifest permission, mode, Windows, and chmod work.
- No open PR or Issue covers this test correction. Open manifest PRs #2223 and #2225 change different validators/tests.
- This is a narrow follow-up to merged #2123, whose production change is intentionally untouched.

## Scope

One test file only:

- `tests/test_refresh_submission_manifest.py` — 4 additions, 1 deletion

No submission package, production helper, schema, scoring policy, source registry, generated asset, or other contributor's work is changed.

## Verification

### Passing

- `python -m unittest -v tests.test_refresh_submission_manifest.RefreshSubmissionManifestTests.test_preserves_manifest_permissions` — 1/1 PASS on Windows
- `python -m unittest -v tests.test_refresh_submission_manifest` — 3/3 PASS
- `python -m unittest -v tests.test_refresh_submission_manifest tests.test_git_blob_hashes` — 10/10 PASS
- `python -m py_compile scripts/refresh_submission_manifest.py tests/test_refresh_submission_manifest.py` — PASS
- AST parse of both affected/neighbor files — PASS
- `git diff --check` — PASS
- Scope, file-mode, size, symlink-mode, and credential-pattern checks — PASS
- Ordinary push dry-run and remote exact-head readback — PASS
- Upstream `submission-validation` run `32630039832`, job `97171294493` — SUCCESS on the exact head; deterministic scope validation reported one non-submission test file and no participant package gate

### Diagnostic baseline comparison

A broader 200-test sample is not a clean gate in this Windows sparse worktree. Frozen base produced **4 failures / 10 errors / 29 skips**; this head produced **3 failures / 10 errors / 29 skips**. The only removed failure is this targeted test. Remaining results are unchanged sparse-checkout fixture omissions and pre-existing Windows temporary-path behavior; they are not caused by this diff.

Participant package gate, preflight, bilingual, PDF/HTML/media, accessibility, and visual QA are not applicable to this shared test-only change. The repository's exact-head CI validates PR scope but does not execute this unit module.

## Evidence level and limitations

- Evidence: **E2 → stronger E2** (current-main negative reproduction plus executable regression).
- No field observation, stakeholder confirmation, adoption, implementation, or policy outcome is claimed.
- Local Linux execution was unavailable, and the repository CI does not run this unit module. The explicit POSIX setup assertion preserves the `0640` contract in code; an actual POSIX unit run remains unobserved locally.

## Unchanged boundaries

- Production `refresh_manifest()` behavior is unchanged.
- Manifest hashing, atomic replacement, failure cleanup, schema, validation severity, and submission policy are unchanged.
- No design claim, resident contact, external authorization, or operational commitment is involved.

## Attribution

Authored by `dvd233` Agent as a focused public-good follow-up. Related production work and original regression context remain credited to contributors and reviewers of #2123.
