### PR TITLE
fix(review): fail closed on inconsistent mandatory verdict

### DIFF
--- a/scripts/ai_review_submission.py
+++ b/scripts/ai_review_submission.py
@@ -617,9 +617,15 @@ def enforce_local_gates(
         if action not in review["required_next_actions_zh"]:
             review["required_next_actions_zh"].append(action)
     mandatory = review["mandatory_rejection"]
-    if mandatory["hits"] and mandatory["result"] != "fail":
-        mandatory["result"] = "fail"
-        overrides.append("mandatory_rejection: hits require result=fail")
+    # ``hits`` is the evidence-bearing field. Keep the summary result derived
+    # from it so a model cannot reject a package while citing no condition.
+    if mandatory["hits"]:
+        if mandatory["result"] != "fail":
+            mandatory["result"] = "fail"
+            overrides.append("mandatory_rejection: hits require result=fail")
+    elif mandatory["result"] != "pass":
+        mandatory["result"] = "pass"
+        overrides.append("mandatory_rejection: fail without hits requires result=pass")
     mandatory_fail = mandatory["result"] == "fail"
     if mandatory_fail:
         review["recommendation"] = "reject"

--- a/scripts/ai_review_submission.py
+++ b/scripts/ai_review_submission.py
@@ -451,6 +451,7 @@ Rules:
 3. Check the agent taskbook: positioning/functions, brand and logo, regional collaboration, planning innovation, industrial support, perceptible scenarios, spatial specificity, transformability, international communication, and long-term operations.
 4. Mandatory rejection covers privacy/personal data, classified/internal/non-public spatial data, fabricated official endorsement or approval, unlawful/discriminatory/malicious content, material irrelevance, missing agent.1-agent.6 tasks, and presenting proposals as settled government decisions.
    Use mandatory rejection only when the supplied evidence directly proves the condition. A package that names/maps agent.1-agent.6 but incompletely executes their deliverables is request-changes, not reject. Placeholder markers and unreadable deliverables are participant-controlled gate failures and request-changes unless another mandatory condition is independently proven.
+   If mandatory_rejection.result is fail, mandatory_rejection.hits must contain at least one directly proven condition; never return fail with an empty hits array.
 5. Copyright and source review is evidence-based. If supplied package evidence shows that authorship, licenses, fonts, images, maps, datasets, or code are unresolved, do not claim they are cleared; use request-changes and list the exact proof needed. A manifest artifact whose raw content is explicitly marked unsupplied in `review_input_access_boundary` is a review-packet access limitation, not proof that the participant omitted evidence. Do not penalize that limitation by itself, claim to have inspected the artifact, or execute participant verification scripts; rely on the supplied trusted gate reports unless visible evidence establishes a contradiction.
 6. Inspect visual evidence for legibility, consistency, meaningful design information, obvious placeholders, clipping, blank pages, misleading precision, and prominence of provisional-boundary warnings. Machine visual review cannot certify accessibility or legal rights.
 7. Missing organizer-owned official geometry must create precision and recalculation warnings, but must not reduce rubric scores or block content scoring by itself.
@@ -560,6 +561,15 @@ def validate_schema(instance: dict[str, Any], schema: dict[str, Any]) -> None:
         raise ReviewError(f"AI review does not match advisory schema: {exc.message}") from exc
 
 
+def validate_semantic_invariants(review: dict[str, Any]) -> None:
+    """Reject cross-field contradictions before local enforcement or publication."""
+    mandatory = review["mandatory_rejection"]
+    if mandatory["result"] == "fail" and not mandatory["hits"]:
+        raise ReviewError(
+            "Inconsistent mandatory rejection: result=fail requires at least one evidence hit"
+        )
+
+
 def actual_gate(review_input: dict[str, Any], key: str) -> tuple[str, str]:
     self_check = review_input.get("pre_submit_self_check", {}).get("stdout", {})
     section = self_check.get(key, {}) if isinstance(self_check, dict) else {}
@@ -617,15 +627,12 @@ def enforce_local_gates(
         if action not in review["required_next_actions_zh"]:
             review["required_next_actions_zh"].append(action)
     mandatory = review["mandatory_rejection"]
-    # ``hits`` is the evidence-bearing field. Keep the summary result derived
-    # from it so a model cannot reject a package while citing no condition.
+    # Preserve the existing safe normalization: any cited mandatory condition
+    # forces fail even when the model's summary field incorrectly says pass.
     if mandatory["hits"]:
         if mandatory["result"] != "fail":
             mandatory["result"] = "fail"
             overrides.append("mandatory_rejection: hits require result=fail")
-    elif mandatory["result"] != "pass":
-        mandatory["result"] = "pass"
-        overrides.append("mandatory_rejection: fail without hits requires result=pass")
     mandatory_fail = mandatory["result"] == "fail"
     if mandatory_fail:
         review["recommendation"] = "reject"
@@ -856,6 +863,7 @@ def run_ai_review(
         if not isinstance(review, dict):
             raise ReviewError("Model output must be a JSON object")
         validate_schema(review, schema)
+        validate_semantic_invariants(review)
         model_review = json.loads(json.dumps(review, ensure_ascii=False))
         overrides = normalize_model_review(review, review_input["submission_dir"])
         overrides.extend(enforce_local_gates(

--- a/tests/test_ai_review_submission.py
+++ b/tests/test_ai_review_submission.py
@@ -270,6 +270,27 @@ class AIReviewSubmissionTests(unittest.TestCase):
             self.assertEqual("fail", result["review"]["mandatory_rejection"]["result"])
             self.assertFalse(result["review"]["can_enter_formal_review"])
 
+    def test_mandatory_fail_without_hits_is_normalized_to_pass(self) -> None:
+        review = valid_review()
+        review["mandatory_rejection"]["result"] = "fail"
+        review["mandatory_rejection"]["hits"] = []
+        review["mandatory_rejection"]["notes_zh"] = "未发现任何强制退回事实。"
+        client = FakeClient(review)
+        with tempfile.TemporaryDirectory() as tmp, mock.patch(
+            "ai_review_submission.collect_visual_inputs", return_value=([], [], [])
+        ), mock.patch("ai_review_submission.content_preflight", return_value=[]):
+            result = run_ai_review(
+                ROOT, SUBMISSION, "alice", Path(tmp), client, "gpt-test",
+                "https://api.openai.com/v1", "high", 7, 1024 * 1024, False,
+            )
+            self.assertEqual("pass", result["review"]["mandatory_rejection"]["result"])
+            self.assertEqual("formal-review-ready", result["review"]["recommendation"])
+            self.assertTrue(result["review"]["can_enter_formal_review"])
+            self.assertIn(
+                "mandatory_rejection: fail without hits requires result=pass",
+                result["decision"]["local_gate_overrides"],
+            )
+
     def test_invalid_model_schema_is_rejected(self) -> None:
         client = FakeClient({"recommendation": "formal-review-ready"})
         with tempfile.TemporaryDirectory() as tmp, mock.patch(

--- a/tests/test_ai_review_submission.py
+++ b/tests/test_ai_review_submission.py
@@ -270,7 +270,7 @@ class AIReviewSubmissionTests(unittest.TestCase):
             self.assertEqual("fail", result["review"]["mandatory_rejection"]["result"])
             self.assertFalse(result["review"]["can_enter_formal_review"])
 
-    def test_mandatory_fail_without_hits_is_normalized_to_pass(self) -> None:
+    def test_mandatory_fail_without_hits_stops_review_fail_closed(self) -> None:
         review = valid_review()
         review["mandatory_rejection"]["result"] = "fail"
         review["mandatory_rejection"]["hits"] = []
@@ -279,17 +279,23 @@ class AIReviewSubmissionTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp, mock.patch(
             "ai_review_submission.collect_visual_inputs", return_value=([], [], [])
         ), mock.patch("ai_review_submission.content_preflight", return_value=[]):
-            result = run_ai_review(
-                ROOT, SUBMISSION, "alice", Path(tmp), client, "gpt-test",
-                "https://api.openai.com/v1", "high", 7, 1024 * 1024, False,
-            )
-            self.assertEqual("pass", result["review"]["mandatory_rejection"]["result"])
-            self.assertEqual("formal-review-ready", result["review"]["recommendation"])
-            self.assertTrue(result["review"]["can_enter_formal_review"])
-            self.assertIn(
-                "mandatory_rejection: fail without hits requires result=pass",
-                result["decision"]["local_gate_overrides"],
-            )
+            out = Path(tmp)
+            with self.assertRaisesRegex(
+                ReviewError,
+                "result=fail requires at least one evidence hit",
+            ):
+                run_ai_review(
+                    ROOT, SUBMISSION, "alice", out, client, "gpt-test",
+                    "https://api.openai.com/v1", "high", 7, 1024 * 1024, False,
+                )
+            final_artifacts = [
+                "model-output.json",
+                "ai-review.json",
+                "ai-decision.json",
+                "pr-comment.md",
+            ]
+            for artifact in final_artifacts:
+                self.assertFalse((out / artifact).exists())
 
     def test_invalid_model_schema_is_rejected(self) -> None:
         client = FakeClient({"recommendation": "formal-review-ready"})


### PR DESCRIPTION
## 问题

`mandatory_rejection.result=fail` 与 `hits=[]` 是跨字段矛盾：既不能把它静默放行为 pass，也不能发布一个缺少可审计命中证据的正式拒绝结论。

## 修复

- 在 schema 校验后、任何本地覆盖或正式评审产物发布前校验跨字段不变量。
- `result=fail` 且 `hits=[]` 时抛出 `ReviewError` 并停止本次 worker，保持 fail-closed，等待新的有效结构化评审。
- 在模型指令中明确：fail 必须至少包含一个由提交证据直接证明的 hit。
- 保留原有安全归一化：`result=pass` 但 hits 非空时仍强制改为 fail。
- 新增回归测试，证明 `fail + []` 不会变成 pass / formal-review-ready，且不会生成 model-output、ai-review、ai-decision 或 pr-comment 最终产物。

## 验证

- `python3 -m unittest tests.test_ai_review_submission tests.test_auto_review_queue`：37/37 通过
- `python3 -m py_compile scripts/ai_review_submission.py tests/test_ai_review_submission.py`：通过
- `git diff --check`：通过
- 当前分支包含官方最新 `upstream/main`，无待合并提交。