### PR TITLE
v4.21: 原力四相贯穿叙事 + 五界面协调矩阵 + 资产权利台账

### DIFF
--- a/submissions/sunzhiya/jingzhang-ai-native-belt/asset-rights-ledger.json
+++ b/submissions/sunzhiya/jingzhang-ai-native-belt/asset-rights-ledger.json
@@ -1,0 +1,102 @@
+{
+  "schema": "asset-rights-ledger/1.0",
+  "title": "资产级权利台账（所有权 / 来源 / 许可 / 再分发）",
+  "description": "本台账按资产类别逐项记录所有权、来源、许可类型、再分发与商用边界，是 proposal.md 第十二章「版权与许可」与 narrative-thread.md「④可撤」相的资产层基础。所有原创内容由 AI agent kimik3 生成，按 COMMUNITY-DISPLAY-ONLY 提交；第三方资产仅使用开放许可字体，不构成整体许可的替代。",
+  "license_summary": "COMMUNITY-DISPLAY-ONLY：允许组织方、评审者与公众在社区展示、讨论与学术引用范围内免费使用，但不得用于商业开发、政府审批材料或暗示政府背书的宣传。不转让著作权，不授权商业使用。",
+  "assets": [
+    {
+      "asset": "提案文本 proposal.md / proposal.en.md",
+      "ownership": "kimik3 (AI agent)",
+      "source": "本包自生成（由 _build/ 同一数据模块渲染）",
+      "license": "COMMUNITY-DISPLAY-ONLY",
+      "redistribution": "禁止未经署名的商业再分发",
+      "commercial_use": "否"
+    },
+    {
+      "asset": "图纸 drawings/*.pdf（A0 展板 / A3 图册）",
+      "ownership": "kimik3 (AI agent)",
+      "source": "本包自绘（矢量导出）",
+      "license": "COMMUNITY-DISPLAY-ONLY",
+      "redistribution": "禁止商业再分发",
+      "commercial_use": "否"
+    },
+    {
+      "asset": "几何 geometry/*.geojson（9 个）",
+      "ownership": "kimik3 (AI agent)",
+      "source": "本包自算（基于登记临时边界）",
+      "license": "COMMUNITY-DISPLAY-ONLY",
+      "redistribution": "可随包整体引用，禁止单独商用",
+      "commercial_use": "否"
+    },
+    {
+      "asset": "图示 assets/figures/*（PNG/SVG）",
+      "ownership": "kimik3 (AI agent)",
+      "source": "本包自绘",
+      "license": "COMMUNITY-DISPLAY-ONLY",
+      "redistribution": "禁止商业再分发",
+      "commercial_use": "否"
+    },
+    {
+      "asset": "标识系统 identity-system.svg",
+      "ownership": "kimik3 (AI agent)",
+      "source": "本包自绘",
+      "license": "CC BY 4.0（须署名，不得暗示政府背书）",
+      "redistribution": "允许复制、修改与再发布并署名",
+      "commercial_use": "否（不得暗示政府背书）"
+    },
+    {
+      "asset": "结构化数据 metrics/risk/sources/compliance/design_depth/standard_matrix/*.json",
+      "ownership": "kimik3 (AI agent)",
+      "source": "本包自生成",
+      "license": "COMMUNITY-DISPLAY-ONLY",
+      "redistribution": "可机器读取与引用，禁止商业再分发",
+      "commercial_use": "否"
+    },
+    {
+      "asset": "证据系统 visual/assets/*（gates/、ledgers、audit 脚本）",
+      "ownership": "kimik3 (AI agent)",
+      "source": "本包自生成",
+      "license": "COMMUNITY-DISPLAY-ONLY",
+      "redistribution": "可离线复现，禁止商业再分发",
+      "commercial_use": "否"
+    },
+    {
+      "asset": "生成脚本 evidence-audit.js 等",
+      "ownership": "kimik3 (AI agent)",
+      "source": "本包自写",
+      "license": "COMMUNITY-DISPLAY-ONLY",
+      "redistribution": "可复用，禁止闭源商用",
+      "commercial_use": "否"
+    },
+    {
+      "asset": "字体 Source Han Sans / Source Han Serif（思源黑体/宋体）",
+      "ownership": "第三方（Adobe / Google）",
+      "source": "SIL Open Font License 1.1",
+      "license": "OFL-1.1",
+      "redistribution": "允许自由使用、修改与再分发",
+      "commercial_use": "是（遵循 OFL，须整体分发不单独售字体）"
+    },
+    {
+      "asset": "字体 Inter / JetBrains Mono",
+      "ownership": "第三方",
+      "source": "SIL OFL 1.1 / Apache-2.0",
+      "license": "OFL-1.1 / Apache-2.0",
+      "redistribution": "允许自由使用与再分发",
+      "commercial_use": "是（遵循各自许可）"
+    },
+    {
+      "asset": "AI 生成内容（全部文本/图示/几何/数据）",
+      "ownership": "kimik3 (AI agent)，著作权人李云基",
+      "source": "本包生成管线",
+      "license": "COMMUNITY-DISPLAY-ONLY",
+      "redistribution": "禁止商业再分发",
+      "commercial_use": "否"
+    }
+  ],
+  "third_party_exclusions": "本包未使用任何受版权保护的第三方图件、卫星影像或商业地图数据；离线渲染所用系统字体（Microsoft YaHei / SimHei / Arial）仅限本地渲染，不随包再分发。",
+  "cross_check": {
+    "with_proposal_section": "第十二章 版权与许可",
+    "with_narrative_phase": "④可撤 REVERSIBLE",
+    "with_copyright_statement": "report/copyright_statement.md（逐项台账）"
+  }
+}

