### PR TITLE
fix(review): publish bounded per-dimension repairs in PR comments

### DIFF
--- a/brief/site-package/schemas/advisory_review.schema.json
+++ b/brief/site-package/schemas/advisory_review.schema.json
@@ -19,7 +19,7 @@
   "additionalProperties": false,
   "properties": {
     "schema_version": {
-      "const": "0.2.0"
+      "const": "0.2.1"
     },
     "submission_dir": {
       "type": "string",
@@ -145,9 +145,11 @@
           },
           "required_repairs_zh": {
             "type": "array",
+            "maxItems": 4,
             "items": {
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "maxLength": 600
             }
           }
         }

--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -44,12 +44,17 @@ python3 scripts/maintainer_review.py \
 精选、正式专业评分或现实实施批准。CI 禁止参赛者创建或修改该文件；维护者应在
 合并投稿后通过独立 PR 添加或更新，并注明对应 PR 与 commit SHA。
 
-AI advisory schema `0.2.0` 将两类事项明确分开：`required_next_actions_zh` 只保存
+AI advisory schema `0.2.1` 延续 `0.2.0` 的两类事项分离：`required_next_actions_zh` 只保存
 当前版本中参与者可关闭、阻断 intake 的修复；`conditional_followups` 保存官方资料
 到位、获得外部授权、进入现场试点或以后实质修改时才触发的事项。后者每项必须显式
 记录 `blocking_now=false`、`trigger` 和 `owner`，保留在 PR 评论和后续 `FEEDBACK.md`
 中，但不阻断当前 intake。归属和触发条件不得通过关键词或子串推断；含混项继续按
 当前修复 fail closed。
+
+`0.2.1` 同时把逐维 `required_repairs_zh` 限为每维最多 4 条、每条最多 600 个字符；
+`pr-comment.md` 必须按维度完整公开所有通过 schema 的当前 repair，不得只给计数或静默
+截断。风险、数据缺口和本地中间材料不进入该 repair 区，条件触发项继续使用独立的
+“不阻断本轮”区块。schema 版本提升会让旧缓存评审失效。
 
 ## 4. 复制 PR 评论
 

--- a/docs/review-rubric.md
+++ b/docs/review-rubric.md
@@ -76,6 +76,11 @@
 如果当前包把未来证据冒充为已取得事实，应阻断的是当前错误表述的修复，而不是要求参与者
 伪造尚不可得的证据。
 
+Schema `0.2.1` 要求每个维度最多给出 4 条 `required_repairs_zh`，每条最多 600 个字符。
+权威 `pr-comment.md` 按维度完整公开所有通过 schema 的 repair，不在展示层静默截断；该区
+不公开 `risks_zh`、`data_gaps_zh` 或本地中间材料，也不把 `conditional_followups` 混成
+当前阻断项。版本提升会使旧缓存评审失效，确保公开评论与当前反馈合同一致。
+
 正式评分表同样是本地维护者材料。若专家组希望向参赛者反馈正式评分摘要，只复制 `formal-scorecard-comment.md` 或整理后的 PR comment；不要把评分 JSON、专家分歧或中间评审材料提交到仓库。
 
 ## English Quick Reference

--- a/scripts/ai_review_submission.py
+++ b/scripts/ai_review_submission.py
@@ -455,7 +455,7 @@ Rules:
 5. Copyright and source review is evidence-based. If supplied package evidence shows that authorship, licenses, fonts, images, maps, datasets, or code are unresolved, do not claim they are cleared; use request-changes and list the exact proof needed. A manifest artifact whose raw content is explicitly marked unsupplied in `review_input_access_boundary` is a review-packet access limitation, not proof that the participant omitted evidence. Do not penalize that limitation by itself, claim to have inspected the artifact, or execute participant verification scripts; rely on the supplied trusted gate reports unless visible evidence establishes a contradiction.
 6. Inspect visual evidence for legibility, consistency, meaningful design information, obvious placeholders, clipping, blank pages, misleading precision, and prominence of provisional-boundary warnings. Machine visual review cannot certify accessibility or legal rights.
 7. Missing organizer-owned official geometry must create precision and recalculation warnings, but must not reduce rubric scores or block content scoring by itself.
