### PR TITLE
fix(review): use sparse review worktrees

### DIFF
--- a/scripts/auto_review_queue.py
+++ b/scripts/auto_review_queue.py
@@ -399,6 +399,33 @@ def load_cached_review(
     return review, decision, outcome
 
 
+def create_review_worktree(
+    repo_root: Path,
+    worktree: Path,
+    ref: str,
+    submission_dir: str,
+) -> None:
+    """Create a minimal checkout containing only trusted review inputs."""
+    run(
+        ["git", "worktree", "add", "--detach", "--no-checkout", str(worktree), ref],
+        cwd=repo_root,
+    )
+    run(
+        [
+            "git",
+            "sparse-checkout",
+            "set",
+            "--no-cone",
+            "--",
+            submission_dir,
+            "brief/site-package/agent_taskbook.json",
+            ADVISORY_REVIEW_SCHEMA_PATH,
+        ],
+        cwd=worktree,
+    )
+    run(["git", "checkout", "--detach", ref], cwd=worktree)
+
+
 def apply_review(
     repo: str,
     number: int,
@@ -501,7 +528,7 @@ def process_pr(args: argparse.Namespace, meta: dict[str, Any], repo_root: Path) 
         if worktree.exists():
             run(["git", "worktree", "remove", "--force", str(worktree)], cwd=repo_root)
         run(["git", "fetch", "--force", "origin", f"pull/{number}/head:{ref}"], cwd=repo_root)
-        run(["git", "worktree", "add", "--detach", str(worktree), ref], cwd=repo_root)
+        create_review_worktree(repo_root, worktree, ref, submission_dir)
     try:
         checked = run(["git", "rev-parse", "HEAD"], cwd=worktree).stdout.strip()
         if checked != head_sha:

--- a/tests/test_auto_review_queue.py
+++ b/tests/test_auto_review_queue.py
@@ -18,6 +18,7 @@ from auto_review_queue import (  # noqa: E402
     apply_review,
     ci_state,
     created_at_on_or_before,
+    create_review_worktree,
     decide,
     has_current_head_formal_review,
     load_cached_review,
@@ -142,6 +143,32 @@ class AutoReviewQueueTests(unittest.TestCase):
             self.assertFalse(
                 has_current_head_formal_review("open-city-ai/haidian", 42, head_sha, ROOT)
             )
+
+    def test_review_worktree_uses_sparse_checkout(self) -> None:
+        worktree = ROOT / ".pr-worktree" / "test"
+        with patch("auto_review_queue.run") as run_mock:
+            create_review_worktree(
+                ROOT,
+                worktree,
+                "refs/review/head",
+                "submissions/alice/plan",
+            )
+        self.assertEqual(
+            [
+                "git",
+                "worktree",
+                "add",
+                "--detach",
+                "--no-checkout",
+                str(worktree),
+                "refs/review/head",
+            ],
+            run_mock.call_args_list[0].args[0],
+        )
+        sparse_command = run_mock.call_args_list[1].args[0]
+        self.assertEqual(["git", "sparse-checkout", "set", "--no-cone", "--"], sparse_command[:5])
+        self.assertIn("submissions/alice/plan", sparse_command)
+        self.assertIn("brief/site-package/agent_taskbook.json", sparse_command)
 
     def test_accepts_score_at_threshold_when_intake_ready_even_if_not_publishable(self) -> None:
         review = {


### PR DESCRIPTION
## Summary
- create review worktrees without a full checkout
- materialize only the exact submission directory and trusted taskbook/schema inputs
- preserve exact-head verification and the 6-worker review model

This prevents the trusted runner from exhausting its disk while processing the deadline-scoped backlog.

## Validation
- `python3 -m unittest tests.test_auto_review_queue`
- local sparse checkout smoke test: 52 submission files, 21 MB worktree