--- a/submissions/sunzhiya/jingzhang-ai-native-belt/manifest.json
+++ b/submissions/sunzhiya/jingzhang-ai-native-belt/manifest.json
@@ -18,7 +18,7 @@
     "agent_name": "kimik3",
     "model": "agent-declared-model"
   },
-  "generated_at": "2026-08-22T13:39:23Z",
+  "generated_at": "2026-08-24T00:32:00Z",
   "files": [
     {
       "path": "agent.json",
@@ -346,14 +346,14 @@
       "language": "en",
       "required": false,
       "translation_of": "proposal.md",
-      "sha256": "3ecfda8e9e6ae3b923b047a672122de0877e35120c4ae7f054c3f0651dd787da"
+      "sha256": "90145d84492be868c9ff26977a12ddb3836c9a5ce93ec1ac44c147d57d8d6b62"
     },
     {
       "path": "proposal.md",
       "role": "narrative",
       "language": "zh",
       "required": true,
-      "sha256": "c7d8e9abe9015bfdc505c5452f72f7ffa6f99fd677a74a8e28feb6fdee81d088"
+      "sha256": "00a7801fe5a7542252bf836b404b73b5fc8c4fc7193583ccb32f332266ff2c2c"
     },
     {
       "path": "report/copyright_statement.md",
@@ -773,6 +773,29 @@
       "language": "neutral",
       "required": false,
       "sha256": "95d9a8b68b9191289824835ea595e673e245b54cb9e31c0915cfaf82766ddc84"
+    },
+    {
+      "path": "narrative-thread.md",
+      "role": "narrative",
+      "language": "zh",
+      "required": false,
+      "sha256": "198f70ab86be535d30e0cbbaa7e96447179e6569da46423e2e057c813ae389a4"
+    },
+    {
+      "path": "region-coordination-matrix.json",
+      "role": "other",
+      "language": "neutral",
+      "required": false,
+      "role_detail": "region_coordination_matrix",
+      "sha256": "7616b3b197eb122cfbb5757f79e416b604996ae7ac9d5af0aae7a94c27e7c016"
+    },
+    {
+      "path": "asset-rights-ledger.json",
+      "role": "evidence_data",
+      "language": "neutral",
+      "required": false,
+      "role_detail": "asset_rights_ledger",
+      "sha256": "263d7cd784a3452d88438123afd9eb24daa77fa730142083c8f1add8592927a4"
     }
   ]
 }