-8. Scores: 0 absent/invalid, 1 seriously deficient, 2 weak, 3 adequate, 4 strong, 5 exceptional. Required repairs must be specific, prioritized, participant-controlled, and actionable on the current package.
+8. Scores: 0 absent/invalid, 1 seriously deficient, 2 weak, 3 adequate, 4 strong, 5 exceptional. Required repairs must be specific, prioritized, participant-controlled, and actionable on the current package. Each dimension may contain at most four required repairs, each no longer than 600 characters; every accepted repair is published in the PR comment, so do not include local-only review material there.
    Calibrate each dimension independently and do not repeatedly punish one defect in every dimension. A gate failure may block readiness without forcing unrelated rubric scores to zero or one.
 9. formal-review-ready requires all participant-controlled gates to pass, no mandatory rejection, adequate rights/source evidence, readable deliverables, and no unresolved current content risk. `required_next_actions_zh` is exclusively for current participant-controlled blockers and must be empty when none exist. Put future-stage or condition-triggered work in `conditional_followups`, with `blocking_now=false`, an explicit trigger, and an explicit owner. A future field trial, official-data refresh, external authorization, professional sign-off, or later material revision must not block current intake merely because its trigger has not occurred. If the current package overclaims such evidence, require the participant to correct that claim now instead of requiring unavailable evidence.
 10. pr_comment_markdown must be a standalone Chinese PR review: decision, gate results, weighted strengths, material risks, current blocking repairs, and separately labeled non-blocking conditional follow-ups. Do not mention hidden chain-of-thought.
@@ -684,7 +684,9 @@ def normalize_model_review(review: dict[str, Any], expected_submission_dir: str)
             break
     repair_count = 0
     for item in review["rubric_scores"]:
-        repair_count += len(item["required_repairs_zh"])
+        repairs = [" ".join(repair.split()) for repair in item["required_repairs_zh"]]
+        item["required_repairs_zh"] = repairs
+        repair_count += len(repairs)
     if repair_count:
         summary = f"完成七维评分中列出的 {repair_count} 项详细 required repairs；逐项证据和修复要求见各维度。"
         if summary not in actions:
