### PR TITLE
fix(ci): retry incomplete GitHub API reads

### DIFF
--- a/scripts/github_pr_validation.py
+++ b/scripts/github_pr_validation.py
@@ -35,6 +35,7 @@ Exit code is 0 when the PR passes validation and 1 when it fails or errors.
 from __future__ import annotations
 
 import base64
+import http.client
 import json
 import os
 import shutil
@@ -124,9 +125,10 @@ def _retry_delay_seconds(error: urllib.error.HTTPError, attempt: int) -> float:
     return min(MAX_RETRY_DELAY_SECONDS, float(2**attempt))
 
 
-def _network_error_message(error: urllib.error.URLError) -> str:
+def _network_error_message(error: Exception) -> str:
     """Return a bounded network error description without request credentials."""
-    return str(error.reason or "network request failed")[:300].replace("\n", " ")
+    detail = error.reason if isinstance(error, urllib.error.URLError) else error
+    return str(detail or "network request failed")[:300].replace("\n", " ")
 
 
 def _is_download_not_found(error: Exception, path: str) -> bool:
@@ -181,6 +183,16 @@ class GitHubClient:
                         f"GitHub API {method} {url} failed with HTTP {error.code}: {message}"
                     ) from error
                 time.sleep(_retry_delay_seconds(error, attempt))
+            except (http.client.IncompleteRead, urllib.error.URLError) as error:
+                if (
+                    method.upper() not in RETRYABLE_METHODS
+                    or attempt + 1 >= MAX_API_ATTEMPTS
+                ):
+                    raise RuntimeError(
+                        f"GitHub API {method} {url} failed after network error: "
+                        f"{_network_error_message(error)}"
+                    ) from error
+                time.sleep(min(MAX_RETRY_DELAY_SECONDS, float(2**attempt)))
         raise AssertionError("unreachable")
 
     def paginate(self, path: str) -> list[dict]:
@@ -230,7 +242,7 @@ class GitHubClient:
                         f"GitHub API download {path} failed with HTTP {error.code}: {message}"
                     ) from error
                 time.sleep(_retry_delay_seconds(error, attempt))
-            except urllib.error.URLError as error:
+            except (http.client.IncompleteRead, urllib.error.URLError) as error:
                 if attempt + 1 >= MAX_API_ATTEMPTS:
                     raise RuntimeError(
                         f"GitHub API download {path} failed after network error: "

--- a/tests/test_submission_workflow.py
+++ b/tests/test_submission_workflow.py
@@ -5,6 +5,7 @@ import json
 import os
 import subprocess
 import hashlib
+import http.client
 import io
 import re
 import struct
@@ -282,6 +283,29 @@ class GitHubApiResilienceTests(unittest.TestCase):
         self.assertEqual(1, urlopen.call_count)
         sleep.assert_not_called()
 
+    def test_request_retries_incomplete_read_then_succeeds(self) -> None:
+        client = GitHubClient("token", "open-city-ai/haidian")
+        incomplete_read = http.client.IncompleteRead(b'{"ok":', 5)
+        with patch(
+            "github_pr_validation.urllib.request.urlopen",
+            side_effect=[incomplete_read, _Response(b'{"ok":true}')],
+        ), patch("github_pr_validation.time.sleep") as sleep:
+            payload, _ = client.request("GET", "/test")
+        self.assertEqual({"ok": True}, payload)
+        sleep.assert_called_once_with(1.0)
+
+    def test_request_does_not_retry_mutating_network_failure(self) -> None:
+        client = GitHubClient("token", "open-city-ai/haidian")
+        incomplete_read = http.client.IncompleteRead(b"partial", 5)
+        with patch(
+            "github_pr_validation.urllib.request.urlopen",
+            side_effect=[incomplete_read, _Response(b'{"ok":true}')],
+        ) as urlopen, patch("github_pr_validation.time.sleep") as sleep:
+            with self.assertRaisesRegex(RuntimeError, "failed after network error"):
+                client.request("POST", "/test", {"body": "comment"})
+        self.assertEqual(1, urlopen.call_count)
+        sleep.assert_not_called()
+
     def test_comment_patch_forbidden_falls_back_to_new_comment(self) -> None:
         client = GitHubClient("token", "open-city-ai/haidian")
         existing = {"id": 42, "body": f"{COMMENT_MARKER}\nold result"}
@@ -406,6 +430,18 @@ class GitHubApiResilienceTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir, patch(
             "github_pr_validation.urllib.request.urlopen",
             side_effect=[network_error, _Response(b"payload")],
+        ), patch("github_pr_validation.time.sleep") as sleep:
+            destination = Path(temp_dir) / "asset.bin"
+            client.download_content("fork/repo", "asset.bin", "head-sha", destination)
+            self.assertEqual(b"payload", destination.read_bytes())
+        sleep.assert_called_once_with(1.0)
+
+    def test_download_incomplete_read_retries_then_succeeds(self) -> None:
+        client = GitHubClient("token", "open-city-ai/haidian")
+        incomplete_read = http.client.IncompleteRead(b"partial", 5)
+        with tempfile.TemporaryDirectory() as temp_dir, patch(
+            "github_pr_validation.urllib.request.urlopen",
+            side_effect=[incomplete_read, _Response(b"payload")],
         ), patch("github_pr_validation.time.sleep") as sleep:
             destination = Path(temp_dir) / "asset.bin"
             client.download_content("fork/repo", "asset.bin", "head-sha", destination)


### PR DESCRIPTION
## Summary

- retry transient IncompleteRead and URLError failures for idempotent GitHub API requests
- apply the same bounded retry behavior to raw content downloads
- keep mutating API requests fail-fast to avoid duplicate side effects
- add focused regression tests for list/read and download paths

This is a generic CI resilience fix prompted by the reproducible silent-failure pattern discussed on #4385. It does not make #4385 mergeable: that PR current head still has a truncated repository tree and must be rebuilt from current main.

## Validation

- GitHubApiResilienceTests: 16 tests passed
- py_compile: passed
- git diff --check: passed

Refs #4385