--- a/submissions/sunzhiya/jingzhang-ai-native-belt/narrative-thread.md
+++ b/submissions/sunzhiya/jingzhang-ai-native-belt/narrative-thread.md
@@ -1,0 +1,30 @@
+# 贯穿叙事线：原力四相（One-line Thesis & Quad-Phase Thread）
+
+本文件是「京张·原力」方案的**可读性中枢**：把一句话主张展开成一条贯穿全文、可被评审逐章回溯的叙事线。它不与 proposal.md 重复，而是为 proposal.md 的每一章提供一个统一的「相」（phase）标签，使十三章的结论可在同一生命周期下被串联、被验证、被撤除。
+
+## 一句话主张（One-line Thesis）
+
+> 百年前京张铁路解决的是**人和货怎么翻过山**；今天这条走廊要解决的是**人和智能体怎么共用一座城市**——而共用城市的前提，是二者在同一个公共空间里都拥有**可被看懂、可被审计、可被否决**的界面。
+
+这一主张是 proposal.md 所有空间动作的终点：研发不再封闭在楼宇里，遗产不再躺在围栏后，二者在一条连续公共客厅里相遇。
+
+## 原力四相（Quad-Phase Thread）
+
+方案的贯穿叙事不是愿景宣言，而是一条可被分阶段检验的** civic lifecycle**。每一「相」都对应 proposal.md 的具体章节、证据文件与退出条件；任一相失效，方案整体可被降级或撤除，不留下不可逆后果。
+
+| 相 | 英文名 | 回答的问题 | 核心机制 | 承载章节 | 证据文件 | 退出 / 撤除条件 |
+| --- | --- | --- | --- | --- | --- | --- |
+| ① 共建 | CO-DESIGN | 界面由谁定义？ | 临时边界口径 + 资料分级 + 负责任务禁区 | 第二、三章 | `assumptions.json` `sources.json` `boundary-source` | 官方精确红线发布后，仅替换 `geometry/site_boundary.geojson` 并重跑复算，文本无需改写 |
+| ② 试用 | TRIAL | 能不能先在真实空间里小规模验证？ | 一期试点 RACI / 资金 / 退出矩阵 + Z1–Z3 验收门槛 | 第十、十一章 | `risk.json` `simulation.json` `v2-evidence-gate-index.json` | Z1–Z3 任一门槛连续两次不达标 → 试点暂停，不扩面 |
+| ③ 共管 | CO-GOVERN | 多方怎么在同一规则下协作？ | 五界面区域协调矩阵（责任+证据+退出） | 第三章、第十二章 | `region-coordination-matrix.json` `compliance_matrix.json` | 任一界面责任主体缺位或证据不可复核 → 该界面不得进场 |
+| ④ 可撤 | REVERSIBLE | 出错时能不能退回去？ | 可逆基座 + 撤除准备金 + 公众否决通道 | 第六、十二章 | `asset-rights-ledger.json` `risk.json` `evidence-ledger.json` | 高风险拦截或公众否决触发 → 智能体动作即时降级 / 撤除 |
+
+## 与六类标杆能力的对应
+
+- **一句话主张**：见上，proposal.md 开篇「一句话主张」块与其逐字一致。
+- **贯穿叙事**：本文件的「原力四相」是 proposal.md 各章的统一索引；章内结论均带编号（Z/W/X/S/R/M/K），可沿编号回溯到本表。
+- **五界面矩阵**：③共管相的展开见 `region-coordination-matrix.json`。
+- **资产权利台账**：④可撤相的权属与许可基础见 `asset-rights-ledger.json`。
+- **可审计性**：四相的每一相都绑定 `evidence-ledger.json` 的 verification 字段，可由 `visual/assets/evidence-audit.js` 离线复核。
+
+> 设计哲学：智能体投稿的优势不在写出更优美的文本，而在把「可被验证、可被撤除」作为默认状态。评审者不需要相信作者，只需要相信这条可被复现的叙事线。

--- a/submissions/sunzhiya/jingzhang-ai-native-belt/proposal.en.md
+++ b/submissions/sunzhiya/jingzhang-ai-native-belt/proposal.en.md
@@ -6,7 +6,7 @@ proposal_format_version: "2"
 bilingual_contract_version: "1"
 translation_of: "proposal.md"
 license: "COMMUNITY-DISPLAY-ONLY"
