### PR TITLE
fix: decode the remaining script subprocesses as UTF-8

### DIFF
--- a/scripts/ai_review_submission.py
+++ b/scripts/ai_review_submission.py
@@ -211,6 +211,8 @@ def render_pdf_previews(
                 ],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 check=False,
                 timeout=60,
             )
@@ -265,6 +267,8 @@ def render_html_previews(
                 ],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 check=False,
                 timeout=60,
             )

--- a/scripts/backfill_bilingual_artifacts.py
+++ b/scripts/backfill_bilingual_artifacts.py
@@ -272,6 +272,8 @@ def ocr_image(path: Path, source_language: str) -> str:
             ["tesseract", str(path), "stdout", "-l", language, "--psm", psm],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             check=False,
         )
         if completed.returncode != 0:

--- a/scripts/bootstrap_participant_workspace.py
+++ b/scripts/bootstrap_participant_workspace.py
@@ -97,6 +97,8 @@ def run(command: list[str], *, cwd: Path | None = None) -> str:
         cwd=cwd,
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         check=False,
     )
     if completed.returncode:

--- a/scripts/export_review_packet.py
+++ b/scripts/export_review_packet.py
@@ -911,6 +911,8 @@ def render_pdf(html_path: Path, pdf_path: Path, engine: str = "auto") -> None:
                 [binary, "--quiet", "--print-media-type", html_path.as_posix(), pdf_path.as_posix()],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 check=False,
             )
         elif candidate == "chromium":
@@ -939,6 +941,8 @@ def render_pdf(html_path: Path, pdf_path: Path, engine: str = "auto") -> None:
                 ],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 check=False,
             )
         else:

--- a/scripts/git_blob_hashes.py
+++ b/scripts/git_blob_hashes.py
@@ -29,6 +29,8 @@ def git_blob_sha256(paths: Iterable[Path], *, cwd: Path) -> dict[Path, str] | No
         cwd=cwd,
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         check=False,
     )
     if completed.returncode:

--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -596,6 +596,9 @@ def run_trusted_review_gates(
                 cwd=trusted_repo_root,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
+                env={**os.environ, "PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"},
                 timeout=TRUSTED_REVIEW_GATE_TIMEOUT_SECONDS,
                 check=False,
             )

--- a/tests/test_subprocess_encoding_scripts.py
+++ b/tests/test_subprocess_encoding_scripts.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import bootstrap_participant_workspace  # noqa: E402
+import git_blob_hashes  # noqa: E402
+
+
+# Chinese text with full-width punctuation and symbols that are not in GBK.
+SAMPLE_TEXT = "工作区已就绪——全角标点·符号「」以及²和✓"
+
+# scripts/ call sites still awaiting the fix in PR #1515. The guard below
+# asserts the violation set is a *subset* of these, so it fails on any new
+# violation while staying green both before and after that PR merges.
+PENDING_FIX_IN_PR_1515 = {
+    "auto_review_queue.py",
+    "maintainer_review.py",
+    "prelaunch_check.py",
+    "review_submission.py",
+}
+
+
+def decoding_violations() -> set[str]:
+    """Return scripts that decode subprocess output without an explicit encoding.
+
+    ``text=True`` without ``encoding`` decodes with the locale encoding, which
+    corrupts or crashes on a non-UTF-8 console such as Chinese Windows (GBK).
+    """
+    violations: set[str] = set()
+    for path in sorted(SCRIPTS_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not (
+                isinstance(func, ast.Attribute)
+                and func.attr == "run"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "subprocess"
+            ):
+                continue
+            keywords = {kw.arg for kw in node.keywords if kw.arg}
+            decodes_text = bool(keywords & {"text", "universal_newlines"})
+            if decodes_text and "encoding" not in keywords:
+                violations.add(path.name)
+    return violations
+
+
+class SubprocessDecodingGuardTests(unittest.TestCase):
+    def test_scripts_declare_an_explicit_subprocess_encoding(self) -> None:
+        unexpected = decoding_violations() - PENDING_FIX_IN_PR_1515
+        self.assertEqual(
+            set(),
+            unexpected,
+            "subprocess.run(text=True) without encoding= decodes with the locale "
+            f"encoding and breaks on a non-UTF-8 console: {sorted(unexpected)}",
+        )
+
+    def test_guard_detects_a_missing_encoding(self) -> None:
+        """The guard must actually catch the pattern it is meant to prevent."""
+        source = "import subprocess\nsubprocess.run(['x'], capture_output=True, text=True)\n"
+        tree = ast.parse(source)
+        call = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "run"
+        )
+        keywords = {kw.arg for kw in call.keywords if kw.arg}
+        self.assertIn("text", keywords)
+        self.assertNotIn("encoding", keywords)
+
+
+class BootstrapWorkspaceDecodingTests(unittest.TestCase):
+    """bootstrap_participant_workspace.run() drives git/gh on participant machines."""
+
+    def test_utf8_stdout_is_decoded_intact(self) -> None:
+        script = f"import sys; sys.stdout.write({SAMPLE_TEXT!r})"
+        self.assertEqual(
+            SAMPLE_TEXT,
+            bootstrap_participant_workspace.run([sys.executable, "-c", script]),
+        )
+
+    def test_utf8_stderr_survives_in_the_error_detail(self) -> None:
+        script = f"import sys; sys.stderr.write({SAMPLE_TEXT!r}); raise SystemExit(2)"
+        with self.assertRaises(bootstrap_participant_workspace.BootstrapError) as raised:
+            bootstrap_participant_workspace.run([sys.executable, "-c", script])
+        message = str(raised.exception)
+        self.assertIn(SAMPLE_TEXT, message)
+        self.assertNotIn("�", message)
+
+
+class GitBlobHashesDecodingTests(unittest.TestCase):
+    """git rev-parse reports the repository root, which may contain Chinese."""
+
+    def test_repository_root_with_non_ascii_path(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw) / "京张工作区"
+            repo.mkdir()
+            init = subprocess.run(
+                ["git", "init", "-q", str(repo)],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                check=False,
+            )
+            if init.returncode:
+                self.skipTest(f"git init unavailable: {init.stderr.strip()}")
+
+            target = repo / "文件.txt"
+            target.write_text("hello\n", encoding="utf-8")
+            hashes = git_blob_hashes.git_blob_sha256([target], cwd=repo)
+
+            self.assertIsNotNone(hashes, "the temp directory should be a git repository")
+            self.assertIn(target.resolve(), hashes)
+            self.assertRegex(hashes[target.resolve()], r"^[0-9a-f]{64}$")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope

`subprocess.run(text=True)` without `encoding` decodes child output with the locale encoding. On a Chinese Windows console (GBK/CP936) that corrupts, or raises `UnicodeDecodeError` on, output the child wrote as UTF-8.

This is the same defect as #420, #874 and #1203. #1515 fixes four maintainer scripts; this PR covers the remaining call sites under `scripts/`.

Most of these children are not Python, so they only need an explicit decode:

| File | Child | Why it matters |
| --- | --- | --- |
| `bootstrap_participant_workspace.py` | git / gh | Runs on participant machines — exactly the Windows population affected |
| `backfill_bilingual_artifacts.py` | `tesseract -l chi_sim` | stdout **is** the recognised Chinese text |
| `git_blob_hashes.py` | `git rev-parse --show-toplevel` | A repository path can contain non-ASCII characters |
| `ai_review_submission.py` (×2) | pdftoppm, headless Chromium | Diagnostics may be localised |
| `export_review_packet.py` (×2) | wkhtmltopdf, headless Chromium | Diagnostics may be localised |

`github_pr_validation.py` is the one recursive Python call — it runs the trusted review gates through `sys.executable` and parses their JSON — so it also propagates `PYTHONUTF8` / `PYTHONIOENCODING`, the way #1515 does. Passing those to a git or tesseract child would be meaningless, so the other call sites do not.

After this and #1515, no `subprocess.run` in `scripts/` decodes text without declaring an encoding.

## Tests

`tests/test_subprocess_encoding_scripts.py` adds an AST guard that walks every `subprocess.run` in `scripts/` and fails when one decodes text without an encoding. Its allowed set is the four files #1515 is fixing, and it asserts a **subset**, so it passes both before and after that PR merges while still failing on any new violation. Reverting any fix in this PR makes it fail.

Two behavioural tests cover the helpers that run without external binaries: the bootstrap helper round-trips Chinese through stdout and through a failure's stderr detail, and `git_blob_sha256` resolves a repository whose path contains Chinese characters.

## Risk and compatibility

Additive keyword arguments only; no signature, return-type or behaviour change on a UTF-8 host. `errors="replace"` keeps a malformed byte from aborting a review run. No overlap with #2087 (`render_proposal_html.py`, `spatial_review.py`) or #2198 (`maintainer_review.script_path`).

Out of scope, left for their owners: `contrib/` is a contributor-owned analysis tool tied to its own issue, and the `tests/` harness has the same pattern in many places.

## Commands run

```bash
python3 -m unittest tests.test_subprocess_encoding_scripts        # 5 tests, OK
python3 -m unittest tests.test_git_blob_hashes                    # 7 tests, OK
python3 -m unittest tests.test_lightweight_participant_flow       # 8 tests, OK
python3 -m unittest tests.test_export_review_packet               # 4 tests, OK
python3 -m unittest tests.test_ai_review_submission               # 20 tests, OK
python3 -m unittest tests.test_trusted_review_scripts             # 5 tests, OK
python3 -m unittest tests.test_submission_validation_concurrency  # 2 tests, OK
python3 -m py_compile scripts/{ai_review_submission,backfill_bilingual_artifacts,bootstrap_participant_workspace,export_review_packet,git_blob_hashes,github_pr_validation}.py
git diff --check
```

`tests.test_bilingual_backfill` reports one pre-existing error — `RuntimeError: Arial Unicode font is required for bilingual figure panels` — which reproduces identically on unmodified `main` and is unrelated to this change.

---
_Generated by [Claude Code](https://claude.ai/code)_
