### PR TITLE
fix: keep auto review queue importable and lockable on Windows

### DIFF
--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -510,7 +510,9 @@ def main() -> int:
     if args.concurrency < 1:
         raise WorkerError("--concurrency must be at least 1")
     args.audit_root.mkdir(parents=True, exist_ok=True)
-    lock_file = (args.audit_root / ".worker.lock").open("w", encoding="utf-8")
+    # Keep the lock byte intact so a second Windows worker reaches the
+    # non-blocking byte-range lock instead of failing while truncating it.
+    lock_file = (args.audit_root / ".worker.lock").open("a+", encoding="utf-8")
     acquire_worker_lock(lock_file)
     candidates = queued_prs(args.repo, args.label, repo_root)
     selected = []

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -45,7 +45,6 @@ from __future__ import annotations
 
 import argparse
 from concurrent.futures import ThreadPoolExecutor, as_completed
-import fcntl
 import json
 import os
 import shutil
@@ -55,6 +54,14 @@ import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+try:
+    import fcntl
+except ImportError:  # Windows has no fcntl; the worker lock uses msvcrt there.
+    fcntl = None
+    import msvcrt
+else:
+    msvcrt = None
 
 from generate_submissions_data import package_sha256
 
@@ -437,6 +444,33 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
                 run(["git", "worktree", "remove", "--force", str(worktree)], cwd=repo_root)
 
 
+def acquire_worker_lock(lock_file: Any) -> None:
+    """Hold a non-blocking inter-process lock on the worker lock file.
+
+    The lock is released when the file object is closed or the process
+    exits, matching the previous flock lifetime. Raises WorkerError when
+    another live worker already holds the lock.
+    """
+    if fcntl is not None:
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise WorkerError("another auto-review worker is already running") from exc
+        return
+    # Windows fallback: lock one byte at the start of the file. The byte is
+    # written only when the file is still empty; touching a byte range held
+    # by another worker fails, and any such OSError means contention.
+    try:
+        lock_file.seek(0, os.SEEK_END)
+        if lock_file.tell() == 0:
+            lock_file.write("0")
+            lock_file.flush()
+        lock_file.seek(0)
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+    except OSError as exc:
+        raise WorkerError("another auto-review worker is already running") from exc
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", default="open-city-ai/haidian")
@@ -477,10 +511,7 @@ def main() -> int:
         raise WorkerError("--concurrency must be at least 1")
     args.audit_root.mkdir(parents=True, exist_ok=True)
     lock_file = (args.audit_root / ".worker.lock").open("w", encoding="utf-8")
-    try:
-        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except BlockingIOError as exc:
-        raise WorkerError("another auto-review worker is already running") from exc
+    acquire_worker_lock(lock_file)
     candidates = queued_prs(args.repo, args.label, repo_root)
     selected = []
     results = []

--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -444,19 +444,21 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
                 run(["git", "worktree", "remove", "--force", str(worktree)], cwd=repo_root)
 
 
-def acquire_worker_lock(lock_file: Any) -> None:
+def acquire_worker_lock(lock_path: Path) -> Any:
     """Hold a non-blocking inter-process lock on the worker lock file.
 
     The lock is released when the file object is closed or the process
     exits, matching the previous flock lifetime. Raises WorkerError when
     another live worker already holds the lock.
     """
+    lock_file = lock_path.open("a+", encoding="utf-8")
     if fcntl is not None:
         try:
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
         except BlockingIOError as exc:
+            lock_file.close()
             raise WorkerError("another auto-review worker is already running") from exc
-        return
+        return lock_file
     # Windows fallback: lock one byte at the start of the file. The byte is
     # written only when the file is still empty; touching a byte range held
     # by another worker fails, and any such OSError means contention.
@@ -468,7 +470,9 @@ def acquire_worker_lock(lock_file: Any) -> None:
         lock_file.seek(0)
         msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
     except OSError as exc:
+        lock_file.close()
         raise WorkerError("another auto-review worker is already running") from exc
+    return lock_file
 
 
 def parse_args() -> argparse.Namespace:
@@ -510,10 +514,7 @@ def main() -> int:
     if args.concurrency < 1:
         raise WorkerError("--concurrency must be at least 1")
     args.audit_root.mkdir(parents=True, exist_ok=True)
