### PR TITLE
test: decode peer catalog output as UTF-8

### DIFF
--- a/tests/test_lightweight_participant_flow.py
+++ b/tests/test_lightweight_participant_flow.py
@@ -168,6 +168,7 @@ class LightweightParticipantFlowTests(unittest.TestCase):
                 "--json",
             ],
             REPO_ROOT,
+            encoding="utf-8",
         )
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         report = json.loads(completed.stdout)


### PR DESCRIPTION
## Summary

Decode the peer-catalog child process as UTF-8 at the one test boundary that parses its JSON output. This removes a deterministic Windows/cp936 test-harness error without changing `read_peer_proposals.py`, repository policy, schemas, submissions, source data, or Gallery output.

## Exact revision

- Frozen `upstream/main`: `94fc9ea0987db897e1b5306939d693f4428f692c`
- PR creation base: `a52b4d9c4448d48a845e623faf6daef85bcd5707`
- Exact head: `4df913171b484ab47698724bf4f396e574a212e8`
- Commit tree: `e7d0bc2ae23ad5b805f2c0352d93d58ef51d6b33`
- Changed-file blob: `6119dcf2f471f926e1acd56f30191972d416f100`
- Patch SHA-256: `1f4b8b0fd9ea617f49c17303829c6a2a2e5acf629fed3ad1a21598c9cffca72e`

## Before / after

**Before:** on Windows/Python 3.10 with preferred encoding `cp936`, `test_peer_catalog_reads_local_index_without_materializing_media` invoked `subprocess.run(text=True, encoding=None)`. The child correctly emitted UTF-8 JSON, but the parent reader thread attempted GBK decoding, raised `UnicodeDecodeError`, set `stdout=None`, and the assertion path then raised `TypeError`. The exact test failed three consecutive times; the focused module reported 7 passes and 1 error.

**After:** that invocation explicitly uses `encoding="utf-8"`, matching the child process's documented and tested output contract. The test parses the same JSON and retains all existing assertions.

## Root cause and non-duplication

Merged #879 intentionally made the **child** write UTF-8 so valid catalog text such as `²` is not lost on GBK terminals; this PR credits and preserves that behavior. The remaining defect is the separate **parent test harness** decode boundary. Searches for the exact test name, `read_peer_proposals` + encoding/UnicodeDecodeError, peer catalog + GBK, and lightweight-flow encoding found no same-root open or closed fix. Open #2232 protects peer-cache write locations and does not change this invocation.

## User and public value

Windows contributors and maintainers can run the lightweight participant-flow suite without a false locale-dependent error. Keeping the real JSON catalog test executable also preserves coverage that reading the local index does not materialize peer media.

## Scope

- `tests/test_lightweight_participant_flow.py`: +1/-0
- Production changes: none
- Submission changes: none
- No schema, scoring, source, workflow, Gallery, bilingual, visual, accessibility, privacy, licence, or safety-policy change

## Validation

- Frozen-base exact reproduction: failed 3/3 with parent-side cp936 `UnicodeDecodeError`
- Raw-byte differential: child return code 0; stdout is valid UTF-8 and valid JSON (`ok=true`, `shown=1`)
- Exact corrected test: 1/1 PASS
- `python -m unittest tests.test_lightweight_participant_flow`: 8/8 PASS
- `python -m unittest tests.test_read_peer_proposals tests.test_site_package_contract`: 14 PASS, 1 optional-dependency skip
- `python -m py_compile tests/test_lightweight_participant_flow.py scripts/read_peer_proposals.py`: PASS
- `git diff --check`: PASS
- Scope/mode/size/symlink/common credential-pattern checks: PASS (`100644`, one 11,651-byte test file)

The same 542-test sparse-Windows discovery command was run on frozen base and exact head. Base: 14 failures / 21 errors / 58 skips. Head: 14 failures / 20 errors / 58 skips. Failure-name comparison shows exactly the targeted peer-catalog error removed and no new failure; the remaining failures are unchanged sparse-workspace/optional-environment baselines (principally intentionally absent peer submission trees and Gallery artifacts), not hidden as passes.

## Evidence boundary

This is stronger E2 executable regression evidence only. Deterministic CI, review, or merge would not imply formal selection, adoption, deployment, or any proposal score.

## Attribution

#879 and its authors remain the source of the child-side UTF-8 output contract. This PR only closes the parent test-harness read boundary and does not claim that earlier contribution as original work.
