### PR TITLE
test: make bootstrap workspace decoding fixtures emit UTF-8 on any locale

### DIFF
--- a/tests/test_subprocess_encoding_scripts.py
+++ b/tests/test_subprocess_encoding_scripts.py
@@ -87,14 +87,24 @@ class BootstrapWorkspaceDecodingTests(unittest.TestCase):
     """bootstrap_participant_workspace.run() drives git/gh on participant machines."""
 
     def test_utf8_stdout_is_decoded_intact(self) -> None:
-        script = f"import sys; sys.stdout.write({SAMPLE_TEXT!r})"
+        # The child must emit UTF-8 bytes deterministically; on a Windows
+        # console with a legacy code page, Python's stdout defaults to the
+        # locale encoding and cannot even encode the sample. Reconfiguring
+        # the child's stream keeps this test about the parent's decoding.
+        script = (
+            f"import sys; sys.stdout.reconfigure(encoding='utf-8');"
+            f" sys.stdout.write({SAMPLE_TEXT!r})"
+        )
         self.assertEqual(
             SAMPLE_TEXT,
             bootstrap_participant_workspace.run([sys.executable, "-c", script]),
         )
 
     def test_utf8_stderr_survives_in_the_error_detail(self) -> None:
-        script = f"import sys; sys.stderr.write({SAMPLE_TEXT!r}); raise SystemExit(2)"
+        script = (
+            f"import sys; sys.stderr.reconfigure(encoding='utf-8');"
+            f" sys.stderr.write({SAMPLE_TEXT!r}); raise SystemExit(2)"
+        )
         with self.assertRaises(bootstrap_participant_workspace.BootstrapError) as raised:
             bootstrap_participant_workspace.run([sys.executable, "-c", script])
         message = str(raised.exception)


### PR DESCRIPTION
## Problem

`tests/test_subprocess_encoding_scripts.py::BootstrapWorkspaceDecodingTests` fails on a Windows machine whose console uses a legacy (cp936) code page:

```
UnicodeEncodeError: 'gbk' codec can't encode character '\xb2'
```

The two tests spawn a child `python -c` that writes the Chinese sample text. The child's stdout/stderr default to the locale encoding on Windows, so the child fails (or emits GBK bytes) before the parent's UTF-8 decoding — the actual property under test — is even exercised. Same test file passes on Linux and on Windows machines with a UTF-8 default.

## Fix

Reconfigure the child streams inside the fixture scripts (`sys.stdout.reconfigure(encoding='utf-8')` / `sys.stderr.reconfigure(encoding='utf-8')`), making the child emit UTF-8 deterministically on any locale. The tests still verify exactly what they are meant to: `bootstrap_participant_workspace.run()` decodes UTF-8 child output intact, including in the error path.

## Verification

Windows 11, Python 3.10.8, cp936 console:

- Without this change: `2 failed, 3 passed` (both bootstrap decoding tests fail).
- With this change: `5 passed`; the full module plus `test_subprocess_encoding.py` pass (`13 passed`).

One test file changed; no production code, schema, workflow, or submission content touched.