### PR TITLE
fix(review): enforce submission deadline eligibility

### DIFF
--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import argparse
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
 import json
 import os
 import shutil
@@ -124,7 +125,7 @@ def queued_prs(repo: str, label: str, cwd: Path) -> list[dict[str, Any]]:
             "--limit",
             "1000",
             "--json",
-            "number,author,headRefOid,state,isDraft,mergeable,statusCheckRollup,labels",
+            "number,author,createdAt,headRefOid,state,isDraft,mergeable,statusCheckRollup,labels",
         ],
         cwd=cwd,
     )
@@ -246,19 +247,67 @@ def pr_meta(repo: str, number: int, cwd: Path) -> dict[str, Any]:
             "view",
             str(number),
             "--json",
-            "number,author,headRefOid,state,isDraft,mergeable,statusCheckRollup,labels",
+            "number,author,createdAt,headRefOid,state,isDraft,mergeable,statusCheckRollup,labels",
         ],
         cwd=cwd,
     )
 
 
-def assert_live(meta: dict[str, Any], expected_sha: str, *, require_success: bool) -> None:
+def parse_timestamp(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError(f"invalid ISO 8601 timestamp: {value}") from exc
+    if parsed.tzinfo is None:
+        raise argparse.ArgumentTypeError("timestamp must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def created_at_on_or_before(meta: dict[str, Any], cutoff: datetime | None) -> bool:
+    if cutoff is None:
+        return True
+    value = meta.get("createdAt")
+    if not isinstance(value, str):
+        raise WorkerError("PR metadata has no createdAt timestamp")
+    try:
+        created_at = parse_timestamp(value)
+    except argparse.ArgumentTypeError as exc:
+        raise WorkerError(f"invalid PR createdAt timestamp: {value}") from exc
+    return created_at <= cutoff
+
+
+def has_current_head_formal_review(repo: str, number: int, head_sha: str, cwd: Path) -> bool:
+    completed = run(
+        ["gh", "api", "--paginate", "--slurp", f"repos/{repo}/pulls/{number}/reviews"],
+        cwd=cwd,
+    )
+    try:
+        pages = json.loads(completed.stdout)
+        reviews = [item for page in pages for item in page]
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise WorkerError(f"invalid review list from gh api for PR #{number}") from exc
+    return any(
+        str(review.get("commit_id") or "") == head_sha
+        and str(review.get("state") or "").upper() in {"APPROVED", "CHANGES_REQUESTED"}
+        for review in reviews
+    )
+
+
+def assert_live(
+    meta: dict[str, Any],
+    expected_sha: str,
+    *,
+    require_success: bool,
+    created_at_or_before: datetime | None = None,
+) -> None:
     if meta.get("headRefOid") != expected_sha:
         raise WorkerError("PR head changed during review")
     if meta.get("state") != "OPEN" or meta.get("isDraft"):
         raise WorkerError("PR is no longer an open non-draft PR")
     if require_success and ci_state(meta) != "success":
         raise WorkerError("required CI is no longer successful")
+    if not created_at_on_or_before(meta, created_at_or_before):
+        raise WorkerError("PR was created after the configured submission cutoff")
 
 
 def label_args(remove: list[str], add: list[str]) -> list[str]:
@@ -270,9 +319,23 @@ def label_args(remove: list[str], add: list[str]) -> list[str]:
     return args
 
 
-def apply_conflict_hold(repo: str, number: int, head_sha: str, cwd: Path) -> None:
+def apply_conflict_hold(
+    repo: str,
+    number: int,
+    head_sha: str,
+    cwd: Path,
+    *,
+    created_at_or_before: datetime | None = None,
+) -> None:
     live = pr_meta(repo, number, cwd)
-    assert_live(live, head_sha, require_success=True)
+    assert_live(
+        live,
+        head_sha,
+        require_success=True,
+        created_at_or_before=created_at_or_before,
+    )
+    if has_current_head_formal_review(repo, number, head_sha, cwd):
+        raise WorkerError("current PR head already has a formal review")
     if live.get("mergeable") != "CONFLICTING":
         raise WorkerError("PR is no longer conflicting")
     body = (
@@ -345,9 +408,17 @@ def apply_review(
     cwd: Path,
     *,
     admin_merge: bool,
+    created_at_or_before: datetime | None = None,
 ) -> None:
     live = pr_meta(repo, number, cwd)
-    assert_live(live, head_sha, require_success=True)
+    assert_live(
+        live,
+        head_sha,
+        require_success=True,
+        created_at_or_before=created_at_or_before,
+    )
+    if has_current_head_formal_review(repo, number, head_sha, cwd):
+        raise WorkerError("current PR head already has a formal review")
     marker = REVIEW_MARKER.format(head_sha=head_sha)
     if outcome.action == "accept":
         if live.get("mergeable") == "CONFLICTING":
@@ -364,7 +435,12 @@ def apply_review(
             f"\n\n{authoritative_comment}"
         )
         run(["gh", "pr", "review", str(number), "--repo", repo, "--approve", "--body", body], cwd=cwd)
-        assert_live(pr_meta(repo, number, cwd), head_sha, require_success=True)
+        assert_live(
+            pr_meta(repo, number, cwd),
+            head_sha,
+            require_success=True,
+            created_at_or_before=created_at_or_before,
+        )
         merge = [
             "gh",
             "pr",
@@ -407,8 +483,12 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
     state = ci_state(meta)
     if meta.get("isDraft"):
         return {"number": number, "result": "skipped-draft"}
+    if not created_at_on_or_before(meta, args.created_at_or_before):
+        return {"number": number, "head_sha": head_sha, "result": "skipped-created-after-cutoff"}
     if state != "success":
         return {"number": number, "head_sha": head_sha, "result": f"skipped-ci-{state}"}
+    if has_current_head_formal_review(args.repo, number, head_sha, repo_root):
+        return {"number": number, "head_sha": head_sha, "result": "skipped-current-head-reviewed"}
     if meta.get("mergeable") == "CONFLICTING":
         return {"number": number, "head_sha": head_sha, "result": "skipped-conflicting"}
 
@@ -434,6 +514,12 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
             advisory_schema_path,
         )
         if cached is None:
+            if has_current_head_formal_review(args.repo, number, head_sha, repo_root):
+                return {
+                    "number": number,
+                    "head_sha": head_sha,
+                    "result": "skipped-current-head-reviewed",
+                }
             command = [
                 sys.executable,
                 str(repo_root / "scripts" / "ai_review_submission.py"),
@@ -487,6 +573,7 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
                     audit_dir / "pr-comment.md",
                     repo_root,
                     admin_merge=args.admin_merge,
+                    created_at_or_before=args.created_at_or_before,
                 )
             result["applied"] = True
         return result
@@ -547,6 +634,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--apply", action="store_true", help="Post reviews, change labels, and merge accepted PRs")
     parser.add_argument("--admin-merge", action="store_true", help="Use the repository ruleset bypass during merge")
     parser.add_argument("--keep-worktrees", action="store_true")
+    parser.add_argument(
+        "--created-at-or-before",
+        type=parse_timestamp,
+        help="Only process PRs created at or before this timezone-aware ISO 8601 timestamp",
+    )
     return parser.parse_args()
 
 
@@ -583,10 +675,40 @@ def main() -> int:
         if live.get("isDraft") or live.get("state") != "OPEN" or state != "success":
             results.append({"number": number, "head_sha": live.get("headRefOid"), "result": f"skipped-ci-{state}"})
             continue
+        try:
+            if not created_at_on_or_before(live, args.created_at_or_before):
+                results.append(
+                    {
+                        "number": number,
+                        "head_sha": live.get("headRefOid"),
+                        "result": "skipped-created-after-cutoff",
+                    }
+                )
+                continue
+            if has_current_head_formal_review(
+                args.repo, number, str(live["headRefOid"]), repo_root
+            ):
+                results.append(
+                    {
+                        "number": number,
+                        "head_sha": live.get("headRefOid"),
+                        "result": "skipped-current-head-reviewed",
+                    }
+                )
+                continue
+        except Exception as exc:
+            results.append({"number": number, "result": "error", "error": str(exc)})
+            continue
         if live.get("mergeable") == "CONFLICTING":
             try:
                 if args.apply:
-                    apply_conflict_hold(args.repo, number, str(live["headRefOid"]), repo_root)
+                    apply_conflict_hold(
+                        args.repo,
+                        number,
+                        str(live["headRefOid"]),
+                        repo_root,
+                        created_at_or_before=args.created_at_or_before,
+                    )
             except Exception as exc:
                 results.append({"number": number, "result": "error", "error": str(exc)})
                 continue

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -1,7 +1,9 @@
+import argparse
 import json
 import sys
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -15,9 +17,12 @@ from auto_review_queue import (  # noqa: E402
     acquire_worker_lock,
     apply_review,
     ci_state,
+    created_at_on_or_before,
     decide,
+    has_current_head_formal_review,
     load_cached_review,
     parse_args,
+    parse_timestamp,
     pr_file_paths,
     queued_prs,
     submission_dir_from_files,
@@ -48,6 +53,7 @@ class AutoReviewQueueTests(unittest.TestCase):
             with self.subTest(admin_merge=admin_merge):
                 with (
                     patch("auto_review_queue.pr_meta", return_value=live),
+                    patch("auto_review_queue.has_current_head_formal_review", return_value=False),
                     patch("auto_review_queue.run") as run_mock,
                 ):
                     apply_review(
@@ -97,6 +103,45 @@ class AutoReviewQueueTests(unittest.TestCase):
         with patch.object(sys, "argv", ["auto_review_queue"]):
             args = parse_args()
         self.assertEqual(18, args.max_images)
+
+    def test_cutoff_is_inclusive_and_normalized_to_utc(self) -> None:
+        cutoff = parse_timestamp("2026-08-31T23:59:59+08:00")
+        self.assertEqual(datetime(2026, 8, 31, 15, 59, 59, tzinfo=timezone.utc), cutoff)
+        self.assertTrue(
+            created_at_on_or_before({"createdAt": "2026-08-31T15:59:59Z"}, cutoff)
+        )
+        self.assertFalse(
+            created_at_on_or_before({"createdAt": "2026-08-31T16:00:00Z"}, cutoff)
+        )
+
+    def test_cutoff_requires_timezone(self) -> None:
+        with self.assertRaises(argparse.ArgumentTypeError):
+            parse_timestamp("2026-08-31T23:59:59")
+
+    def test_formal_review_must_match_current_head(self) -> None:
+        head_sha = "a" * 40
+        reviews = [[
+            {"commit_id": "b" * 40, "state": "APPROVED"},
+            {"commit_id": head_sha, "state": "COMMENTED"},
+            {"commit_id": head_sha, "state": "CHANGES_REQUESTED"},
+        ]]
+        completed = type("Completed", (), {"stdout": json.dumps(reviews)})()
+        with patch("auto_review_queue.run", return_value=completed):
+            self.assertTrue(
+                has_current_head_formal_review("open-city-ai/haidian", 42, head_sha, ROOT)
+            )
+
+    def test_old_or_comment_only_reviews_do_not_count_as_formal(self) -> None:
+        head_sha = "a" * 40
+        reviews = [[
+            {"commit_id": "b" * 40, "state": "APPROVED"},
+            {"commit_id": head_sha, "state": "COMMENTED"},
+        ]]
+        completed = type("Completed", (), {"stdout": json.dumps(reviews)})()
+        with patch("auto_review_queue.run", return_value=completed):
+            self.assertFalse(
+                has_current_head_formal_review("open-city-ai/haidian", 42, head_sha, ROOT)
+            )
 
     def test_accepts_score_at_threshold_when_intake_ready_even_if_not_publishable(self) -> None:
         review = {


### PR DESCRIPTION
## Summary
- enforce an inclusive timezone-aware PR creation cutoff
- skip PRs with an APPROVED or CHANGES_REQUESTED review on the exact current head
- re-check both constraints before review writes and merge

## Validation
- `python3 -m unittest tests.test_auto_review_queue`

Operational cutoff after merge: `2026-08-31T15:59:59Z` (Beijing `2026-08-31 23:59:59`).