@@ -764,6 +766,22 @@ def authoritative_pr_comment(
     lines.extend(["", "## 七维评分"])
     for item in review["rubric_scores"]:
         lines.append(f"- **{item['dimension_zh']} {item['score']}/5**：{item['comment_zh']}")
+    repair_groups = [item for item in review["rubric_scores"] if item["required_repairs_zh"]]
+    if repair_groups:
+        lines.extend(
+            [
+                "",
+                "## 当前版本逐维修复项（阻断本轮）",
+                "",
+                "> 仅列出当前版本中参与者可立即关闭的阻断项；所有通过 schema 的条目均完整公开。未来条件不会列在此处。",
+            ]
+        )
+        for item in repair_groups:
+            lines.extend(["", f"### {item['dimension_zh']}"])
+            lines.extend(
+                f"{index}. {repair}"
+                for index, repair in enumerate(item["required_repairs_zh"], 1)
+            )
     if review["mandatory_rejection"]["hits"]:
         lines.extend(["", "## 强制拒绝命中"])
         lines.extend(f"- {item}" for item in review["mandatory_rejection"]["hits"])

--- a/tests/test_ai_review_submission.py
+++ b/tests/test_ai_review_submission.py
@@ -41,7 +41,7 @@ DIMENSIONS = [
 
 def valid_review() -> dict:
     return {
-        "schema_version": "0.2.0",
+        "schema_version": "0.2.1",
         "submission_dir": SUBMISSION_REL,
         "recommendation": "formal-review-ready",
         "can_enter_formal_review": True,
@@ -225,6 +225,11 @@ class AIReviewSubmissionTests(unittest.TestCase):
             blocking_now = followup_properties["blocking_now"]
             self.assertEqual("boolean", blocking_now["type"])
             self.assertIs(False, blocking_now["const"])
+            repairs_schema = api_schema["properties"]["rubric_scores"]["items"][
+                "properties"
+            ]["required_repairs_zh"]
+            self.assertEqual(4, repairs_schema["maxItems"])
+            self.assertEqual(600, repairs_schema["items"]["maxLength"])
             self.assertFalse(client.payload["store"])
             content = client.payload["input"][0]["content"]
             self.assertTrue(any(item["type"] == "input_image" for item in content))
@@ -264,6 +269,83 @@ class AIReviewSubmissionTests(unittest.TestCase):
             self.assertEqual("request-changes", result["review"]["recommendation"])
             self.assertTrue(any("1 项详细 required repairs" in item for item in result["review"]["required_next_actions_zh"]))
             self.assertEqual("do-not-publish", result["decision"]["publication_recommendation"])
+            comment = result["review"]["pr_comment_markdown"]
+            self.assertIn("## 当前版本逐维修复项（阻断本轮）", comment)
+            self.assertIn("### 任务书相关性", comment)
+            self.assertIn("1. 补充任务书条款逐项对应表。", comment)
+
+    def test_required_repair_budget_fails_closed(self) -> None:
+        review = valid_review()
+        review["rubric_scores"][0]["required_repairs_zh"] = [
+            f"当前版本修复项 {index}。" for index in range(5)
+        ]
+        client = FakeClient(review)
+        with tempfile.TemporaryDirectory() as tmp, mock.patch(
+            "ai_review_submission.collect_visual_inputs", return_value=([], [], [])
+        ), mock.patch("ai_review_submission.content_preflight", return_value=[]):
+            with self.assertRaisesRegex(ReviewError, "does not match advisory schema"):
+                run_ai_review(
+                    ROOT, SUBMISSION, "alice", Path(tmp), client, "gpt-test",
+                    "https://api.openai.com/v1", "high", 7, 1024 * 1024, False,
+                )
+
+    def test_required_repair_length_budget_fails_closed(self) -> None:
+        review = valid_review()
+        review["rubric_scores"][0]["required_repairs_zh"] = ["修" * 601]
+        client = FakeClient(review)
+        with tempfile.TemporaryDirectory() as tmp, mock.patch(
+            "ai_review_submission.collect_visual_inputs", return_value=([], [], [])
+        ), mock.patch("ai_review_submission.content_preflight", return_value=[]):
+            with self.assertRaisesRegex(ReviewError, "does not match advisory schema"):
+                run_ai_review(
+                    ROOT, SUBMISSION, "alice", Path(tmp), client, "gpt-test",
+                    "https://api.openai.com/v1", "high", 7, 1024 * 1024, False,
+                )
+
+    def test_comment_publishes_every_repair_without_mixing_followups_or_gaps(self) -> None:
+        review = valid_review()
+        review["rubric_scores"][0]["required_repairs_zh"] = [
+            "补充任务书条款逐项对应表。",
+            "说明目标与任务书约束的取舍。",
+        ]
+        review["rubric_scores"][1]["required_repairs_zh"] = ["补充同类方案差异证据。"]
+        review["rubric_scores"][0]["risks_zh"] = ["任务书映射仍可能存在解释风险。"]
+        review["conditional_followups"] = [
+            {
+                "action_zh": "官方边界发布后复算空间指标。",
+                "blocking_now": False,
+                "trigger": "official-data-available",
+                "owner": "participant",
+            }
+        ]
+        client = FakeClient(review)
+        with tempfile.TemporaryDirectory() as tmp, mock.patch(
+            "ai_review_submission.collect_visual_inputs", return_value=([], [], [])
+        ), mock.patch("ai_review_submission.content_preflight", return_value=[]):
+            result = run_ai_review(
+                ROOT, SUBMISSION, "alice", Path(tmp), client, "gpt-test",
+                "https://api.openai.com/v1", "high", 7, 1024 * 1024, False,
+            )
+
+        comment = result["review"]["pr_comment_markdown"]
+        repair_section = comment.split("## 当前版本逐维修复项（阻断本轮）", 1)[1].split(
+            "## 数据缺口", 1
+        )[0]
+        self.assertIn("### 任务书相关性", repair_section)
+        self.assertIn("1. 补充任务书条款逐项对应表。", repair_section)
+        self.assertIn("2. 说明目标与任务书约束的取舍。", repair_section)
+        self.assertIn("### 原创性", repair_section)
+        self.assertIn("1. 补充同类方案差异证据。", repair_section)
+        self.assertNotIn("官方边界仍未提供", repair_section)
+        self.assertNotIn("任务书映射仍可能存在解释风险", repair_section)
+        self.assertNotIn("官方边界发布后复算空间指标", repair_section)
+        self.assertIn("## 条件触发的后续事项（不阻断本轮）", comment)
+        self.assertTrue(
+            any(
+                "3 项详细 required repairs" in item
+                for item in result["review"]["required_next_actions_zh"]
+            )
+        )
 
     def test_mandatory_hits_force_rejection_even_if_model_marks_pass(self) -> None:
         review = valid_review()
@@ -502,6 +584,7 @@ class AIReviewSubmissionTests(unittest.TestCase):
             result["review"]["pr_comment_markdown"],
         )
         self.assertIn("当前阻断：否", result["review"]["pr_comment_markdown"])
+        self.assertNotIn("## 当前版本逐维修复项（阻断本轮）", result["review"]["pr_comment_markdown"])
 
     def test_conditional_followup_cannot_set_blocking_now_true(self) -> None:
         review = valid_review()

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -395,7 +395,7 @@ class AutoReviewQueueTests(unittest.TestCase):
             )
             schema_path.parent.mkdir(parents=True)
             schema_path.write_text(
-                json.dumps({"properties": {"schema_version": {"const": "0.2.0"}}}),
+                json.dumps({"properties": {"schema_version": {"const": "0.2.1"}}}),
                 encoding="utf-8",
             )
             (submission / "proposal.md").write_text("proposal", encoding="utf-8")
@@ -404,7 +404,7 @@ class AutoReviewQueueTests(unittest.TestCase):
             audit = Path(temp_dir) / "audit"
             audit.mkdir()
             review = {
-                "schema_version": "0.2.0",
+                "schema_version": "0.2.1",
                 "submission_dir": "submissions/alice/plan",
                 "mandatory_rejection": {"result": "pass"},
                 "gate_checks": {
@@ -437,11 +437,11 @@ class AutoReviewQueueTests(unittest.TestCase):
             assert cached is not None
             self.assertEqual("accept", cached[2].action)
 
-            review["schema_version"] = "0.1.0"
+            review["schema_version"] = "0.2.0"
             (audit / "ai-review.json").write_text(json.dumps(review), encoding="utf-8")
             self.assertIsNone(load_cached_review(audit, "submissions/alice/plan", checkout, 60))
 
-            review["schema_version"] = "0.2.0"
+            review["schema_version"] = "0.2.1"
             (audit / "ai-review.json").write_text(json.dumps(review), encoding="utf-8")
 
             (submission / "proposal.md").write_text("updated", encoding="utf-8")


### PR DESCRIPTION
## Problem

The authoritative AI review comment currently collapses rubric_scores[].required_repairs_zh into a count-only next action. Participants can therefore be told that detailed repairs exist without seeing the actual participant-controlled blockers. The 96-point exact-head review on #3821 reproduced this gap, and maintainers requested that it be handled as a bounded, separate enhancement.

## Change

- Bump the advisory review contract to 0.2.1, invalidating incompatible cached reviews.
- Bound each dimension to four repairs and each repair to 600 characters.
- Publish every schema-valid current repair under its rubric dimension in the authoritative PR comment.
- Keep risks, data gaps, local review material, and conditional non-blocking follow-ups outside that repair section.
- Document the feedback contract and add runtime/cache tests for visibility, grouping, empty output, separation, item count, and item length.

## Verification

- 70 focused unittest cases pass across AI review, queue caching, maintainer review, review input, site-package contract, and trusted review scripts.
- py_compile passes for the modified review path.
- git diff --check passes; all six files remain LF.
- Maintainer prelaunch: 9/10 checks pass. The only failure is generated_data_current because this worktree is intentionally sparse and contains only submissions/README.md under submissions; no generated index file is modified by this PR.

Fixes #4010