-    # Keep the lock byte intact so a second Windows worker reaches the
-    # non-blocking byte-range lock instead of failing while truncating it.
-    lock_file = (args.audit_root / ".worker.lock").open("a+", encoding="utf-8")
-    acquire_worker_lock(lock_file)
+    lock_file = acquire_worker_lock(args.audit_root / ".worker.lock")
     candidates = queued_prs(args.repo, args.label, repo_root)
     selected = []
     results = []

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(ROOT / "scripts"))
 from auto_review_queue import (  # noqa: E402
     Decision,
     WorkerError,
+    acquire_worker_lock,
     apply_review,
     ci_state,
     decide,
@@ -124,6 +125,29 @@ class AutoReviewQueueTests(unittest.TestCase):
         self.assertEqual("submissions/Alice/plan", submission_dir_from_files(paths, "alice"))
         with self.assertRaises(WorkerError):
             submission_dir_from_files(paths + ["README.md"], "alice")
+
+    def test_worker_lock_rejects_second_holder_until_released(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            lock_path = Path(tmp) / ".worker.lock"
+            first = lock_path.open("w", encoding="utf-8")
+            try:
+                acquire_worker_lock(first)
+                # "r+": on Windows a truncating "w" open of a locked file is
+                # itself refused, which also proves the lock but cannot reach
+                # the WorkerError path under test.
+                second = lock_path.open("r+", encoding="utf-8")
+                try:
+                    with self.assertRaises(WorkerError):
+                        acquire_worker_lock(second)
+                finally:
+                    second.close()
+            finally:
+                first.close()
+            third = lock_path.open("w", encoding="utf-8")
+            try:
+                acquire_worker_lock(third)
+            finally:
+                third.close()
 
     def test_pr_file_paths_preserve_unicode_from_paginated_json(self) -> None:
         payload = [[

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -129,13 +129,12 @@ class AutoReviewQueueTests(unittest.TestCase):
     def test_worker_lock_rejects_second_holder_until_released(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             lock_path = Path(tmp) / ".worker.lock"
-            first = lock_path.open("w", encoding="utf-8")
+            first = lock_path.open("a+", encoding="utf-8")
             try:
                 acquire_worker_lock(first)
-                # "r+": on Windows a truncating "w" open of a locked file is
-                # itself refused, which also proves the lock but cannot reach
-                # the WorkerError path under test.
-                second = lock_path.open("r+", encoding="utf-8")
+                # Use the same non-truncating mode as production so lock
+                # contention is reported through the WorkerError contract.
+                second = lock_path.open("a+", encoding="utf-8")
                 try:
                     with self.assertRaises(WorkerError):
                         acquire_worker_lock(second)
@@ -143,7 +142,7 @@ class AutoReviewQueueTests(unittest.TestCase):
                     second.close()
             finally:
                 first.close()
-            third = lock_path.open("w", encoding="utf-8")
+            third = lock_path.open("a+", encoding="utf-8")
             try:
                 acquire_worker_lock(third)
             finally:

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -129,24 +129,14 @@ class AutoReviewQueueTests(unittest.TestCase):
     def test_worker_lock_rejects_second_holder_until_released(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             lock_path = Path(tmp) / ".worker.lock"
-            first = lock_path.open("a+", encoding="utf-8")
+            first = acquire_worker_lock(lock_path)
             try:
-                acquire_worker_lock(first)
-                # Use the same non-truncating mode as production so lock
-                # contention is reported through the WorkerError contract.
-                second = lock_path.open("a+", encoding="utf-8")
-                try:
-                    with self.assertRaises(WorkerError):
-                        acquire_worker_lock(second)
-                finally:
-                    second.close()
+                with self.assertRaises(WorkerError):
+                    acquire_worker_lock(lock_path)
             finally:
                 first.close()
-            third = lock_path.open("a+", encoding="utf-8")
-            try:
-                acquire_worker_lock(third)
-            finally:
-                third.close()
+            third = acquire_worker_lock(lock_path)
+            third.close()
 
     def test_pr_file_paths_preserve_unicode_from_paginated_json(self) -> None:
         payload = [[


### PR DESCRIPTION
## Problem

On Windows, `import auto_review_queue` fails at module import time:

```
scripts\auto_review_queue.py:48: in <module>
    import fcntl
E   ModuleNotFoundError: No module named 'fcntl'
```

Because two test modules import it, a Windows contributor cannot even collect them:

```
ERROR tests/test_auto_review_queue.py
ERROR tests/test_subprocess_encoding.py
!!!!! Interrupted: 2 errors during collection !!!!!
```

(reproduced on Python 3.10.8 / Windows 11 against current `main` `68f39f2883`; see also the earlier Windows portability rounds #1515, #3833, #3834.)

## Fix

- Guard `import fcntl` and fall back to `msvcrt` on Windows.
- Extract `acquire_worker_lock()`: POSIX keeps the exact existing `fcntl.flock(LOCK_EX | LOCK_NB)` behavior; Windows takes the same non-blocking, held-until-close lock via `msvcrt.locking` on one byte of `.worker.lock`.
- Lock contention raises the same `WorkerError("another auto-review worker is already running")` on both platforms (on Windows any `OSError` from preparing or taking the byte lock, including `PermissionError`, means contention).
- The lock keeps its previous lifetime: released on file close / process exit; no behavior change on Linux.

## Tests

New regression test `test_worker_lock_rejects_second_holder_until_released` proves contention is rejected and the lock can be reacquired after release, on both platforms.

Windows verification:

- `tests/test_auto_review_queue.py` + `tests/test_subprocess_encoding.py`: previously uncollectable, now **21 passed, 2 subtests passed**.
- Full suite on Windows: no new failures attributable to this change (remaining failures reproduce identically on unmodified `main`; they are pre-existing Windows-only issues in unrelated modules).

## Scope and history

Two files: `scripts/auto_review_queue.py`, `tests/test_auto_review_queue.py`. No workflow, schema, scoring, or `submissions/` changes.

Refs #526: an earlier broader PR also replaced this `fcntl` usage, but was closed unmerged because it additionally changed participant-forbidden repository infrastructure (`.gitattributes` etc.) and the author withdrew it. This PR is the minimal, participant-scope version of just the import/lock fix.