### PR TITLE
fix: emit LF-only artifacts from participant-flow writers on Windows

### DIFF
--- a/scripts/finalize_submission.py
+++ b/scripts/finalize_submission.py
@@ -277,7 +277,7 @@ def main() -> int:
         rel = item.get("path")
         if rel and rel != "manifest.json" and str(rel) in hashes:
             item["sha256"] = hashes[str(rel)]
-    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8", newline="\n")
     print(f"Review-ready package: {root}")
     print(
         "Run self_check_submission.py --mark-self-checked --json now; "

--- a/scripts/finalize_submission.py
+++ b/scripts/finalize_submission.py
@@ -277,7 +277,8 @@ def main() -> int:
         rel = item.get("path")
         if rel and rel != "manifest.json" and str(rel) in hashes:
             item["sha256"] = hashes[str(rel)]
-    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8", newline="\n")
+    with manifest_path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n")
     print(f"Review-ready package: {root}")
     print(
         "Run self_check_submission.py --mark-self-checked --json now; "

--- a/scripts/render_proposal_html.py
+++ b/scripts/render_proposal_html.py
@@ -202,6 +202,7 @@ def write_text_atomically(path: Path, text: str) -> None:
             delete=False,
             mode="w",
             encoding="utf-8",
+            newline="\n",
         ) as handle:
             temporary = handle.name
             handle.write(text)

--- a/scripts/self_check_submission.py
+++ b/scripts/self_check_submission.py
@@ -465,7 +465,7 @@ def mark_self_checked(submission_dir: Path, report: dict[str, Any]) -> tuple[boo
         self_check_item["sha256"] = hashlib.sha256(self_check_bytes).hexdigest()
         claim["readiness_contract"] = PERSISTED_READINESS_CONTRACT
         claim["self_checked"] = True
-        manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8", newline="\n")
     except OSError as exc:
         self_check_path.write_bytes(original_self_check)
         manifest_path.write_bytes(original_manifest)

--- a/scripts/self_check_submission.py
+++ b/scripts/self_check_submission.py
@@ -465,7 +465,8 @@ def mark_self_checked(submission_dir: Path, report: dict[str, Any]) -> tuple[boo
         self_check_item["sha256"] = hashlib.sha256(self_check_bytes).hexdigest()
         claim["readiness_contract"] = PERSISTED_READINESS_CONTRACT
         claim["self_checked"] = True
-        manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8", newline="\n")
+        with manifest_path.open("w", encoding="utf-8", newline="\n") as handle:
+            handle.write(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n")
     except OSError as exc:
         self_check_path.write_bytes(original_self_check)
         manifest_path.write_bytes(original_manifest)

--- a/tests/test_agent_scaffold_and_self_check.py
+++ b/tests/test_agent_scaffold_and_self_check.py
@@ -426,6 +426,20 @@ class AgentScaffoldAndSelfCheckTests(unittest.TestCase):
                 result["next_command_note"],
             )
 
+    def test_finalize_and_mark_self_checked_write_lf_only_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_official_site_package(root)
+            submission_dir = root / "submissions" / "alice" / "lf-line-endings"
+            self.assertEqual(run_scaffold(submission_dir, cwd=root).returncode, 0)
+            self.assertEqual(complete_scaffold(submission_dir).returncode, 0)
+            manifest_bytes = (submission_dir / "manifest.json").read_bytes()
+            self.assertNotIn(b"\r", manifest_bytes, "finalize_submission must not emit CR bytes")
+            self.assertEqual(mark_self_checked(submission_dir).returncode, 0)
+            manifest_bytes = (submission_dir / "manifest.json").read_bytes()
+            self.assertNotIn(b"\r", manifest_bytes, "mark_self_checked must not emit CR bytes")
+            self.assertTrue(manifest_bytes.endswith(b"\n"))
+
     def test_ready_package_manifest_refresh_restores_missing_hashes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_render_proposal_html.py
+++ b/tests/test_render_proposal_html.py
@@ -9,10 +9,18 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-from render_proposal_html import render_html, render_inputs  # noqa: E402
+from render_proposal_html import render_html, render_inputs, write_text_atomically  # noqa: E402
 
 
 class RenderProposalHtmlTests(unittest.TestCase):
+    def test_write_text_atomically_emits_lf_only_bytes_on_every_platform(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "report.html"
+            write_text_atomically(target, "<p>alpha</p>\n<p>beta</p>\n")
+            self.assertEqual(target.read_bytes(), b"<p>alpha</p>\n<p>beta</p>\n")
+            write_text_atomically(target, "<p>gamma</p>\n")
+            self.assertEqual(target.read_bytes(), b"<p>gamma</p>\n")
+
     def test_render_html_supports_emphasis_without_reformatting_inline_code(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             submission_dir = Path(tmp)


### PR DESCRIPTION
## Problem

On Windows, three writer paths in the participant flow silently emit CRLF while the repository convention is LF:

1. `scripts/render_proposal_html.py` `write_text_atomically()` uses `tempfile.NamedTemporaryFile(mode="w")` without `newline=`, so regenerated `report/proposal*.html` come out CRLF: every line shows as changed in `git diff`, and `git diff --check` reports trailing-whitespace on all of them.
2. `scripts/self_check_submission.py` `mark_self_checked()` rewrites `manifest.json` with `Path.write_text()` right after hashing the freshly written `self_check.json` — the CRLF manifest then mismatches declared byte hashes as soon as anyone normalizes the file, and PRs pick up whole-file churn.
3. `scripts/finalize_submission.py` writes `manifest.json` the same way.

Concrete harm while iterating on a submission from Windows: a render → refresh → self-check cycle flips generated artifacts to CRLF, breaking hash chains (manifest pins file bytes; the package's own consistency audits re-hash them) and burying real diffs under line-ending noise.

## Fix

Add `newline="\n"` at the three sites. No behavior change on POSIX; Windows output now matches Linux byte-for-byte.

## Tests

- `test_write_text_atomically_emits_lf_only_bytes_on_every_platform`: direct byte-level assertion on the atomic writer, including overwrite of an existing file.
- `test_finalize_and_mark_self_checked_write_lf_only_manifest`: end-to-end scaffold → finalize → mark-self-checked flow asserting `manifest.json` contains no CR bytes after both writers.

## Verification (Windows 11, Python 3.10.8)

- Without the script changes, the new end-to-end test **fails**; with them it **passes**.
- Full suite: failure set byte-identical to unmodified `main` (`a166a0b9f1`); remaining failures are pre-existing Windows-only issues in unrelated modules. (Suite collection itself requires #3859, merged.)

## Scope

Three shared scripts (one line each) + two test files. No workflow, schema, scoring, validator semantics, or `submissions/` changes.