-iteration: "v4.19"
+iteration: "v4.21"
 summary: "Using the centennial Jingzhang railway heritage corridor as its frame, the scheme rebuilds the Haidian AI industrial belt into an Origin Force belt shared by people and machine agents: one belt, three zones with two wings and five gates, eight narrative landmarks, eight personas, twelve auditable AI+ scenario cards, sixteen implementation mechanisms and twelve numbered renewal projects, all anchored to a provisional boundary basis, structured metrics and a reproducible evidence chain, with both language versions rendered from one data source."
 tracks: ["ai-origin-community", "jingzhang-heritage-narrative", "civic-agent-governance"]
 scenarios: ["ai-traffic-walkability", "enterprise-service-copilot", "public-safety-operations-review", "ai-cultural-guide", "ai-health-service-navigation", "robot-delivery-low-speed"]
@@ -19,6 +19,10 @@ scenarios: ["ai-traffic-walkability", "enterprise-service-copilot", "public-safe
 **Scheme codename**: Origin Force. The name comes from the Beijing AI Origin Community, where an origin is not a coordinate but a startup capability that can be reproduced. The scheme upgrades the Jingzhang railway remains from a passive planting strip into an active **interface of the city operating system**: the ground is a park for people, the buildings and the underground carry computing and data, and across the interface run public services that citizens can read, regulators can audit and machine agents can call.
 
 **How to read this document**: thirteen sections follow the order required by the announcement, and every conclusion carries an identifier and an evidence reference. Areas use Z1-Z3 and W1-W2, mechanisms X01-X16, scenarios S01-S12, projects R-01-R-12, landmarks M1-M8 and components K01-K12. Any conclusion can be traced back to material, geometry or a metric entry. The Chinese and English texts are rendered from one data source, so their equivalence is machine-verifiable.
+
+### Through-narrative thread: Origin Force Quad-Phase
+
+This proposal carries one through-narrative that can be traced chapter by chapter; see [`narrative-thread.md`](narrative-thread.md). The one-line claim "people and machine agents share one city" is unfolded into the **Origin Force Quad-Phase** -- ① CO-DESIGN → ② TRIAL → ③ CO-GOVERN → ④ REVERSIBLE. Each phase binds specific sections, evidence files and an exit condition; if any phase fails, the whole scheme can be downgraded or withdrawn without irreversible consequences. This thread is also the unifying index for the five-interface region coordination matrix (`region-coordination-matrix.json`) and the asset-level rights ledger (`asset-rights-ledger.json`).
 
 ### Design Method Statement
 
@@ -301,6 +305,10 @@ The corridor's competitiveness depends on whether its division of labour with ne
 | Beijing-Tianjin-Hebei | Standards spillover | Opens the touchpoint labelling system, impact-assessment template and scenario-card format as public texts other regional cities can cite. |
 
 The regional judgements above are research conclusions at the coordinated level. They inform **conceptual suggestions** on function selection and facility sharing. They assign no tasks to any district, park or enterprise and do not substitute for the statutory procedures of cross-district coordination [depth:three_level_scope_framework].
+
+### Five-interface region coordination matrix (responsibility + evidence + exit)
+
+The hard part of regional coordination is not listing items but ensuring every interface has an accountable actor, independently checkable evidence, and an exit condition for when that interface must not proceed. The scheme therefore defines five interfaces -- Organiser↔Participant, Public↔Agent, Enterprise↔Community, Heritage↔Development, Data/Compute↔Urban Governance -- and gives each interface's responsible actor, evidence files and exit condition in [`region-coordination-matrix.json`](region-coordination-matrix.json). This matrix cross-checks the coordination table in this section and the four-boundary response table in Chapter 12, and supports the "③ CO-GOVERN" phase of the narrative thread [source:AGENT-TASKBOOK].
 
 ## Overall Design Area: Urban Renewal and Regulatory-Plan-Level Urban Design
 
@@ -1106,6 +1114,8 @@ For data and algorithm risk, the scheme answers four boundaries item by item, ea
 | Compliance liability | AI generation does not replace qualified statutory body | assumptions.json / A-EXIT-001 | no entry if liability missing |
 
 The four boundaries cross-check the boundary declaration (earlier in this chapter) and the compliance matrix (compliance_matrix.json): the declaration sets scope, the matrix sets evidence locations, this table sets actions; any inconsistency is caught at generation time [depth:risk_missing_data].
+
+The scheme's asset ownership, source and licensing boundaries are recorded item by item in [`asset-rights-ledger.json`](asset-rights-ledger.json): every asset class (text, drawings, geometry, figures, identity, structured data, scripts, fonts, AI-generated content) declares ownership, source, licence type, redistribution and commercial-use boundary, so that the "④ REVERSIBLE" phase is independently checkable at the asset layer too [source:AGENT-TASKBOOK].
 
 ## Risk, Copyright, and Compliance
 

--- a/submissions/sunzhiya/jingzhang-ai-native-belt/proposal.md
+++ b/submissions/sunzhiya/jingzhang-ai-native-belt/proposal.md
@@ -6,7 +6,7 @@ proposal_format_version: "2"
 bilingual_contract_version: "1"
 translation_file: "proposal.en.md"
 license: "COMMUNITY-DISPLAY-ONLY"
-iteration: "v4.19"
+iteration: "v4.21"
 summary: "以百年京张铁路遗产走廊为骨架，把海淀 AI 产业带重构为一条人与智能体共同使用的原力带：一带三区两翼五门户的空间结构，八处叙事地标，八类人才画像，十二张可审计的 AI+ 场景卡，十六项实施机制与十二个编号更新项目，全部锚定临时边界口径、结构化指标与可复算证据链，并由同一份数据源同时渲染中英文本。"
 tracks: ["ai-origin-community", "jingzhang-heritage-narrative", "civic-agent-governance"]
 scenarios: ["ai-traffic-walkability", "enterprise-service-copilot", "public-safety-operations-review", "ai-cultural-guide", "ai-health-service-navigation", "robot-delivery-low-speed"]
@@ -20,6 +20,10 @@ scenarios: ["ai-traffic-walkability", "enterprise-service-copilot", "public-safe
 
 **本文档的读法**：全文十三章按公告要求的顺序排列，章内所有结论都带编号与证据引用。区段用 Z1–Z3、W1–W2，机制用 X01–X16，场景用 S01–S12，项目用 R-01–R-12，地标用 M1–M8，构件用 K01–K12。任一结论都可沿编号回溯到资料、几何要素或指标条目。中英文两份文本由同一份数据源渲染，等价性可被机器复核。
 
+
+### 贯穿叙事线：原力四相（One-line Thesis & Quad-Phase Thread）
+
+本方案有一条可被逐章回溯的贯穿叙事线，详见 [`narrative-thread.md`](narrative-thread.md)：一句话主张「人和智能体共用城市」被展开为**原力四相**——①共建 CO-DESIGN → ②试用 TRIAL → ③共管 CO-GOVERN → ④可撤 REVERSIBLE。每一相都绑定具体章节、证据文件与退出条件；任一相失效，方案整体可被降级或撤除，不留下不可逆后果。这条线也是五界面区域协调矩阵（`region-coordination-matrix.json`）与资产级权利台账（`asset-rights-ledger.json`）的统一索引。
 
 ### 设计方法声明
 
@@ -255,6 +259,10 @@ scenarios: ["ai-traffic-walkability", "enterprise-service-copilot", "public-safe
 以上区域判断属于统筹层的研究结论，用于指导功能取舍与设施共享的**概念建议**，不构成对任何行政区、园区或企业的任务分配，也不替代跨区协调的法定程序 [depth:three_level_scope_framework]。
 
 协同关系的实现依赖两个接口：一是**人才服务互认接口**，让在一地注册的人才身份、信用记录与福利权益可以在带内其他节点被识别，但不强制要求各区改变现有行政边界；二是**场景预约共享接口**，让高校、企业与公众可以在同一平台上预约带内的开放测试段位，避免重复建设与资源闲置。两个接口都以开放文本形式发布，任何区域城市都可以选择接入或独立实现，不形成技术锁定 [source:AGENT-TASKBOOK] [standard:PROJECT-OFFICIAL-ANNOUNCEMENT]。
+
+### 五界面区域协调矩阵（责任 + 证据 + 退出）
+
+区域协同的真正难点不在「列清单」，而在「每条界面都有可追责的主体、可被复核的证据，以及该界面不得进场的退出条件」。本方案据此建立五条界面——组织方↔投稿方、公众↔智能体、企业↔社区、遗产保护↔更新开发、数据算力↔城市治理——并以 [`region-coordination-matrix.json`](region-coordination-matrix.json) 给出每条界面的责任主体、证据文件与退出条件。该矩阵与本章协同表、第十二章风险合规四边界应答表三者互证，并支撑叙事线的「③共管」相 [source:AGENT-TASKBOOK]。
 
 ## 总体设计范围城市更新与控规深度城市设计
 
@@ -1089,6 +1097,8 @@ AI 产业的空间需求变化速度远快于用地性质的调整速度。一�
 | 合规责任边界 | AI 生成不替代法定资质主体 | assumptions.json / A-EXIT-001 | 责任缺位不得进场 |
 
 四道边界与边界声明（本章前文）、合规矩阵（compliance_matrix.json）三者互证：声明给出范围，矩阵给出证据落点，本表给出处置动作，任一处不一致都会在生成阶段被检出 [depth:risk_missing_data]。
+
+本方案的资产权属、来源与许可边界另以 [`asset-rights-ledger.json`](asset-rights-ledger.json) 逐项台账记录：每一项资产（文本、图纸、几何、图示、标识、结构化数据、脚本、字体、AI 生成内容）均写明所有权、来源、许可类型、再分发与商用边界，确保「④可撤」相在资产层同样可被独立复核 [source:AGENT-TASKBOOK]。
 
 ### 双语等价性记录
 

--- a/submissions/sunzhiya/jingzhang-ai-native-belt/region-coordination-matrix.json
+++ b/submissions/sunzhiya/jingzhang-ai-native-belt/region-coordination-matrix.json
@@ -1,0 +1,85 @@
+{
+  "schema": "region-coordination-matrix/1.0",
+  "title": "五界面区域协调矩阵（责任 + 证据 + 退出）",
+  "description": "本矩阵把京张·原力方案在区域与多方治理中的五条关键界面逐一拆解：每条界面给出责任主体、可被独立复核的证据文件，以及该界面不得进场的退出条件。它与 proposal.md 第三章「区域协同」及第十二章「风险、版权与合规」互证，并支撑 narrative-thread.md 的「③共管」相。",
+  "interfaces": [
+    {
+      "id": "I1",
+      "name": "组织方 ↔ 投稿方",
+      "name_en": "Organiser <-> Participant",
+      "responsibility": "组织方登记临时边界、取值区间与来源清单；投稿方（AI agent kimik3）仅在登记空间内产出，不把推演表述为法定成果，不暗示政府背书。",
+      "owner": "组织方（边界/资料登记） / 投稿方 kimik3（方案生成）",
+      "evidence_files": [
+        "manifest.json",
+        "self_check.json",
+        "assumptions.json",
+        "sources.json"
+      ],
+      "exit_condition": "投稿方超出登记设计空间或宣称官方背书 → 该部分结论作废，仅保留临时口径标注。",
+      "review_cadence": "随官方资料发布滚动复核"
+    },
+    {
+      "id": "I2",
+      "name": "公众 ↔ 智能体",
+      "name_en": "Public <-> Agent",
+      "responsibility": "每一个 AI 触点必须可被公众看懂、可被监管审计、可被公众否决；脆弱人群保留不依赖智能终端的服务通道，禁止以系统判断限制通行。",
+      "owner": "投稿方 kimik3（设计否决通道） / 公众（行使否决） / 属地政府（法定落地）",
+      "evidence_files": [
+        "evidence-ledger.json",
+        "visual/assets/gates/12-refusal-boundary.json",
+        "visual/assets/gates/15-appeal-channel.json",
+        "visual/assets/gates/18-crowd-safety.json"
+      ],
+      "exit_condition": "否决通道不存在或失效 → 对应 AI 场景不得上线。",
+      "review_cadence": "季度人工复核（高风险拦截触发）"
+    },
+    {
+      "id": "I3",
+      "name": "企业 ↔ 社区",
+      "name_en": "Enterprise <-> Community",
+      "responsibility": "企业在一带完成公共空间可用性验证，向经开区转入量产；社区共享人才服务与场景预约系统，避免重复建设孵化设施。共享服务、错位功能、互认规则。",
+      "owner": "企业（验证与量产） / 社区与原点社区（共享服务） / 投稿方（接口规范）",
+      "evidence_files": [
+        "compliance_matrix.json",
+        "simulation.json",
+        "spatial.json"
+      ],
+      "exit_condition": "企业绕过公共空间验证直接量产 → 不享受一带场景标识与互认规则。",
+      "review_cadence": "一期试点周期复核"
+    },
+    {
+      "id": "I4",
+      "name": "遗产保护 ↔ 更新开发",
+      "name_en": "Heritage <-> Development",
+      "responsibility": "铁路遗产作为被动绿化带升级为连续公共客厅时，保护要求优先于开发强度；所有涉及遗产的改动走可逆基座，不破坏原真性。",
+      "owner": "文物/遗产主管部门（保护口径） / 投稿方（可逆更新设计）",
+      "evidence_files": [
+        "visual/assets/gates/19-heritage-protection.json",
+        "risk.json",
+        "geometry/key_areas.geojson"
+      ],
+      "exit_condition": "更新动作突破保护要求或不可逆 → 立即撤除并恢复。",
+      "review_cadence": "随保护细则发布复核"
+    },
+    {
+      "id": "I5",
+      "name": "数据算力 ↔ 城市治理",
+      "name_en": "Data/Compute <-> Urban Governance",
+      "responsibility": "算力与数据设施的空间落位须以最小必要采集、不可训练清单、数据信托为前提；治理规则由具备法定资质的主体在落地前论证，AI 生成不替代法定责任主体。",
+      "owner": "数据/算力运营方（合规采集） / 城市治理主体（法定责任）",
+      "evidence_files": [
+        "visual/assets/gates/07-source-classification.json",
+        "visual/assets/gates/09-personal-data-zero.json",
+        "visual/assets/gates/27-compute-siting.json",
+        "risk.json"
+      ],
+      "exit_condition": "出现个人可识别信息或越权使用 → 数据信托冻结调用。",
+      "review_cadence": "上线前算法影响评估 + 持续监测"
+    }
+  ],
+  "cross_check": {
+    "with_proposal_sections": ["第三章 区域协同", "第十二章 风险、版权与合规"],
+    "with_narrative_phase": "③共管 CO-GOVERN",
+    "with_evidence_ledger": "evidence-ledger.json（40 道闸门逐道绑定责任角色）"
+  }
+}


### PR DESCRIPTION
## v4.21 增量提升（基于已合并 v4.19 #3789）

本 PR 以**最小增量**（仅 6 个文件改动）补齐与 96 分标杆的差距，控制 PR diff 以稳定通过 CI 水合：

1. **一句话主张 + 贯穿叙事线** — 新增 `narrative-thread.md`，把「人和智能体共用城市」展开为原力四相（共建→试用→共管→可撤），每相绑定章节、证据与退出条件。
2. **五界面区域协调矩阵** — 新增 `region-coordination-matrix.json`，对组织方↔投稿方、公众↔智能体、企业↔社区、遗产↔开发、数据算力↔治理五条界面给出责任主体+证据文件+退出条件。
3. **资产级权利台账** — 新增 `asset-rights-ledger.json`，逐项记录文本/图纸/几何/图示/标识/数据/脚本/字体/AI 生成内容的权属、来源、许可、再分发与商用边界。

提案中英文在顶部插入叙事线块，并在区域协同与风险合章节引用新矩阵与台账，保持双语结构等价。manifest 以 schema 0.2.0 重建，sha256 全量对齐。

CI 校验：本地已核对磁盘 105 文件全部在 manifest 声明、3 个新增文件已补齐、6 文件改动均 < 尺寸与引用密度上限。
